### PR TITLE
fix(ci): make badge verification non-blocking in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,11 +388,15 @@ jobs:
           echo "3. Set repository variable DOCKERHUB_ENABLED=true"
 
   # Verify PyPI badges auto-update correctly after release
+  # NOTE: This job is non-blocking (continue-on-error: true) to prevent badge
+  # caching from blocking the entire release. Badges will update within 15-30
+  # minutes after PyPI propagation completes.
   verify-badges:
     name: Verify PyPI Badges
     runs-on: ubuntu-latest
     needs: pypi-publish
     if: startsWith(github.ref, 'refs/tags/v')
+    continue-on-error: true  # Don't block release on badge caching issues
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -401,12 +405,12 @@ jobs:
         run: |
           echo "⏳ Waiting for PyPI to propagate the new version..."
 
-          # Initial wait
-          echo "  Initial wait: 90s..."
-          sleep 90
+          # Initial wait (increased from 90s to 2 minutes)
+          echo "  Initial wait: 120s..."
+          sleep 120
 
           # Retry loop with exponential backoff
-          MAX_RETRIES=3
+          MAX_RETRIES=5  # Increased from 3 to 5
           RETRY_COUNT=0
           SUCCESS=false
 
@@ -421,7 +425,7 @@ jobs:
 
             RETRY_COUNT=$((RETRY_COUNT + 1))
             if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-              WAIT_TIME=$((30 * RETRY_COUNT))  # 30s, 60s exponential backoff
+              WAIT_TIME=$((60 * RETRY_COUNT))  # 60s, 120s, 180s, 240s exponential backoff
               echo "⏳ Waiting ${WAIT_TIME}s before retry..."
               sleep $WAIT_TIME
             fi
@@ -429,16 +433,21 @@ jobs:
 
           if [ "$SUCCESS" = false ]; then
             echo ""
-            echo "❌ Badge verification failed after $MAX_RETRIES attempts."
+            echo "⚠️  Badge verification did not complete after $MAX_RETRIES attempts."
             echo ""
-            echo "⚠️  This is often due to:"
-            echo "  1. PyPI API propagation delay (can take 2-5 minutes)"
-            echo "  2. Badge CDN caching (wait 15-30 minutes for global propagation)"
-            echo "  3. Version mismatch (check pyproject.toml)"
+            echo "This is expected behavior and does NOT indicate a release failure."
             echo ""
-            echo "Manual verification:"
+            echo "Badges update asynchronously and typically take 5-30 minutes:"
+            echo "  1. PyPI API propagation: 2-5 minutes"
+            echo "  2. Badge CDN caching: 15-30 minutes for global propagation"
+            echo ""
+            echo "The release will proceed successfully. Badges will auto-update."
+            echo ""
+            echo "Manual verification (optional):"
             echo "  make verify-badges"
-            exit 1
+            echo ""
+            echo "✅ Release workflow continues..."
+            exit 0  # Exit with success to mark job as passed
           fi
 
           echo ""


### PR DESCRIPTION
## Problem

The v0.8.0 release **failed** because badge verification blocked the entire workflow:

1. ✅ PyPI published successfully
2. ❌ Badge verification timed out (PyPI propagation delay)
3. ❌ **GitHub Release was never created** (workflow blocked)

**Result:** v0.8.0 existed on PyPI but showed as v0.7.1 everywhere else for hours.

## Root Cause

- Badge verification job **blocks** on PyPI/CDN propagation
- PyPI API can take 2-5 minutes to propagate
- Badge CDN (shields.io) caches for 15-30 minutes
- Old retry logic: 3 attempts × ~60s = ~3 minutes (too short)

## Solution

Make badge verification **non-blocking**:

### ✅ Changes

1. **`continue-on-error: true`** — Release proceeds even if badges are cached
2. **Increased initial wait**: 90s → 120s
3. **Increased retries**: 3 → 5 attempts
4. **Longer backoff**: 30s/60s → 60s/120s/180s/240s (up to ~12 minutes total)
5. **Exit success on timeout** — Clarify this is expected behavior, not failure
6. **Updated messaging** — Explain CDN caching is normal

### Why This Is The Right Approach

**Badge verification is NOT a release requirement:**
- ✅ PyPI package published (critical)
- ✅ Docker images built (critical)
- ✅ GitHub Release created (critical)
- ⏱️ Badges update (nice-to-have, happens asynchronously)

**This follows CI/CD best practices:**
- Fail fast on critical issues (PyPI, Docker)
- Warn on non-critical issues (badge CDN)
- Don't block on external dependencies

## Testing

Verification window now covers:
- PyPI API propagation: 2-5 minutes ✅
- Badge CDN caching: up to 12 minutes in workflow
- Full propagation: 15-30 minutes (but release doesn't wait)

## Impact

✅ **Future releases will complete successfully** even with badge CDN delays  
✅ **GitHub Releases created reliably**  
✅ **Badges still auto-update** (within 15-30 minutes)  
✅ **No manual intervention needed**

## Related

- Fixes: v0.8.0 release failure
- Related: PR #104 (manual v0.8.0 badge fixes)

---

**This is a production-grade solution, not a band-aid.** Badge CDN caching is expected behavior and should not block releases.