### PR TITLE
feat(release): publish bare variant tags; rename Dockerfile to Dockerfile.deep (v1.0.2 prep)

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -108,7 +108,7 @@ jobs:
           git checkout -b "$BRANCH"
 
           # Stage changes
-          git add versions.yaml Dockerfile Dockerfile.balanced Dockerfile.slim Dockerfile.fast \
+          git add versions.yaml Dockerfile.deep Dockerfile.balanced Dockerfile.slim Dockerfile.fast \
                  .pre-commit-config.yaml
           # Stage any files reformatted by updated hooks
           git add -u -- scripts/ tests/ hooks/
@@ -282,7 +282,7 @@ jobs:
         run: |
           # Extract Trivy versions from all 4 Dockerfiles
           # shellcheck disable=SC2252
-          TRIVY_FULL=$(grep -oP 'TRIVY_VERSION="\K[0-9.]+' Dockerfile || echo "not_found")
+          TRIVY_FULL=$(grep -oP 'TRIVY_VERSION="\K[0-9.]+' Dockerfile.deep || echo "not_found")
           # shellcheck disable=SC2252
           TRIVY_BALANCED=$(grep -oP 'TRIVY_VERSION="\K[0-9.]+' Dockerfile.balanced || echo "not_found")
           # shellcheck disable=SC2252
@@ -291,7 +291,7 @@ jobs:
           TRIVY_FAST=$(grep -oP 'TRIVY_VERSION="\K[0-9.]+' Dockerfile.fast || echo "not_found")
 
           echo "Trivy versions found:"
-          echo "  Dockerfile:          $TRIVY_FULL"
+          echo "  Dockerfile.deep:     $TRIVY_FULL"
           echo "  Dockerfile.balanced: $TRIVY_BALANCED"
           echo "  Dockerfile.slim:     $TRIVY_SLIM"
           echo "  Dockerfile.fast:     $TRIVY_FAST"
@@ -327,7 +327,7 @@ jobs:
           ISSUES=0
 
           # Check for inline version patterns that should use variables
-          for dockerfile in Dockerfile Dockerfile.balanced Dockerfile.slim Dockerfile.fast; do
+          for dockerfile in Dockerfile.deep Dockerfile.balanced Dockerfile.slim Dockerfile.fast; do
             echo "Checking $dockerfile for hardcoded versions..."
 
             # Look for download URLs with hardcoded versions (bad pattern)
@@ -364,7 +364,7 @@ jobs:
           # Check if Python security tools have updates
           for tool in bandit semgrep checkov ruff; do
             echo "Checking $tool..."
-            CURRENT=$(grep -oP "${tool}==[0-9.]+" Dockerfile | head -n1 | cut -d'=' -f3 || echo "unknown")
+            CURRENT=$(grep -oP "${tool}==[0-9.]+" Dockerfile.deep | head -n1 | cut -d'=' -f3 || echo "unknown")
             LATEST=$(pip index versions "$tool" 2>/dev/null | grep -oP '(?<=Available versions: )[0-9.]+' | head -n1 || echo "unknown")
 
             echo "  Current: $CURRENT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Bump version in pyproject.toml
         id: bump
+        env:
+          VERSION_BUMP: ${{ inputs.version_bump }}
         run: |
           CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           echo "Current version: $CURRENT_VERSION"
@@ -93,8 +95,8 @@ jobs:
           # Parse version components
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION" || true
 
-          # Bump version based on input
-          case "${{ inputs.version_bump }}" in
+          # Bump version based on input (env var, not interpolated, to avoid shell injection)
+          case "$VERSION_BUMP" in
             major)
               MAJOR=$((MAJOR + 1))
               MINOR=0
@@ -164,14 +166,15 @@ jobs:
       - name: Commit release changes
         env:
           CHANGELOG_ENTRY: ${{ inputs.changelog_entry }}
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          VERSION_BUMP: ${{ inputs.version_bump }}
+          TOOLS_UPDATED: ${{ steps.tool_updates.outputs.tools_updated }}
         run: |
-          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
-
           git add pyproject.toml CHANGELOG.md
 
-          # Add tool updates if any
-          if [[ "${{ steps.tool_updates.outputs.tools_updated }}" == "true" ]]; then
-            git add versions.yaml Dockerfile Dockerfile.balanced Dockerfile.slim Dockerfile.fast
+          # Add tool updates if any (env var, not interpolated, to avoid shell injection)
+          if [[ "$TOOLS_UPDATED" == "true" ]]; then
+            git add versions.yaml Dockerfile.deep Dockerfile.balanced Dockerfile.slim Dockerfile.fast
           fi
 
           # Create commit
@@ -185,25 +188,28 @@ jobs:
           - All security tools updated to latest versions
           - CHANGELOG.md updated
 
-          🤖 Generated with [Claude Code](https://claude.com/claude-code)
+          Generated with Claude Code (https://claude.com/claude-code)
 
           Co-Authored-By: Claude <noreply@anthropic.com>
           COMMIT_MSG
 
-          # Substitute variables
-          sed -i "s/\$NEW_VERSION/${NEW_VERSION}/g" commit_message.txt
+          # Substitute variables via env (safer than GitHub-context interpolation in run:)
           printf '%s\n' \
             'import os,pathlib as PL' \
             'p=PL.Path("commit_message.txt")' \
-            'p.write_text(p.read_text().replace("$CHANGELOG_ENTRY",os.environ["CHANGELOG_ENTRY"]))' \
+            't=p.read_text()' \
+            't=t.replace("$NEW_VERSION",os.environ["NEW_VERSION"])' \
+            't=t.replace("$CHANGELOG_ENTRY",os.environ["CHANGELOG_ENTRY"])' \
+            't=t.replace("$VERSION_BUMP",os.environ["VERSION_BUMP"])' \
+            'p.write_text(t)' \
             | python3
-          sed -i "s/\$VERSION_BUMP/${{ inputs.version_bump }}/g" commit_message.txt
 
           git commit -F commit_message.txt
 
       - name: Push release branch
+        env:
+          BRANCH: ${{ steps.create_branch.outputs.branch }}
         run: |
-          BRANCH="${{ steps.create_branch.outputs.branch }}"
           git push origin "$BRANCH"
 
       - name: Create Pull Request
@@ -271,17 +277,18 @@ jobs:
             --label "release"
 
       - name: Summary
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          BRANCH: ${{ steps.create_branch.outputs.branch }}
+          VERSION_BUMP: ${{ inputs.version_bump }}
         run: |
-          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
-          BRANCH="${{ steps.create_branch.outputs.branch }}"
-
           {
             echo "## Automated Release Summary"
             echo ""
-            echo "✅ **Release PR created successfully**"
+            echo "**Release PR created successfully**"
             echo ""
             echo "- **Version**: v${NEW_VERSION}"
-            echo "- **Type**: ${{ inputs.version_bump }}"
+            echo "- **Type**: ${VERSION_BUMP}"
             echo "- **Branch**: \`${BRANCH}\`"
             echo ""
             echo "### Next Steps"
@@ -467,7 +474,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [full, balanced, slim, fast]
+        variant: [deep, balanced, slim, fast]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -485,11 +492,9 @@ jobs:
       - name: Determine Dockerfile
         id: dockerfile
         run: |
-          if [ "${{ matrix.variant }}" = "full" ]; then
-            echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
-          else
-            echo "file=Dockerfile.${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
-          fi
+          # After v1.0.2 every variant has its own Dockerfile.<variant> — no
+          # special case for the heavyweight image (which is now Dockerfile.deep).
+          echo "file=Dockerfile.${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push by digest
         id: build
@@ -526,7 +531,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [full, balanced, slim, fast]
+        variant: [deep, balanced, slim, fast]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -544,11 +549,9 @@ jobs:
       - name: Determine Dockerfile
         id: dockerfile
         run: |
-          if [ "${{ matrix.variant }}" = "full" ]; then
-            echo "file=Dockerfile" >> "$GITHUB_OUTPUT"
-          else
-            echo "file=Dockerfile.${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
-          fi
+          # After v1.0.2 every variant has its own Dockerfile.<variant> — no
+          # special case for the heavyweight image (which is now Dockerfile.deep).
+          echo "file=Dockerfile.${{ matrix.variant }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push by digest
         id: build
@@ -586,7 +589,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [full, balanced, slim, fast]
+        variant: [deep, balanced, slim, fast]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -626,9 +629,16 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && matrix.variant == 'full' }}
+            # Bare :latest points at the heavyweight `deep` variant on version-tag pushes.
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && matrix.variant == 'deep' }}
+            # Bare :deep / :balanced / :slim / :fast (no version suffix) — the user-facing
+            # convenience tags referenced in FAQ, USER_GUIDE, DOCKER_README.
+            type=raw,value=${{ matrix.variant }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # One-release backward-compat alias: keep :full pointing at :deep until users
+            # migrate. Remove this line in the release after v1.0.2.
+            type=raw,value=full,enable=${{ startsWith(github.ref, 'refs/tags/v') && matrix.variant == 'deep' }}
           flavor: |
-            suffix=-${{ matrix.variant }},onlatest=${{ matrix.variant != 'full' }}
+            suffix=-${{ matrix.variant }},onlatest=${{ matrix.variant != 'deep' }}
             latest=false
 
       - name: Download amd64 digest
@@ -789,7 +799,7 @@ jobs:
     if: always() && needs.docker-merge.result == 'success'
     strategy:
       matrix:
-        variant: [full, balanced, slim, fast]
+        variant: [deep, balanced, slim, fast]
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,7 @@ tests/               # 5,000+ tests across unit/adapters/reporters/integration
 | `scripts/core/adapters/*.py` | Tool output parsers (28 adapters) |
 | `jmo.yml` | Main configuration |
 | `versions.yaml` | Tool version registry |
-| `Dockerfile*` | Docker variants (main=deep, .fast, .slim, .balanced) |
+| `Dockerfile.*` | Docker variants: `Dockerfile.deep` (heavyweight, also tagged `:latest`), `.fast`, `.slim`, `.balanced` |
 
 ## Scan Profiles
 
@@ -290,7 +290,7 @@ tests/               # 5,000+ tests across unit/adapters/reporters/integration
 | `balanced` | 18 | 18-25 min | Production scans, CI/CD | `:balanced` |
 | `deep` | 29 | 40-70 min | Compliance audits, pentests | `:deep` (default) |
 
-**Note:** Main `Dockerfile` = deep variant. See PROFILES_AND_TOOLS.md for complete tool lists.
+**Note:** The heavyweight image lives at `Dockerfile.deep` (also pulled via `:latest` and `:deep` bare tags). See PROFILES_AND_TOOLS.md for complete tool lists.
 
 ## Development Guidelines
 

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -304,5 +304,5 @@ CMD ["--help"]
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD jmo --help > /dev/null || exit 1
 
-# Usage: docker run --rm -v "$(pwd)/.jmo:/scan/.jmo" -v "$(pwd):/scan" ghcr.io/jimmy058910/jmo-security:1.0.1-balanced scan --repo /scan --profile balanced
+# Usage: docker run --rm -v "$(pwd)/.jmo:/scan/.jmo" -v "$(pwd):/scan" ghcr.io/jimmy058910/jmo-security:balanced scan --repo /scan --profile balanced
 # The .jmo mount persists the SQLite history DB between runs so `jmo history`, `jmo diff`, and `jmo trend` work.

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -423,9 +423,13 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # Basic scan (deep profile, all 27 tools):
 # docker run --rm -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:1.0.1-full scan --repo /scan --results /scan/results --profile deep
 #
+# Usage: docker run --rm -v "$(pwd)/.jmo:/scan/.jmo" -v "$(pwd):/scan" \
+#   ghcr.io/jimmy058910/jmo-security:deep scan --repo /scan --profile deep --fail-on HIGH
+# The .jmo mount persists the SQLite history DB between runs so `jmo history`, `jmo diff`, and `jmo trend` work.
+#
 # CI mode with caching (30s faster on subsequent runs):
 # docker run --rm -v $(pwd):/scan -v trivy-cache:/root/.cache/trivy -v grype-cache:/root/.cache/grype \
-#   ghcr.io/jimmy058910/jmo-security:1.0.1-full ci --repo /scan --fail-on HIGH --profile
+#   ghcr.io/jimmy058910/jmo-security:deep ci --repo /scan --fail-on HIGH --profile
 #
 # v1.0.0 Optimizations:
 # - Multi-stage builds: Reduced image size by 21% (2.49 GB → 1.97 GB)

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -193,5 +193,5 @@ CMD ["--help"]
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD jmo --help > /dev/null || exit 1
 
-# Usage: docker run --rm -v "$(pwd)/.jmo:/scan/.jmo" -v "$(pwd):/scan" ghcr.io/jimmy058910/jmo-security:1.0.1-fast scan --repo /scan --profile fast --fail-on HIGH
+# Usage: docker run --rm -v "$(pwd)/.jmo:/scan/.jmo" -v "$(pwd):/scan" ghcr.io/jimmy058910/jmo-security:fast scan --repo /scan --profile fast --fail-on HIGH
 # The .jmo mount persists the SQLite history DB between runs so `jmo history`, `jmo diff`, and `jmo trend` work.

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -260,4 +260,4 @@ CMD ["--help"]
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD jmo --help > /dev/null || exit 1
 
-# Usage: docker run --rm -v ~/.aws:/root/.aws:ro ghcr.io/jimmy058910/jmo-security:1.0.1-slim scan --aws-account 123456789012 --profile cloud
+# Usage: docker run --rm -v ~/.aws:/root/.aws:ro ghcr.io/jimmy058910/jmo-security:slim scan --aws-account 123456789012 --profile cloud

--- a/Makefile
+++ b/Makefile
@@ -532,10 +532,11 @@ DOCKER_REGISTRY ?= ghcr.io
 DOCKER_ORG ?= jimmy058910
 DOCKER_IMAGE ?= jmo-security
 DOCKER_TAG ?= latest
-VARIANT ?= full
+VARIANT ?= deep
 
-# Determine Dockerfile based on variant
-DOCKERFILE := $(if $(filter full,$(VARIANT)),Dockerfile,Dockerfile.$(VARIANT))
+# Determine Dockerfile based on variant. After v1.0.2, every variant lives in
+# its own file — the heavyweight image is Dockerfile.deep, not bare Dockerfile.
+DOCKERFILE := Dockerfile.$(VARIANT)
 
 # Auto-detect target architecture (amd64 or arm64) for Docker builds
 # This ensures Alpine builds install semgrep/checkov on amd64
@@ -545,30 +546,30 @@ docker-build:
 	@echo "Building Docker image: $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG)-$(VARIANT)"
 	@echo "Target architecture: $(TARGETARCH)"
 	docker build --build-arg TARGETARCH=$(TARGETARCH) -f $(DOCKERFILE) -t $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG)-$(VARIANT) .
-	@if [ "$(VARIANT)" = "full" ]; then \
+	@if [ "$(VARIANT)" = "deep" ]; then \
 		docker tag $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG)-$(VARIANT) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG); \
 		echo "Tagged as latest: $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG)"; \
 	fi
 
 docker-build-all:
 	@echo "Building all Docker image variants..."
-	$(MAKE) docker-build VARIANT=full
+	$(MAKE) docker-build VARIANT=deep
 	$(MAKE) docker-build VARIANT=slim
 	$(MAKE) docker-build VARIANT=alpine
 
 docker-build-local:
 	@echo "Building all Docker variants with 'local' tag for testing..."
 	@echo "Target architecture: $(TARGETARCH)"
-	docker build --build-arg TARGETARCH=$(TARGETARCH) -f Dockerfile -t jmo-security:local-full .
+	docker build --build-arg TARGETARCH=$(TARGETARCH) -f Dockerfile.deep -t jmo-security:local-deep .
 	docker build --build-arg TARGETARCH=$(TARGETARCH) -f Dockerfile.slim -t jmo-security:local-slim .
 	docker build --build-arg TARGETARCH=$(TARGETARCH) -f Dockerfile.alpine -t jmo-security:local-alpine .
 	@echo ""
-	@echo "✅ Local Docker images built successfully:"
-	@echo "  - jmo-security:local-full"
+	@echo "Local Docker images built successfully:"
+	@echo "  - jmo-security:local-deep"
 	@echo "  - jmo-security:local-slim"
 	@echo "  - jmo-security:local-alpine"
 	@echo ""
-	@echo "Test with: docker run --rm jmo-security:local-full --help"
+	@echo "Test with: docker run --rm jmo-security:local-deep --help"
 	@echo "Run E2E tests: DOCKER_IMAGE_BASE=jmo-security DOCKER_TAG=local make test-e2e"
 
 docker-test:
@@ -586,7 +587,7 @@ docker-test:
 docker-push:
 	@echo "Pushing Docker image: $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG)-$(VARIANT)"
 	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG)-$(VARIANT)
-	@if [ "$(VARIANT)" = "full" ]; then \
+	@if [ "$(VARIANT)" = "deep" ]; then \
 		docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG); \
 		echo "Pushed latest: $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(DOCKER_IMAGE):$(DOCKER_TAG)"; \
 	fi

--- a/docs/DOCKER_README.md
+++ b/docs/DOCKER_README.md
@@ -407,8 +407,8 @@ START: What is your primary use case?
 ### Choosing a Variant
 
 ```bash
-# Deep - Maximum coverage (29 tools, 26 Docker-ready)
-docker pull ghcr.io/jimmy058910/jmo-security:latest
+# Deep - Maximum coverage (29 tools, 26 Docker-ready) — also published as :latest
+docker pull ghcr.io/jimmy058910/jmo-security:deep
 
 # Balanced - Production CI/CD (18 tools)
 docker pull ghcr.io/jimmy058910/jmo-security:balanced
@@ -419,6 +419,8 @@ docker pull ghcr.io/jimmy058910/jmo-security:slim
 # Fast - Quick validation (9 tools)
 docker pull ghcr.io/jimmy058910/jmo-security:fast
 ```
+
+All tags are also published with version suffixes (e.g. `:1.0.2-deep`, `:1.0-deep`, `:1-deep`) for pinning in CI. For one release cycle, `:full` is kept as an alias for `:deep` so existing scripts don't break — use `:deep` going forward.
 
 ### Alpine Deprecation Notice
 

--- a/scripts/cli/build_commands.py
+++ b/scripts/cli/build_commands.py
@@ -21,7 +21,7 @@ VARIANTS = {
     "fast": "Dockerfile.fast",
     "slim": "Dockerfile.slim",
     "balanced": "Dockerfile.balanced",
-    "deep": "Dockerfile",  # Base Dockerfile is the full/deep variant
+    "deep": "Dockerfile.deep",
 }
 
 # Default registry configuration

--- a/scripts/core/validators/release_validator.py
+++ b/scripts/core/validators/release_validator.py
@@ -1618,7 +1618,7 @@ _QUICK_CHECKS: list[tuple[str, _CheckFn]] = [
 
 # Full tier additional Dockerfiles (4) + pip install (1) + entry point (1) = 6
 _DOCKERFILES = [
-    "Dockerfile",
+    "Dockerfile.deep",
     "Dockerfile.fast",
     "Dockerfile.slim",
     "Dockerfile.balanced",

--- a/scripts/dev/update_versions.py
+++ b/scripts/dev/update_versions.py
@@ -56,7 +56,7 @@ except ImportError:
 # Paths
 REPO_ROOT = Path(__file__).parent.parent.parent
 VERSIONS_YAML = REPO_ROOT / "versions.yaml"
-DOCKERFILE = REPO_ROOT / "Dockerfile"
+DOCKERFILE = REPO_ROOT / "Dockerfile.deep"
 DOCKERFILE_BALANCED = REPO_ROOT / "Dockerfile.balanced"
 DOCKERFILE_SLIM = REPO_ROOT / "Dockerfile.slim"
 DOCKERFILE_FAST = REPO_ROOT / "Dockerfile.fast"

--- a/tests/cli/test_build_commands.py
+++ b/tests/cli/test_build_commands.py
@@ -36,7 +36,7 @@ def test_variants_has_correct_dockerfiles():
     assert VARIANTS["fast"] == "Dockerfile.fast"
     assert VARIANTS["slim"] == "Dockerfile.slim"
     assert VARIANTS["balanced"] == "Dockerfile.balanced"
-    assert VARIANTS["deep"] == "Dockerfile"  # Base Dockerfile
+    assert VARIANTS["deep"] == "Dockerfile.deep"
 
 
 def test_default_registry():


### PR DESCRIPTION
## Summary

Three drifted sources of truth for the heavyweight Docker variant are finally aligned, the bare variant tags that every user-facing doc references are finally published, and three pre-existing shell-injection findings on the release workflow are fixed.

This is the **v1.0.2 prep PR** — after merge, cut v1.0.2 to republish all images with the new tag templates.

## Problems fixed

### Bug A: Release workflow never published bare variant tags

Every ``docker pull ghcr.io/jimmy058910/jmo-security:latest`` (or ``:deep``, ``:balanced``, ``:slim``, ``:fast``) returned ``manifest unknown``. Only ``:1.0.1-full`` / ``:latest-full`` / ``:main-full`` existed. FAQ, DOCKER_README, CLAUDE.md, wizard docs — all point users at tags that don't exist.

### Bug B: ``full`` ≠ ``deep`` — three sources of truth drifted

- ``release.yml`` matrix: ``variant: [full, balanced, slim, fast]``
- ``scheduled.yml`` matrix: ``variant: [deep, balanced, slim, fast]``
- ``scripts/cli/build_commands.py`` VARIANTS: ``deep -> Dockerfile``

Whichever one scheduled.yml matched never existed in GHCR because release.yml called the heavyweight variant ``full``. The ``jmo build`` tool's ``deep`` keyword mapped to bare ``Dockerfile``.

## Changes

### 1. Rename ``Dockerfile`` → ``Dockerfile.deep``

``git mv`` preserves history (96% similarity on rename). Every file that referenced the bare ``Dockerfile`` by name is updated:
- ``scripts/cli/build_commands.py`` VARIANTS dict
- ``scripts/core/validators/release_validator.py`` ``_DOCKERFILES`` tuple
- ``scripts/dev/update_versions.py`` ``DOCKERFILE`` constant
- ``Makefile`` (``VARIANT`` default is now ``deep``, ``DOCKERFILE`` derivation simplified)
- ``.github/workflows/release.yml`` (matrix + Determine Dockerfile steps)
- ``.github/workflows/maintenance.yml`` (several ``git add`` and ``grep`` references)

### 2. Publish bare variant tags

``release.yml`` metadata-action now emits on every ``v*`` tag push:

\`\`\`yaml
type=raw,value=latest,enable=... && matrix.variant == 'deep'
type=raw,value=${{ matrix.variant }},enable=startsWith(github.ref, 'refs/tags/v')
type=raw,value=full,enable=... && matrix.variant == 'deep'   # backward-compat alias, remove after v1.0.2
\`\`\`

Result per release (v1.0.2+): **``:deep``, ``:balanced``, ``:slim``, ``:fast``, ``:latest`` ← bare, finally**, plus all the versioned variants and the one-release ``:full`` alias.

### 3. Fix three pre-existing ``yaml.github-actions.security.run-shell-injection`` findings

The ``Bump version``, ``Commit release changes``, and ``Summary`` steps in ``release.yml`` all interpolated ``${{ inputs.X }}`` / ``${{ steps.X.outputs.Y }}`` directly into ``run:`` scripts (CWE-78, HIGH severity). Moved to ``env:`` blocks and ``"$ENVVAR"`` references per the semgrep rule. These pre-existed on main but bundled here because the semgrep hook blocks further release.yml edits otherwise.

### 4. Docs swept

- ``docs/DOCKER_README.md`` example corrected (used to say "Deep" but pull ``:latest`` — now shows bare ``:deep`` explicitly and explains the version-suffix convention for CI pinning)
- ``CLAUDE.md`` file-map updated to describe ``Dockerfile.deep``
- Dockerfile usage comments now use bare variant tags

## What's aspirational until v1.0.2 cuts

The bare tags don't exist yet on GHCR — they get created when the next ``v*`` tag push hits the fixed workflow. Docs, comments, and examples in this PR all assume v1.0.2 is published. Users pulling ``:deep`` on main today still hit manifest-unknown. **The next step after merging this PR is cutting v1.0.2.**

## Test plan

- [x] ``tests/cli/test_build_commands.py`` passes (41/41)
- [x] actionlint passes on release.yml and maintenance.yml
- [x] yamllint passes
- [x] mypy passes on all modified Python files
- [x] No bare ``Dockerfile`` references remain in workflow/code (verified via grep)
- [x] ``Dockerfile.deep`` git-history preserved (96% similarity on rename)
- [ ] CI passes on this PR
- [ ] **After merge:** cut v1.0.2 (tag push) and verify all five bare tags land in GHCR (``curl ghcr.io/v2/.../tags/list | jq``)
- [ ] **After v1.0.2:** ``docker pull ghcr.io/jimmy058910/jmo-security:deep`` succeeds; scheduled ``Validate X`` matrix jobs go green

## Follow-up

Task #13 — after v1.0.2 stabilizes, wire ``update_versions.py --classify`` (shipped in PR #302) into ``maintenance.yml auto-update-tools`` for aggressive auto-merge on patch+minor bumps.