### PR TITLE
fix: add WinGet existence check for first-release graceful handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -997,7 +997,6 @@ jobs:
     runs-on: windows-latest  # Required for WinGet releaser
     needs: pypi-publish  # WinGet needs PyPI package, not Docker images
     if: startsWith(github.ref, 'refs/tags/v')
-    continue-on-error: true  # Non-blocking until package is in winget-pkgs
     timeout-minutes: 15
     steps:
       - name: Extract version
@@ -1006,9 +1005,23 @@ jobs:
         run: |
           $version = $env:GITHUB_REF -replace 'refs/tags/v', ''
           Write-Output "version=$version" >> $env:GITHUB_OUTPUT
-          Write-Output "📦 Creating WinGet manifest for version: $version"
+
+      - name: Check if package exists in winget-pkgs
+        id: check_package
+        shell: pwsh
+        run: |
+          try {
+            winget show jmo.jmo-security 2>$null
+            Write-Output "exists=true" >> $env:GITHUB_OUTPUT
+          } catch {
+            Write-Output "exists=false" >> $env:GITHUB_OUTPUT
+            Write-Output "Package 'jmo.jmo-security' not yet in winget-pkgs."
+            Write-Output "Submit initial manifest via PR to:"
+            Write-Output "  https://github.com/microsoft/winget-pkgs"
+          }
 
       - name: Submit manifest to microsoft/winget-pkgs
+        if: steps.check_package.outputs.exists == 'true'
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           # Required: Personal Access Token with public_repo scope
@@ -1017,11 +1030,11 @@ jobs:
           identifier: jmo.jmo-security
 
       - name: Success notification
-        if: success()
+        if: steps.check_package.outputs.exists == 'true' && success()
         shell: pwsh
         run: |
           $version = "${{ steps.version.outputs.version }}"
-          Write-Output "✅ Successfully submitted PR to microsoft/winget-pkgs for version $version"
+          Write-Output "Successfully submitted PR to winget-pkgs for $version"
           Write-Output ""
           Write-Output "📋 Next steps:"
           Write-Output "  1. Monitor PR at: https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+jmo-security"


### PR DESCRIPTION
## Summary

Add `winget show` pre-check to WinGet job (same pattern as Homebrew formula check). When `jmo.jmo-security` doesn't exist in winget-pkgs yet, the job succeeds gracefully instead of failing. Removes `continue-on-error` so the job reports its true status.

This is the last fix needed for 100% green release workflow.

## Test plan
- [x] YAML valid + yamllint + actionlint pass
- [ ] CI quick-checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced WinGet package release workflow with validation checks to verify package existence before submission, ensuring more reliable releases and accurate success notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->