### PR TITLE
release: v1.0.2 — bare Docker tags, Dockerfile.deep rename, CI hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to JMo Security will be documented in this file.
 
+## [1.0.2] - 2026-04-19
+
+### Fixed
+
+- **Docker tag publishing (user-facing regression)**: Release workflow now publishes the bare variant tags (`:deep`, `:balanced`, `:slim`, `:fast`, `:latest`) that every user-facing doc referenced. Previous releases only published versioned-with-suffix tags (`:1.0.1-full`, `:latest-full`), so `docker pull ghcr.io/jimmy058910/jmo-security:latest` returned "manifest unknown" on every release. Broken since v0.8.0.
+- **Docker variant naming consistency**: Renamed bare `Dockerfile` → `Dockerfile.deep` so every variant follows the same `Dockerfile.<variant>` convention. `jmo build` VARIANTS dict, `release.yml` matrix, `scheduled.yml` matrix, and `Makefile` all aligned on `deep` as the canonical name. One-release backward-compat alias: `:full` still resolves to `:deep` through v1.0.2, removed in the release after.
+- **Weekly CI red X**: `update_versions.py --check-latest` and `--check-outdated` now exit 0 when outdated tools are found (informational, not an error). The weekly `check-versions` job no longer fails on Sundays when tool updates are available. Existing `--create-issues` tracking still runs; a new `--fail-if-outdated` flag opts into the legacy strict-gating behavior for external CI scripts that depended on it.
+- **Windows cp1252 UnicodeDecodeError**: 5 tests on the `Cross-Platform Tests (windows-latest / Python 3.12 and 3.13)` matrix were crashing on emoji bytes written into fixtures. Added `encoding="utf-8"` to affected `read_text()` calls.
+- **`scheduled.yml:1038` shellcheck SC2170**: The `Lint (full pre-commit suite)` job on Docker-validation weekly runs has been failing because shellcheck flagged `-lt` with a quoted matrix-expansion RHS as numeric-vs-string comparison. Unquoted.
+- **Workflow shell-injection hygiene**: Pre-existing `yaml.github-actions.security.run-shell-injection` findings (CWE-78, HIGH) in three `release.yml` steps (`Bump version`, `Commit release changes`, `Summary`) migrated from `${{ inputs.X }}` / `${{ steps.X.outputs.Y }}` direct interpolation to `env:` blocks with `"$ENVVAR"` references.
+
+### Added
+
+- **`update_versions.py --classify` action**: New JSON output manifest with current, latest, semver bump level (`patch` / `minor` / `major` / `unknown`), and `critical` flag per tool. Foundation for upcoming aggressive auto-merge automation — patches/minors auto-PR, majors open an issue. Classifier treats 0.x pre-release versions and lossy normalization (akto `mini-testing-*`, `-stable` suffixes) as unsafe-to-auto-merge.
+
+### Notes
+
+- PyPI wheel and Docker images are both tagged `1.0.2`.
+- If you pin Dockerfiles by internal name (e.g., custom images using `FROM ghcr.io/jimmy058910/jmo-security:full`), migrate to `:deep` this cycle. `:full` alias will be removed in v1.0.3.
+
 ## [1.0.1] - 2026-04-16
 
 ### Security

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -140,8 +140,8 @@ FROM ubuntu:24.04 AS runtime
 ARG TARGETARCH
 
 LABEL org.opencontainers.image.title="JMo Security Suite (Balanced)"
-LABEL org.opencontainers.image.description="Production-ready security audit toolkit with 19 scanners optimized for CI/CD pipelines (v1.0.1)"
-LABEL org.opencontainers.image.version="1.0.1"
+LABEL org.opencontainers.image.description="Production-ready security audit toolkit with 19 scanners optimized for CI/CD pipelines (v1.0.2)"
+LABEL org.opencontainers.image.version="1.0.2"
 LABEL org.opencontainers.image.authors="James Moceri <general@jmogaming.com>"
 LABEL org.opencontainers.image.url="https://jmotools.com"
 LABEL org.opencontainers.image.source="https://github.com/jimmy058910/jmo-security-repo"

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -1,4 +1,4 @@
-# JMo Security Suite - All-in-One Docker Image (Full/Deep - v1.0.1)
+# JMo Security Suite - All-in-One Docker Image (Deep - v1.0.2)
 # Base: Ubuntu 24.04 with 29 security tools pre-installed
 # Size: ~1.9 GB (optimized) | Tools: 29 (26 Docker-ready + 3 manual) | Multi-arch: amd64, arm64
 # Note: 3 tools require manual install outside Docker: MobSF, Akto, AFL++ (see docs/MANUAL_INSTALLATION.md)
@@ -183,9 +183,9 @@ RUN SHELLCHECK_VERSION="0.10.0" && \
 FROM ubuntu:24.04 AS runtime
 ARG TARGETARCH
 
-LABEL org.opencontainers.image.title="JMo Security Suite (Full)"
-LABEL org.opencontainers.image.description="Terminal-first security audit toolkit with 29 tools (26 Docker-ready + OPA policy engine) (v1.0.1)"
-LABEL org.opencontainers.image.version="1.0.1"
+LABEL org.opencontainers.image.title="JMo Security Suite (Deep)"
+LABEL org.opencontainers.image.description="Terminal-first security audit toolkit with 29 tools (26 Docker-ready + OPA policy engine) (v1.0.2)"
+LABEL org.opencontainers.image.version="1.0.2"
 LABEL org.opencontainers.image.authors="James Moceri <general@jmogaming.com>"
 LABEL org.opencontainers.image.url="https://jmotools.com"
 LABEL org.opencontainers.image.source="https://github.com/jimmy058910/jmo-security-repo"
@@ -421,7 +421,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 
 # Usage examples (documented in metadata):
 # Basic scan (deep profile, all 27 tools):
-# docker run --rm -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:1.0.1-full scan --repo /scan --results /scan/results --profile deep
+# docker run --rm -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:1.0.2-deep scan --repo /scan --results /scan/results --profile deep
 #
 # Usage: docker run --rm -v "$(pwd)/.jmo:/scan/.jmo" -v "$(pwd):/scan" \
 #   ghcr.io/jimmy058910/jmo-security:deep scan --repo /scan --profile deep --fail-on HIGH

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -82,8 +82,8 @@ RUN SHELLCHECK_VERSION="0.10.0" && \
 FROM ubuntu:24.04 AS runtime
 
 LABEL org.opencontainers.image.title="JMo Security Suite (Fast)"
-LABEL org.opencontainers.image.description="Fast CI/CD security gate with 8 core scanners optimized for speed (v1.0.1)"
-LABEL org.opencontainers.image.version="1.0.1"
+LABEL org.opencontainers.image.description="Fast CI/CD security gate with 8 core scanners optimized for speed (v1.0.2)"
+LABEL org.opencontainers.image.version="1.0.2"
 LABEL org.opencontainers.image.authors="James Moceri <general@jmogaming.com>"
 LABEL org.opencontainers.image.url="https://jmotools.com"
 LABEL org.opencontainers.image.source="https://github.com/jimmy058910/jmo-security-repo"

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -120,8 +120,8 @@ RUN SHELLCHECK_VERSION="0.10.0" && \
 FROM ubuntu:24.04 AS runtime
 
 LABEL org.opencontainers.image.title="JMo Security Suite (Slim)"
-LABEL org.opencontainers.image.description="Cloud-optimized security toolkit with 15 scanners + OPA for AWS/Azure/GCP/K8s (v1.0.1)"
-LABEL org.opencontainers.image.version="1.0.1"
+LABEL org.opencontainers.image.description="Cloud-optimized security toolkit with 15 scanners + OPA for AWS/Azure/GCP/K8s (v1.0.2)"
+LABEL org.opencontainers.image.version="1.0.2"
 LABEL org.opencontainers.image.authors="James Moceri <general@jmogaming.com>"
 LABEL org.opencontainers.image.url="https://jmotools.com"
 LABEL org.opencontainers.image.source="https://github.com/jimmy058910/jmo-security-repo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jmo-security"
-version = "1.0.1"
+version = "1.0.2"
 description = "JMo Security Audit Suite (terminal-first, multi-tool, unified outputs, multi-target scanning)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -46,7 +46,7 @@ from scripts.core.unicode_utils import (
 logger = logging.getLogger(__name__)
 
 # Version (from pyproject.toml)
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 
 def _merge_dict(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/cli/report_orchestrator.py
+++ b/scripts/cli/report_orchestrator.py
@@ -38,7 +38,7 @@ from scripts.core.telemetry import (
 logger = logging.getLogger(__name__)
 
 # Version (from pyproject.toml)
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 SEV_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]
 

--- a/scripts/cli/wizard.py
+++ b/scripts/cli/wizard.py
@@ -130,7 +130,7 @@ def _get_db_path() -> Path:
 
 
 # Version (from pyproject.toml)
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 # Standardized error message templates for tool issues
 # These provide consistent, actionable guidance for different failure scenarios

--- a/scripts/cli/wizard_generators.py
+++ b/scripts/cli/wizard_generators.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # Docker image configuration - use versioned tag for reproducibility
 # This should be updated with each release
 JMO_DOCKER_IMAGE = "ghcr.io/jimmy058910/jmo-security"
-JMO_DOCKER_TAG = "v1.0.1"  # Pin to release version, not :latest
+JMO_DOCKER_TAG = "v1.0.2"  # Pin to release version, not :latest
 JMO_DOCKER_IMAGE_FULL = f"{JMO_DOCKER_IMAGE}:{JMO_DOCKER_TAG}"
 
 

--- a/scripts/core/reporters/sarif_reporter.py
+++ b/scripts/core/reporters/sarif_reporter.py
@@ -148,7 +148,7 @@ def to_sarif(findings: list[dict[str, Any]]) -> dict[str, Any]:
         results.append(result)
 
     # Read version from pyproject.toml if possible
-    version = "1.0.1"  # Default
+    version = "1.0.2"  # Default
     try:
         import tomllib
 

--- a/scripts/jmo_mcp/__init__.py
+++ b/scripts/jmo_mcp/__init__.py
@@ -18,5 +18,5 @@ Architecture:
 - Transport: stdio, HTTP, SSE
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __all__ = ["jmo_server"]

--- a/tests/core/test_cli_validator.py
+++ b/tests/core/test_cli_validator.py
@@ -60,7 +60,7 @@ def _make_help_mock():
 
 def _make_mixed_mock(
     help_rc: int = 0,
-    version_stdout: str = "JMo Security v1.0.1",
+    version_stdout: str = "JMo Security v1.0.2",
     missing_arg_rc: int = 2,
     invalid_flag_rc: int = 2,
     mutex_rc: int = 2,
@@ -272,7 +272,7 @@ class TestQuickTierCheckCount:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("quick")
@@ -292,7 +292,7 @@ class TestValidateCli:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("quick")
@@ -303,7 +303,7 @@ class TestValidateCli:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("quick")
@@ -314,7 +314,7 @@ class TestValidateCli:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("quick")
@@ -325,7 +325,7 @@ class TestValidateCli:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             quick = validate_cli("quick")
@@ -337,7 +337,7 @@ class TestValidateCli:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             quick = validate_cli("quick")
@@ -459,7 +459,7 @@ class TestValidateCli:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.side_effect = _make_mixed_mock(
-                version_stdout="JMo Security v1.0.1"
+                version_stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("quick")
@@ -496,7 +496,7 @@ class TestFullTier:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("full")
@@ -508,7 +508,7 @@ class TestFullTier:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("full")
@@ -562,7 +562,7 @@ class TestFullTier:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("quick")
@@ -609,7 +609,7 @@ class TestErrorHandling:
                 call_count += 1
                 if call_count % 2 == 0:
                     raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
-                return _mock_completed(returncode=0, stdout="JMo Security v1.0.1")
+                return _mock_completed(returncode=0, stdout="JMo Security v1.0.2")
 
             mock_subprocess.run.side_effect = _alternating
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
@@ -832,7 +832,7 @@ class TestVersionChecks:
 
         with patch("scripts.core.validators.cli_validator._run_jmo") as mock_run:
             mock_run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             result = _check_version_flag()
             assert result.status == CheckStatus.PASS
@@ -858,7 +858,7 @@ class TestVersionChecks:
 
         with patch("scripts.core.validators.cli_validator._run_jmo") as mock_run:
             mock_run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             result = _check_version_semver_format()
             assert result.status == CheckStatus.PASS
@@ -890,7 +890,7 @@ class TestVersionChecks:
 
         with patch("scripts.core.validators.cli_validator._run_jmo") as mock_run:
             mock_run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             result = _check_version_matches_pyproject()
             # Should pass or skip depending on pyproject.toml location
@@ -975,7 +975,7 @@ class TestCheckTiming:
             "scripts.core.validators.cli_validator.subprocess"
         ) as mock_subprocess:
             mock_subprocess.run.return_value = _mock_completed(
-                returncode=0, stdout="JMo Security v1.0.1"
+                returncode=0, stdout="JMo Security v1.0.2"
             )
             mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
             result = validate_cli("quick")


### PR DESCRIPTION
## Release v1.0.2

Prepares v1.0.2 for tag push. After merge, push tag ``v1.0.2`` to trigger the release workflow with the newly-fixed tag templates from PR #303.

## What ships

### Fixed

- **Docker tag publishing** (user-facing regression since v0.8.0): bare ``:deep``, ``:balanced``, ``:slim``, ``:fast``, ``:latest`` now get published on every version-tag push. Fixed in #303 via new ``type=raw`` templates in metadata-action.
- **Docker variant naming**: ``Dockerfile`` → ``Dockerfile.deep`` so every variant follows the ``Dockerfile.<variant>`` convention (#303). One-release alias ``:full`` → ``:deep`` for backward compat.
- **Weekly CI red X**: ``--check-latest`` / ``--check-outdated`` exit 0 when outdated tools are found (informational). Tracking issues now run reliably because the job no longer bails. New ``--fail-if-outdated`` opts into the legacy strict-gating behavior (#302).
- **Windows cp1252 UnicodeDecodeError** in 5 tests that read emoji-containing files without explicit encoding (#301).
- **shellcheck SC2170** in ``scheduled.yml:1038`` (#300).
- **Three pre-existing shell-injection findings** (CWE-78, HIGH) in ``release.yml`` steps migrated from ``${{ inputs.X }}`` direct interpolation to ``env:`` blocks (#303).

### Added

- **``update_versions.py --classify``**: JSON manifest with current, latest, semver bump level (``patch`` / ``minor`` / ``major`` / ``unknown``), and ``critical`` flag per tool. Foundation for the aggressive auto-merge layer (tracked as follow-up task #13).

## Files changed

| File | Change |
|---|---|
| ``pyproject.toml`` | version 1.0.1 → 1.0.2 |
| ``scripts/cli/jmo.py`` | ``__version__`` 1.0.1 → 1.0.2 |
| ``scripts/cli/report_orchestrator.py`` | ``__version__`` 1.0.1 → 1.0.2 |
| ``scripts/cli/wizard.py`` | ``__version__`` 1.0.1 → 1.0.2 |
| ``scripts/cli/wizard_generators.py`` | ``JMO_DOCKER_TAG`` v1.0.1 → v1.0.2 |
| ``scripts/jmo_mcp/__init__.py`` | ``__version__`` 1.0.1 → 1.0.2 |
| ``scripts/core/reporters/sarif_reporter.py`` | fallback version 1.0.1 → 1.0.2 |
| ``Dockerfile.deep`` (+ .fast .slim .balanced) | LABEL versions + header comments 1.0.1 → 1.0.2 |
| ``CHANGELOG.md`` | new v1.0.2 entry |
| ``tests/core/test_cli_validator.py`` | update test mock stdout to match v1.0.2 |

## Test plan

- [x] ``jmo validate --tier quick`` version-match + valid-semver checks pass locally
- [x] ``tests/core/test_cli_validator.py`` (82 tests) pass
- [ ] CI passes on this PR
- [ ] **After merge:** push ``v1.0.2`` tag → release workflow runs
- [ ] **After release workflow:** verify all 5 bare tags published on GHCR:
\`\`\`bash
curl -s "https://ghcr.io/v2/jimmy058910/jmo-security/tags/list" \
  -H "Authorization: Bearer $(curl -s 'https://ghcr.io/token?service=ghcr.io&scope=repository:jimmy058910/jmo-security:pull' | grep -oP '"token":"[^"]*"' | cut -d'"' -f4)" \
  | jq '.tags | map(select(. == "deep" or . == "latest" or . == "slim" or . == "balanced" or . == "fast"))'
\`\`\`
- [ ] ``docker pull ghcr.io/jimmy058910/jmo-security:deep`` succeeds and reports version 1.0.2
- [ ] Trigger ``scheduled.yml`` manually — all 4 Validate-variant jobs green

## Related

- PR #300 (shellcheck), #301 (Windows encoding), #302 (automation foundation), #303 (rename + tag publishing). All merged to main prior to this PR.