### PR TITLE
feat: Add .hadolint.yaml to ignore CI false-positives

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,14 @@
+# .hadolint.yaml - Hadolint configuration for JMo Security Dockerfiles
+ignored:
+  # DL3006: Always tag the version of an image explicitly
+  # Suppressed: We manage tool versions centrally via versions.yaml
+  - DL3006
+  
+  # DL3018: Pin versions in apk add
+  # Suppressed: Some Alpine base images don't support version pinning
+  - DL3018
+  
+  # DL3008: Pin versions in apt-get install
+  # Suppressed: Some Debian base images don't support version pinning
+  - DL3008
+# Keep all other rules enabled for security best practices


### PR DESCRIPTION
**Closes #103 **

### What this PR does
This pull request adds a `.hadolint.yaml` configuration file to the repository root.

### Why this PR is needed
This file is needed to suppress three specific Hadolint warnings (`DL3006`, `DL3018`, `DL3008`) that are considered false-positives for this project's patterns. This will clean up the CI pipeline and allow the team to focus on relevant linting errors, as originally discussed in issue #85.

### How I tested
I confirmed the fix locally using Hadolint's official Docker image and mounting the repository root. The test output below confirms that the false-positive warnings (like `DL3008`) are gone, while other valid warnings (like `DL4001`) remain.

**Test output for `Dockerfile`:**
```text
Dockerfile:78 DL4001 warning: Either use Wget or Curl but not both
Dockerfile:85 DL4001 warning: Either use Wget or Curl but not both
Dockerfile:96 DL3003 warning: Use WORKDIR to switch to a directory
Dockerfile:96 SC2046 warning: Quote this to prevent word splitting.
Dockerfile:96 DL4001 warning: Either use Wget or Curl but not both
Dockerfile:141 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
Dockerfile:190 DL3003 warning: Use WORKDIR to switch to a directory
```
**Test output for `Dockerfile.slim`:**
```text
Dockerfile.slim:52 DL4001 warning: Either use Wget or Curl but not both
Dockerfile.slim:59 DL4001 warning: Either use Wget or Curl but not both
Dockerfile.slim:99 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
Dockerfile.slim:130 DL3003 warning: Use WORKDIR to switch to a directory
```
**Test output for `Dockerfile.alpine`:**
```text
Dockerfile.alpine:99 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
Dockerfile.alpine:133 DL3003 warning: Use WORKDIR to switch to a directory
```