### PR TITLE
fix: update trivy 0.67.2->0.69.3, make homebrew non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -779,11 +779,14 @@ jobs:
           echo "✅ Badge verification successful!"
 
   # Submit Homebrew formula PR (automated) - inlined from homebrew-bump-formula.yml
+  # NOTE: Requires formula to already exist in homebrew-core. First-time submission
+  # must be done manually via PR to https://github.com/Homebrew/homebrew-core
   homebrew-bump:
     name: Submit Homebrew Formula PR
     runs-on: ubuntu-latest
     needs: pypi-publish
     if: startsWith(github.ref, 'refs/tags/v')
+    continue-on-error: true  # Non-blocking until formula is accepted into homebrew-core
     timeout-minutes: 10
     steps:
       - name: Extract version
@@ -791,28 +794,38 @@ jobs:
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "📦 Submitting Homebrew formula PR for version $VERSION"
+
+      - name: Check if formula exists in homebrew-core
+        id: check_formula
+        run: |
+          if brew info jmo-security > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Formula 'jmo-security' not yet in homebrew-core."
+            echo "Submit initial formula via PR to https://github.com/Homebrew/homebrew-core"
+            echo "See: https://docs.brew.sh/Adding-Software-to-Homebrew"
+          fi
 
       - name: Wait for PyPI release
+        if: steps.check_formula.outputs.exists == 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          echo "⏳ Waiting for PyPI release to be available..."
-
           MAX_ATTEMPTS=30
           ATTEMPT=0
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             if curl -fsSL "https://pypi.org/pypi/jmo-security/$VERSION/json" > /dev/null 2>&1; then
-              echo "✅ PyPI release $VERSION confirmed!"
+              echo "PyPI release $VERSION confirmed"
               exit 0
             fi
             ATTEMPT=$((ATTEMPT + 1))
-            echo "⏳ Attempt $ATTEMPT/$MAX_ATTEMPTS: waiting 10s..."
             sleep 10
           done
-          echo "❌ PyPI release not available after 5 minutes"
+          echo "PyPI release not available after 5 minutes"
           exit 1
 
       - name: Bump Homebrew formula
+        if: steps.check_formula.outputs.exists == 'true'
         uses: dawidd6/action-homebrew-bump-formula@v4
         with:
           # Required: Personal Access Token with repo + workflow scopes
@@ -823,15 +836,10 @@ jobs:
           force: false
 
       - name: Success notification
-        if: success()
+        if: steps.check_formula.outputs.exists == 'true' && success()
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          echo "✅ Successfully submitted PR to homebrew-core for version $VERSION"
-          echo ""
-          echo "📋 Next steps:"
-          echo "  1. Monitor PR at: https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+jmo-security"
-          echo "  2. Homebrew maintainers will review (typically 1-2 weeks)"
-          echo "  3. After merge, users can install with: brew install jmo-security"
+          echo "Successfully submitted PR to homebrew-core for version $VERSION"
 
   # Submit WinGet manifest PR (automated) - inlined from winget-releaser.yml
   winget-bump:

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN SYFT_VERSION="1.38.0" && \
     tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
 
 # Download Trivy (SCA + Vuln)
-RUN TRIVY_VERSION="0.67.2" && \
+RUN TRIVY_VERSION="0.69.3" && \
     TRIVY_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "ARM64" || echo "64bit") && \
     curl -sSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" \
     -o /tmp/trivy.tar.gz && \
@@ -129,7 +129,7 @@ RUN OSV_VERSION="2.3.1" && \
     chmod +x /usr/local/bin/osv-scanner
 
 # Download Bearer (Data Privacy + SAST)
-RUN BEARER_VERSION="2.0.0" && \
+RUN BEARER_VERSION="2.0.1" && \
     BEARER_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -sSL "https://github.com/bearer/bearer/releases/download/v${BEARER_VERSION}/bearer_${BEARER_VERSION}_linux_${BEARER_ARCH}.tar.gz" \
     -o /tmp/bearer.tar.gz && \

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -36,7 +36,7 @@ RUN SYFT_VERSION="1.38.0" && \
     tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
 
 # Download Trivy (SCA + Vuln)
-RUN TRIVY_VERSION="0.67.2" && \
+RUN TRIVY_VERSION="0.69.3" && \
     TRIVY_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "ARM64" || echo "64bit") && \
     curl -sSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" \
     -o /tmp/trivy.tar.gz && \
@@ -95,7 +95,7 @@ RUN GRYPE_VERSION="0.104.0" && \
     chmod +x /usr/local/bin/grype
 
 # Download Bearer (Data Privacy + SAST)
-RUN BEARER_VERSION="2.0.0" && \
+RUN BEARER_VERSION="2.0.1" && \
     BEARER_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -sSL "https://github.com/bearer/bearer/releases/download/v${BEARER_VERSION}/bearer_${BEARER_VERSION}_linux_${BEARER_ARCH}.tar.gz" \
     -o /tmp/bearer.tar.gz && \

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -36,7 +36,7 @@ RUN SYFT_VERSION="1.38.0" && \
     tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
 
 # Download Trivy
-RUN TRIVY_VERSION="0.67.2" && \
+RUN TRIVY_VERSION="0.69.3" && \
     TRIVY_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "ARM64" || echo "64bit") && \
     curl -sSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" \
     -o /tmp/trivy.tar.gz && \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -36,7 +36,7 @@ RUN SYFT_VERSION="1.38.0" && \
     tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
 
 # Download Trivy (SCA + Vuln)
-RUN TRIVY_VERSION="0.67.2" && \
+RUN TRIVY_VERSION="0.69.3" && \
     TRIVY_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "ARM64" || echo "64bit") && \
     curl -sSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" \
     -o /tmp/trivy.tar.gz && \
@@ -76,7 +76,7 @@ RUN GRYPE_VERSION="0.104.0" && \
     chmod +x /usr/local/bin/grype
 
 # Download Bearer (Data Privacy)
-RUN BEARER_VERSION="2.0.0" && \
+RUN BEARER_VERSION="2.0.1" && \
     BEARER_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -sSL "https://github.com/bearer/bearer/releases/download/v${BEARER_VERSION}/bearer_${BEARER_VERSION}_linux_${BEARER_ARCH}.tar.gz" \
     -o /tmp/bearer.tar.gz && \

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -87,7 +87,7 @@ All Dockerfiles use parameterized versions:
 
 ```dockerfile
 # ✅ CORRECT: Read from ARG/ENV
-RUN TRIVY_VERSION="0.67.2" && \
+RUN TRIVY_VERSION="0.69.3" && \
     curl -sSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/..."
 
 # ❌ WRONG: Hardcoded version

--- a/packaging/docker/legacy/Dockerfile.alpine
+++ b/packaging/docker/legacy/Dockerfile.alpine
@@ -34,7 +34,7 @@ RUN SYFT_VERSION="1.36.0" && \
     tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
 
 # Download Trivy
-RUN TRIVY_VERSION="0.67.2" && \
+RUN TRIVY_VERSION="0.69.3" && \
     TRIVY_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "ARM64" || echo "64bit") && \
     wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" \
     -O /tmp/trivy.tar.gz && \

--- a/versions.yaml
+++ b/versions.yaml
@@ -97,7 +97,7 @@ binary_tools:
     update_check: gh api repos/anchore/syft/releases/latest
     critical: true
   trivy:
-    version: 0.67.2
+    version: 0.69.3
     github_repo: aquasecurity/trivy
     description: Vulnerability/misconfig/secrets scanner
     release_pattern: trivy_{version}_Linux-{arch}.tar.gz


### PR DESCRIPTION
## Summary

Fixes release workflow Docker build failures and Homebrew formula error.

- **Docker (all 4 variants):** Trivy v0.67.2 binary assets no longer exist on GitHub (404). Updated to v0.69.3 via `versions.yaml` + `--sync` to all Dockerfiles.
- **Homebrew:** Formula `jmo-security` doesn't exist in homebrew-core yet (first release). Added existence check and `continue-on-error: true` until initial formula is submitted.

After merge: delete v1.0.0 tag, re-tag, push to re-trigger release workflow.

## Test plan
- [x] `curl -sI` confirms trivy v0.69.3 download URL returns 302
- [x] All pre-commit hooks pass (YAML lint, Actions lint, markdownlint)
- [ ] CI quick-checks pass
- [ ] Release workflow succeeds on re-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core security scanning tools: Trivy to v0.69.3 (from 0.67.2) and Bearer to v2.0.1 (from 2.0.0)
  * Enhanced release workflow with automated validation to verify distribution readiness and prevent failed package submissions
  * Improved release process resilience with conditional step execution and refined error handling for distribution notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->