### PR TITLE
fix(release): override suffix= on raw and bare-semver tags in metadata-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,18 +625,30 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
+          # NOTE on `suffix=`: the global `flavor: suffix=-<variant>` below gets applied
+          # to every tag type including type=raw and type=semver. For the bare-tag family
+          # (:latest, :deep, :balanced, :slim, :fast, :full, :1.0.2, :1.0, :1) we override
+          # with `suffix=` (empty) per-tag to produce bare tags instead of `:latest-deep`,
+          # `:deep-deep`, `:1.0.2-deep`. Without the override we get garbage like `:deep-deep`.
           tags: |
+            # Versioned-with-variant: suffix -<variant> applied via global flavor.
+            # Produces :1.0.2-deep, :1.0.2-balanced, :1.0.2-slim, :1.0.2-fast (and :1.0-*, :1-*).
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            # Bare :latest points at the heavyweight `deep` variant on version-tag pushes.
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && matrix.variant == 'deep' }}
-            # Bare :deep / :balanced / :slim / :fast (no version suffix) — the user-facing
-            # convenience tags referenced in FAQ, USER_GUIDE, DOCKER_README.
-            type=raw,value=${{ matrix.variant }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            # One-release backward-compat alias: keep :full pointing at :deep until users
-            # migrate. Remove this line in the release after v1.0.2.
-            type=raw,value=full,enable=${{ startsWith(github.ref, 'refs/tags/v') && matrix.variant == 'deep' }}
+            # Bare semver (no variant suffix) — only on the deep matrix job.
+            # Produces :1.0.2, :1.0, :1 — pin-friendly tags for CI.
+            type=semver,pattern={{version}},suffix=,enable=${{ matrix.variant == 'deep' }}
+            type=semver,pattern={{major}}.{{minor}},suffix=,enable=${{ matrix.variant == 'deep' }}
+            type=semver,pattern={{major}},suffix=,enable=${{ matrix.variant == 'deep' }}
+            # Bare :latest — points at the heavyweight deep variant.
+            type=raw,value=latest,suffix=,enable=${{ startsWith(github.ref, 'refs/tags/v') && matrix.variant == 'deep' }}
+            # Bare :deep / :balanced / :slim / :fast — user-facing convenience tags
+            # referenced in FAQ, USER_GUIDE, DOCKER_README.
+            type=raw,value=${{ matrix.variant }},suffix=,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # One-release backward-compat alias: :full points at :deep until users
+            # migrate off the old name. Remove in the release after v1.0.2.
+            type=raw,value=full,suffix=,enable=${{ startsWith(github.ref, 'refs/tags/v') && matrix.variant == 'deep' }}
           flavor: |
             suffix=-${{ matrix.variant }},onlatest=${{ matrix.variant != 'deep' }}
             latest=false


### PR DESCRIPTION
## Problem

The bare-tag templates I added in PR #303 didn't work. v1.0.2 was published with garbage tag names because docker/metadata-action applies the global ``flavor: suffix=-<variant>`` to ``type=raw`` tags too:

| Intended | What got published |
|----------|--------------------|
| ``:deep`` | ``:deep-deep`` |
| ``:balanced`` | ``:balanced-balanced`` |
| ``:latest`` | ``:latest-deep`` (already existed from old ``latest=...`` templates) |
| ``:full`` (alias) | ``:full-deep`` |
| ``:1.0.2`` / ``:1.0`` / ``:1`` (bare semver) | (never published) |

v1.0.2 has been manually backfilled via ``docker buildx imagetools create`` (tag alias, no rebuild). This PR fixes the workflow so it doesn't happen again.

## Fix

Per-tag ``suffix=`` (empty) override in the metadata-action tag spec disables the global flavor suffix for that specific tag. Added to:

1. All three ``type=raw`` entries (``:latest``, bare ``:<variant>``, ``:full`` alias).
2. Three new ``type=semver`` entries for bare ``:1.0.2`` / ``:1.0`` / ``:1``, gated on ``matrix.variant == 'deep'`` so only the heavyweight variant publishes pin-friendly version-only tags.

Added a comment above the tag list explaining the interaction so this doesn't regress.

## Garbage tags from v1.0.2

Leaving ``:deep-deep`` / ``:balanced-balanced`` / ``:full-deep`` / ``:1.0.1-full`` / etc. untouched — they're noise but don't break anything, and users won't know to pull them. Can be cleaned up in a separate housekeeping PR via ``gh api --method DELETE /user/packages/container/jmo-security/versions/...`` if desired.

## Test plan

- [x] actionlint passes on release.yml
- [x] yamllint passes
- [ ] CI passes on this PR
- [ ] **Next release cut:** verify bare tags get published directly (no manual backfill required)

Specifically the next release should publish: ``:deep``, ``:balanced``, ``:slim``, ``:fast``, ``:latest``, ``:full``, ``:<version>``, ``:<major>.<minor>``, ``:<major>`` — all as bare tags without suffix.

## Related

Supersedes the `type=raw` templates in PR #303. The ``:full`` → ``:deep`` alias is scheduled for removal the release after v1.0.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image tag generation in the release workflow to prevent duplicate variant suffixes and ensure consistent, clean tagging across container image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->