### PR TITLE
docs(v1.0.1): correct FAQ examples and Dockerfile usage comments

### DIFF
--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -304,4 +304,5 @@ CMD ["--help"]
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD jmo --help > /dev/null || exit 1
 
-# Usage: docker run --rm -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:1.0.1-balanced scan --repo /scan --profile balanced
+# Usage: docker run --rm -v "$(pwd)/.jmo:/scan/.jmo" -v "$(pwd):/scan" ghcr.io/jimmy058910/jmo-security:1.0.1-balanced scan --repo /scan --profile balanced
+# The .jmo mount persists the SQLite history DB between runs so `jmo history`, `jmo diff`, and `jmo trend` work.

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -193,4 +193,5 @@ CMD ["--help"]
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD jmo --help > /dev/null || exit 1
 
-# Usage: docker run --rm -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:1.0.1-fast scan --repo /scan --profile fast --fail-on HIGH
+# Usage: docker run --rm -v "$(pwd)/.jmo:/scan/.jmo" -v "$(pwd):/scan" ghcr.io/jimmy058910/jmo-security:1.0.1-fast scan --repo /scan --profile fast --fail-on HIGH
+# The .jmo mount persists the SQLite history DB between runs so `jmo history`, `jmo diff`, and `jmo trend` work.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -79,7 +79,7 @@ jmo scan --gitlab-url https://gitlab.com/myorg/myrepo
 jmo scan --k8s
 ```
 
-You can combine multiple targets in one command.
+Target flags are mutually exclusive — pick one per `jmo scan` invocation. For multi-target workflows, chain separate scans into the same results directory (or use `--repos-dir` to iterate over a parent folder of repositories).
 
 ### How long do scans take?
 
@@ -97,10 +97,10 @@ per_tool:
     timeout: 600
 ```
 
-Or skip tools via CLI:
+Or skip tools via CLI (space-separated, not comma):
 
 ```bash
-jmo scan --repo . --skip-tools trivy,checkov
+jmo scan --repo . --skip-tools trivy checkov
 ```
 
 ### Why does my scan fail with "tool not found"?


### PR DESCRIPTION
## Summary

Three CodeRabbit findings on merged v1.0.1 PRs reached users in shipped docs. This patch corrects them.

### Bugs

1. **`FAQ.md:82`** — Claimed "You can combine multiple targets in one command" but `jmo scan`'s target flags are in `add_mutually_exclusive_group` (`scripts/cli/jmo.py:263`). Users following the FAQ hit argparse errors.
2. **`FAQ.md:103`** — Example `--skip-tools trivy,checkov` is a silent no-op. The argparse definition is `nargs="*"` (space-separated); the comma form becomes a single literal tool name with no match, so nothing is skipped.
3. **`Dockerfile.balanced:307` + `Dockerfile.fast:196`** — Usage comments omitted `-v \$(pwd)/.jmo:/scan/.jmo`. CLAUDE.md flags this as a CRITICAL mount — without it, SQLite scan history is lost every container run, silently breaking `jmo history`, `jmo diff`, and `jmo trend`.

### Verification

- [x] FAQ.md:82 replaced with accurate "mutually exclusive" guidance + `--repos-dir` pointer
- [x] FAQ.md:103 uses space-separated form (`--skip-tools trivy checkov`)
- [x] Both Dockerfiles include `.jmo` mount with explanatory comment matching the existing pattern in `FAQ.md:135-140`
- [x] markdownlint + doc-links pre-commit hooks pass

## Test plan

- [ ] CI green
- [ ] Spot-check rendered FAQ.md on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)