### PR TITLE
fix(ci): Validate-variant deep count (29→25) + /scan UID bind-mount

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -990,9 +990,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # expected_tools counts match scripts/core/tool_registry.py PROFILE_TOOLS
+          # expected_tools is the number of tools ACTUALLY in the Docker image
+          # (on amd64). For fast/slim/balanced, that equals PROFILE_TOOLS in
+          # scripts/core/tool_registry.py. For deep, subtract the 4 tools in
+          # MANUAL_INSTALL_TOOLS (akto, afl++, mobsf, falco) which are listed
+          # in PROFILE_TOOLS["deep"] but intentionally not in the image —
+          # users install them manually (see docs/MANUAL_INSTALLATION.md).
           - variant: deep
-            expected_tools: 29
+            expected_tools: 25   # 29 profile - 4 manual-only = 25
             profile: deep
           - variant: balanced
             expected_tools: 18
@@ -1055,6 +1060,11 @@ jobs:
           const userId = req.query.id;
           const query = "SELECT * FROM users WHERE id = " + userId;
           EOF
+          # UID mismatch fix: GitHub runner is UID 1001, container USER jmo
+          # is UID 1000. Bind mounts preserve host UID, so without this chmod
+          # the container can't write /scan/results (PermissionError [Errno 13]).
+          # Safe because the mount source is a run-scoped tmp directory.
+          chmod 777 /tmp/test-repo
 
       - name: Run scan
         id: docker-scan


### PR DESCRIPTION
## Two remaining failures after PR #306

PR #306 fixed the primary tool-check jq-filter bug, revealing two more issues in the Validate-variant jobs:

| Job | Remaining failure |
|-----|-------------------|
| Validate deep | ``Tool count < 29`` — expected 29, actual ~25 |
| Validate fast/slim/balanced | ``PermissionError: [Errno 13] Permission denied: '/scan/results'`` in the scan step |

A codebase-explorer agent mapped the full tool inventory and confirmed both root causes.

## Cause 1: ``deep`` expected_tools off by 4

``PROFILE_TOOLS[""deep""]`` in ``scripts/core/tool_registry.py:80-111`` has **29 entries**, but 4 of them (``akto``, ``afl++``, ``mobsf``, ``falco``) are in ``MANUAL_INSTALL_TOOLS`` at ``tool_registry.py:160`` and intentionally **not in the Docker image**. Users install those 4 manually per ``docs/MANUAL_INSTALLATION.md``.

``jmo tools check --profile deep --json`` iterates over every entry in ``PROFILE_TOOLS`` and calls ``tool_exists()`` on each; the 4 manual tools always return ``installed: false`` in a normal deep image.

The ``Dockerfile.deep`` header even says "29 tools (26 Docker-ready + 3 manual)" but the actual count is 25 Docker-installed + 4 manual (``falco`` was removed from the image in a past cleanup, replaced by ``falcoctl`` which isn't in PROFILE_TOOLS).

**Fix**: ``expected_tools: 29 → 25`` for ``deep``, with a comment citing ``tool_registry.py:160`` so future edits don't regress.

## Cause 2: UID mismatch on bind mount

The GitHub ``ubuntu-latest`` runner user is UID 1001; container ``USER jmo`` (all 4 Dockerfiles) is UID 1000. Bind mounts pass host UID through unchanged, so ``mkdir -p /tmp/test-repo/src`` creates the tree as UID 1001 → container user ``jmo`` cannot write ``/scan/results`` → ``PermissionError``.

**Fix**: ``chmod 777 /tmp/test-repo`` before the ``docker run``. Safe because the mount source is a run-scoped tmp directory (nothing secret or shared). Same approach as ``nightly-docker-smoke`` already uses. Documented pattern in ``memory/post-v1.0.1-review-2026-04-18.md`` trap #4.

## Changes

**scheduled.yml matrix** (lines ~991-1006):
- ``deep.expected_tools``: 29 → 25
- Comment cites ``MANUAL_INSTALL_TOOLS`` and explains the 4-tool subtraction

**scheduled.yml Test scan capability step** (lines ~1059-1065):
- Added ``chmod 777 /tmp/test-repo`` before the bind-mount docker run
- Comment explains the UID mismatch and safety rationale

No production code changed — still purely CI hygiene in the same file.

## Test plan

- [x] actionlint passes
- [x] yamllint passes
- [ ] CI passes on this PR
- [ ] **After merge:** manually trigger Docker validation: ``gh workflow run ""Scheduled Tests"" --ref main -f task=docker`` — all 4 ``Validate <variant>`` jobs **including deep** should go green for the first time ever

## Related

- Follows PR #306 (primary ``--profile`` fix)
- Completes task #12 (Cut v1.0.2 release) — this is the last validation gate