### PR TITLE
fix(ci): Validate-variant jobs pass --profile and match PROFILE_TOOLS counts

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -990,17 +990,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # expected_tools counts match scripts/core/tool_registry.py PROFILE_TOOLS
           - variant: deep
-            expected_tools: 28
+            expected_tools: 29
             profile: deep
           - variant: balanced
             expected_tools: 18
             profile: balanced
           - variant: slim
             expected_tools: 14
-            profile: fast
+            profile: slim
           - variant: fast
-            expected_tools: 8
+            expected_tools: 9
             profile: fast
     # Run on Sunday 3AM schedule OR manual docker/all dispatch
     if: |
@@ -1026,10 +1027,14 @@ jobs:
         id: tools
         run: |
           echo "Checking tools in ${{ matrix.variant }} variant..."
+          # --profile is required: without it, `tools check --json` emits a dict of
+          # profile summaries where `installed` is an integer count, not a per-tool
+          # boolean — the jq filter below would then match zero entries (jq is
+          # strictly typed: `7 == true` is false).
           docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.variant }} \
-            tools check --json > tools-check.json
+            tools check --profile ${{ matrix.profile }} --json > tools-check.json
 
-          # Count installed tools
+          # Count installed tools (expected JSON shape: {tool_name: {installed: bool, ...}})
           INSTALLED=$(cat tools-check.json | jq '[.[] | select(.installed == true)] | length')
           echo "installed_count=$INSTALLED" >> $GITHUB_OUTPUT
 
@@ -1037,7 +1042,8 @@ jobs:
 
           if [ "$INSTALLED" -lt ${{ matrix.expected_tools }} ]; then
             echo "::error::Tool count $INSTALLED is less than expected ${{ matrix.expected_tools }}"
-            cat tools-check.json | jq '.[] | select(.installed == false) | .name'
+            echo "Missing tools:"
+            cat tools-check.json | jq -r 'to_entries[] | select(.value.installed == false) | .key'
             exit 1
           fi
 


### PR DESCRIPTION
## Two-in-one root-cause fix for long-broken Validate-variant jobs

The 4 ``Validate <variant>`` jobs in ``scheduled.yml`` have **always** been broken since they were written. Two independent bugs in the same step, both masked by the manifest-unknown tag bug until PR #303 fixed tag publishing in v1.0.2.

Two codebase-explorer agents dug into this in parallel and independently converged on the same diagnosis.

## Root cause 1: Missing ``--profile`` flag

The step runs:
\`\`\`
docker run ... tools check --json > tools-check.json
\`\`\`

Without ``--profile``, ``cmd_tools_check`` at ``scripts/cli/tool_commands.py:136-140`` takes the "show profile summary" branch and emits:

\`\`\`json
{
  ""fast"":  {""profile"": ""fast"",  ""total"": 9,  ""installed"": 7,  ...},
  ""slim"":  {""profile"": ""slim"",  ""total"": 14, ""installed"": 11, ...},
  ""balanced"": {...},
  ""deep"":    {...}
}
\`\`\`

Note ``installed`` is an **integer count**, not a per-tool boolean. The jq filter ``'.[] | select(.installed == true)'`` evaluates ``7 == true`` which is **strictly false in jq** (jq has no truthy-number coercion). Every variant always reported ``Installed tools: 0`` → every job always failed (or would have, if the tag pull had ever succeeded).

**Fix**: add ``--profile ${{ matrix.profile }}`` to the invocation. That hits the per-profile branch at ``tool_commands.py:133-134`` and emits the expected shape:

\`\`\`json
{
  ""trivy"":      {""installed"": true,  ""installed_version"": ""0.69.3"", ...},
  ""semgrep"":    {""installed"": true,  ...},
  ""shellcheck"": {""installed"": true,  ...}
}
\`\`\`

Then the jq filter works as intended.

## Root cause 2: ``expected_tools`` drifted from ``PROFILE_TOOLS``

``scripts/core/tool_registry.py`` ``PROFILE_TOOLS`` (canonical source) has:
- fast: **9**, slim: **14**, balanced: **18**, deep: **29**

scheduled.yml matrix had:
- fast: **8**, slim: 14, balanced: 18, deep: **28**

Off by 1 for ``fast`` (OPA wasn't counted originally) and ``deep`` (scancode added later without matrix update). Even with root cause 1 fixed, fast and deep would still fail until the matrix catches up.

**Also**: the ``slim`` variant's matrix entry had ``profile: fast`` instead of ``profile: slim`` — a subtle copy-paste bug. With ``--profile`` now passed through, ``slim`` would have run against the fast tool list (9 tools) instead of slim's 14, causing a count mismatch.

## Changes

**scheduled.yml matrix** (lines ~992-1004):
- ``fast`` ``expected_tools``: 8 → 9
- ``deep`` ``expected_tools``: 28 → 29
- ``slim`` ``profile``: ``fast`` → ``slim``
- Added comment pointing at ``tool_registry.py`` as canonical source

**scheduled.yml verify-tool-installation step** (lines ~1025-1048):
- Added ``--profile ${{ matrix.profile }}`` to ``tools check`` invocation
- Explained the ``--profile`` requirement in a comment
- Fixed jq filter for missing-tool enumeration (was ``.[] | select(.installed == false) | .name`` — iterates over dict *values*, so ``.name`` wasn't defined; now uses ``to_entries[] | select(.value.installed == false) | .key``)

No production code changed — purely CI hygiene.

## Test plan

- [x] ``actionlint`` passes
- [x] ``yamllint`` passes
- [ ] CI passes on this PR
- [ ] **After merge:** manually trigger Docker validation: ``gh workflow run ""Scheduled Tests"" --ref main -f task=docker`` — all 4 ``Validate <variant>`` jobs should succeed against the v1.0.2 images

## Related

- Surfaced when cutting v1.0.2 (task #12). PR #303 fixed tag publishing so these jobs could actually reach the validation step.
- Companion to PR #305 (fix metadata-action suffix override for future release cuts).