### PR TITLE
fix(tests): pin utf-8 encoding on read_text() to fix Windows cp1252 failures

### DIFF
--- a/tests/cli/test_diff_commands.py
+++ b/tests/cli/test_diff_commands.py
@@ -294,7 +294,7 @@ def test_cli_directory_mode_md(sample_scan_directories, tmp_path):
     assert result == 0
     assert output_path.exists()
 
-    content = output_path.read_text()
+    content = output_path.read_text(encoding="utf-8")
     assert "# 🔍 Security Diff Report" in content
     assert "## 📊 Summary" in content
 
@@ -1251,7 +1251,7 @@ class TestCmdDiffOutputFormats:
 
         assert result == 0
         assert output_file.exists()
-        content = output_file.read_text()
+        content = output_file.read_text(encoding="utf-8")
         assert "<html" in content or "<!DOCTYPE" in content
 
     def test_cmd_diff_sarif_to_file(self, sample_scan_directories, tmp_path):
@@ -1275,7 +1275,7 @@ class TestCmdDiffOutputFormats:
 
         assert result == 0
         assert output_file.exists()
-        content = json.loads(output_file.read_text())
+        content = json.loads(output_file.read_text(encoding="utf-8"))
         # Verify SARIF schema (actual URL uses 'master' branch and 'Schemata' path)
         assert "$schema" in content
         assert "sarif-schema-2.1.0.json" in content["$schema"]
@@ -1306,7 +1306,7 @@ class TestCmdDiffFilters:
         assert result == 0
         assert output_file.exists()
 
-        data = json.loads(output_file.read_text())
+        data = json.loads(output_file.read_text(encoding="utf-8"))
         # All findings should be CRITICAL or HIGH
         for finding in data.get("new_findings", []):
             assert finding["severity"] in ["CRITICAL", "HIGH"]
@@ -1333,7 +1333,7 @@ class TestCmdDiffFilters:
         assert result == 0
         assert output_file.exists()
 
-        data = json.loads(output_file.read_text())
+        data = json.loads(output_file.read_text(encoding="utf-8"))
         # All findings should be from trivy
         for finding in data.get("new_findings", []):
             assert finding["tool"]["name"] == "trivy"
@@ -1360,7 +1360,7 @@ class TestCmdDiffFilters:
         assert result == 0
         assert output_file.exists()
 
-        data = json.loads(output_file.read_text())
+        data = json.loads(output_file.read_text(encoding="utf-8"))
         # Should have new findings but empty resolved/modified
         assert "new_findings" in data
         assert len(data.get("resolved_findings", [])) == 0
@@ -1498,7 +1498,7 @@ class TestCmdDiffEdgeCases:
         assert result == 0
         assert output_file.exists()
 
-        data = json.loads(output_file.read_text())
+        data = json.loads(output_file.read_text(encoding="utf-8"))
         # Modifications should be empty or not present
         assert len(data.get("modified_findings", [])) == 0
 
@@ -1524,7 +1524,7 @@ class TestCmdDiffEdgeCases:
         assert result == 0
         assert output_file.exists()
 
-        data = json.loads(output_file.read_text())
+        data = json.loads(output_file.read_text(encoding="utf-8"))
         # All findings should pass all filters
         for finding in data.get("new_findings", []):
             assert finding["severity"] in ["HIGH", "CRITICAL"]

--- a/tests/cli/test_wizard_policy_integration.py
+++ b/tests/cli/test_wizard_policy_integration.py
@@ -511,7 +511,7 @@ def test_export_violations_json(tmp_path):
         assert output_file.exists()
 
         # Check file contents
-        data = json.loads(output_file.read_text())
+        data = json.loads(output_file.read_text(encoding="utf-8"))
         assert data["policy"] == "zero-secrets"
         assert data["passed"] is False
         assert data["violation_count"] == 1
@@ -552,7 +552,7 @@ def test_export_violations_markdown(tmp_path):
         assert output_file.exists()
 
         # Check file contents
-        content = output_file.read_text()
+        content = output_file.read_text(encoding="utf-8")
         assert "# Policy Violations: owasp-top-10" in content
         assert "❌ FAILED" in content
         assert "**Violations:** 1" in content
@@ -954,7 +954,7 @@ def test_display_policy_violations_interactive_export_markdown(tmp_path, capsys)
         assert md_file.exists()
 
         # Check content includes message
-        content = md_file.read_text()
+        content = md_file.read_text(encoding="utf-8")
         assert "Policy failed" in content
     finally:
         os.chdir(original_dir)

--- a/tests/cli/test_wizard_security.py
+++ b/tests/cli/test_wizard_security.py
@@ -38,7 +38,7 @@ class TestCommandInjectionPrevention:
         wizard_path = (
             Path(__file__).parent.parent.parent / "scripts" / "cli" / "wizard.py"
         )
-        content = wizard_path.read_text()
+        content = wizard_path.read_text(encoding="utf-8")
 
         # Check that shell=False is used (and shell=True is removed)
         assert "shell=False" in content, "shell=False should be used for subprocess.run"
@@ -283,7 +283,7 @@ class TestRegressionTests:
         wizard_path = (
             Path(__file__).parent.parent.parent / "scripts" / "cli" / "wizard.py"
         )
-        content = wizard_path.read_text()
+        content = wizard_path.read_text(encoding="utf-8")
 
         # Count instances of shell=True in actual code (not comments, not nosec)
         code_lines = [
@@ -303,7 +303,7 @@ class TestRegressionTests:
         wizard_path = (
             Path(__file__).parent.parent.parent / "scripts" / "cli" / "wizard.py"
         )
-        content = wizard_path.read_text()
+        content = wizard_path.read_text(encoding="utf-8")
 
         # subprocess.run with shell=False is safe (no B602/B603 HIGH findings)
         assert "subprocess.run(" in content


### PR DESCRIPTION
## Summary

Five tests on the nightly ``Cross-Platform Tests (windows-latest / Python 3.12 and 3.13)`` matrix have been crashing with ``UnicodeDecodeError``:

\`\`\`
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 5: character maps to <undefined>
C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\encodings\cp1252.py:23
\`\`\`

On Windows, ``Path.read_text()`` defaults to ``cp1252``, which cannot decode UTF-8-encoded emoji bytes written into fixtures by the wizard/policy flows (``✅`` = ``0xe2 0x9c 0x85``, ``❌`` = ``0xe2 0x9d 0x8c``). The specific failing tests were:

- ``test_cli_directory_mode_md``
- ``test_cmd_diff_html_to_file``
- ``test_export_violations_markdown``
- ``test_display_policy_violations_interactive_export_markdown``
- ``test_no_shell_true_in_execution`` (reads wizard.py source, which contains emoji)

## Change

Added ``encoding=\"utf-8\"`` to every bare ``read_text()`` call in three affected test files (14 lines total). No production code changed.

## Test plan

- [x] Local on Windows: ``pytest tests/cli/test_diff_commands.py tests/cli/test_wizard_policy_integration.py tests/cli/test_wizard_security.py`` passes 128/128
- [ ] CI cross-platform matrix passes on this PR
- [ ] Next nightly scheduled run (2AM UTC) has green windows-3.12 and windows-3.13 jobs

## Related

Part of the post-v1.0.1 triage cluster. See failing run ``24619699508``.