### PR TITLE
fix(ci): unquote matrix expansion in scheduled.yml to fix shellcheck SC2170

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1035,7 +1035,7 @@ jobs:
 
           echo "Installed tools: $INSTALLED (expected: ${{ matrix.expected_tools }})"
 
-          if [ "$INSTALLED" -lt "${{ matrix.expected_tools }}" ]; then
+          if [ "$INSTALLED" -lt ${{ matrix.expected_tools }} ]; then
             echo "::error::Tool count $INSTALLED is less than expected ${{ matrix.expected_tools }}"
             cat tools-check.json | jq '.[] | select(.installed == false) | .name'
             exit 1


### PR DESCRIPTION
## Summary

The weekly ``Lint (full pre-commit suite)`` job on ``scheduled.yml`` has been failing because shellcheck flags ``SC2170`` on line 1038:

\`\`\`
if [ \"\$INSTALLED\" -lt \"\${{ matrix.expected_tools }}\" ]; then
\`\`\`

shellcheck sees the quoted RHS as a string literal, so ``-lt`` (a numeric comparator) is invalid.

## Change

One character removed: drop the quotes around ``\${{ matrix.expected_tools }}``. GitHub Actions expands the matrix value as a bare integer at parse time, which shellcheck accepts.

## Test plan

- [x] ``pre-commit run actionlint --files .github/workflows/scheduled.yml`` passes locally
- [ ] CI Lint job goes green on this PR
- [ ] Next scheduled run (3AM UTC) has green Lint job

## Related

Part of the post-v1.0.1 triage cluster — see failing runs ``24620635715`` and ``24619699508`` on current main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Fixed Docker tool installation verification in CI/CD pipeline to correctly validate the expected tool count during automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->