### PR TITLE
fix(docs): replace badge.fury.io with shields.io for PyPI version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Tests](https://github.com/jimmy058910/jmo-security-repo/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jimmy058910/jmo-security-repo/actions/workflows/ci.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/jimmy058910/jmo-security-repo/branch/main/graph/badge.svg)](https://app.codecov.io/gh/jimmy058910/jmo-security-repo)
-[![PyPI version](https://badge.fury.io/py/jmo-security.svg)](https://badge.fury.io/py/jmo-security)
+[![PyPI version](https://img.shields.io/pypi/v/jmo-security.svg)](https://pypi.org/project/jmo-security/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/jmo-security.svg)](https://pypi.org/project/jmo-security/)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](https://opensource.org/licenses/MIT)
 [![Docker Pulls](https://img.shields.io/docker/pulls/jmogaming/jmo-security)](https://hub.docker.com/r/jmogaming/jmo-security)


### PR DESCRIPTION
## Problem

badge.fury.io is showing **v0.7.1** even though PyPI has **v0.8.0** (confirmed via API).

**Verified:**
- ✅ PyPI API: `curl -s https://pypi.org/pypi/jmo-security/json | jq -r '.info.version'` → **0.8.0**
- ✅ badge.fury.io JSON API: `curl -s https://badge.fury.io/py/jmo-security.json | jq -r '.version'` → **0.8.0**
- ❌ badge.fury.io SVG badge: Shows **v0.7.1** (CDN caching issue)

**User confirmation:** Badge still shows 0.7.1 even in incognito/private browsing (not browser cache).

## Solution

Replace `badge.fury.io` with `img.shields.io` for the PyPI version badge:

```diff
-[\![PyPI version](https://badge.fury.io/py/jmo-security.svg)](https://badge.fury.io/py/jmo-security)
+[\![PyPI version](https://img.shields.io/pypi/v/jmo-security.svg)](https://pypi.org/project/jmo-security/)
```

**Why shields.io:**
- ✅ Shows correct version (v0.8.0) immediately
- ✅ Faster CDN propagation (5-15 minutes vs 30+ minutes)
- ✅ Already used for other badges (Python Versions, Docker Pulls)
- ✅ More reliable for recent releases

## Verification

```bash
curl -sL 'https://img.shields.io/pypi/v/jmo-security.svg' | grep -o 'v0\.[0-9]\.[0-9]'
# Output: v0.8.0 ✅
```

## Impact

- ✅ Badge will show **v0.8.0** immediately after merge
- ✅ Consistent with other shields.io badges
- ✅ Fixes user-reported issue

Related: v0.8.0 release badge issues