### PR TITLE
feat(ci): aggressive auto-merge for tool-version bumps (Layer 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,3 +503,87 @@ jobs:
       - name: Check shell formatting (shfmt -d)
         run: |
           shfmt -d -i 2 -ci -bn scripts/dev/*.sh scripts/core/*.sh 2>/dev/null || true
+
+  # Tool-output contract tests for PRs that bump tool versions.
+  #
+  # This job is a required status check for PRs labeled dependencies+automated
+  # (see docs/RELEASE.md -> "Tool-Version Auto-Merge"). It must ALWAYS run
+  # (so the required-check name stays stable for branch protection) but only
+  # does real work when versions.yaml or Dockerfile.* changed — other PRs get
+  # a trivial pass via the paths-filter step.
+  #
+  # Both the job key AND `name:` are pinned to `tool-contract-tests` so branch
+  # protection can match the exact string without surprises.
+  tool-contract-tests:
+    name: tool-contract-tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Detect version-affecting changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            versions:
+              - 'versions.yaml'
+              - 'Dockerfile.*'
+              - 'tests/integration/test_tool_contracts.py'
+
+      - name: Set up Python 3.12
+        if: steps.changes.outputs.versions == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install JMo Security and test dependencies
+        if: steps.changes.outputs.versions == 'true'
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install -e .
+          pip install -r requirements-dev.txt
+
+      - name: Install security tools for contract tests
+        if: steps.changes.outputs.versions == 'true'
+        run: |
+          # Same install block as scheduled.yml:tool-contract-tests — kept in
+          # sync manually. Any drift means the weekly and PR gates disagree.
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+          pip install semgrep bandit checkov
+          wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
+          chmod +x /usr/local/bin/hadolint
+          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+          sudo apt-get update && sudo apt-get install -y shellcheck
+
+          echo "Installed tools:"
+          trivy --version || echo "trivy not available"
+          semgrep --version || echo "semgrep not available"
+          bandit --version || echo "bandit not available"
+          hadolint --version || echo "hadolint not available"
+          trufflehog --version || echo "trufflehog not available"
+          checkov --version || echo "checkov not available"
+          shellcheck --version || echo "shellcheck not available"
+
+      - name: Run tool contract tests
+        if: steps.changes.outputs.versions == 'true'
+        env:
+          CI: "true"
+        run: |
+          pytest tests/integration/test_tool_contracts.py \
+            -v \
+            -m "requires_tools" \
+            --tb=short \
+            --timeout=300
+
+      - name: Summarize skip
+        if: steps.changes.outputs.versions != 'true'
+        run: |
+          echo "No version-affecting files changed — contract tests not required."
+          echo "Paths watched: versions.yaml, Dockerfile.*, tests/integration/test_tool_contracts.py"

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -18,6 +18,7 @@ on:
     - cron: '0 0 * * 0'  # Sunday 00:00 UTC - tool updates
     - cron: '0 2 * * 0'  # Sunday 02:00 UTC - version checks
     - cron: '0 6 * * 1'  # Monday 06:00 UTC - repo completeness
+    - cron: '0 */6 * * *'  # Every 6h - soak-window auto-merge sweep
   workflow_dispatch:
     inputs:
       task:
@@ -25,12 +26,18 @@ on:
         required: false
         default: 'all'
         type: choice
-        options: [all, tool-update, version-check, completeness]
+        options: [all, tool-update, version-check, completeness, auto-merge]
       create_issues:
         description: 'Create GitHub issues for outdated tools (version-check task only)'
         required: false
         default: 'true'
         type: boolean
+      bump_level:
+        description: 'Bump level for auto-update-tools (cumulative: minor includes patch; major includes patch+minor)'
+        required: false
+        default: 'minor'
+        type: choice
+        options: [patch, minor, major, all]
 
 permissions:
   contents: write
@@ -79,11 +86,40 @@ jobs:
             echo "All tools already up-to-date"
           fi
 
-      - name: Update all tools to latest versions
+      - name: Capture classification manifest (before update)
+        # MUST run before --update-all, otherwise the manifest sees
+        # current==latest for every bumped tool and reports level=patch
+        # for all. The PR body reads this file so reviewers see the
+        # actual bump level of each change.
         if: steps.check.outputs.updates_available == 'true'
         run: |
-          echo "Updating all tools to latest versions..."
-          python3 scripts/dev/update_versions.py --update-all
+          python3 scripts/dev/update_versions.py --classify > classify_before.json
+          echo "Classification captured:"
+          cat classify_before.json
+
+      - name: Resolve bump level
+        id: level
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_BUMP_LEVEL: ${{ github.event.inputs.bump_level }}
+        run: |
+          # Default to 'minor' on cron — auto-PR patches+minors only, leave
+          # majors/unknowns for the tracking-issue dashboard. Dispatch overrides.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$DISPATCH_BUMP_LEVEL" ]; then
+            LEVEL="$DISPATCH_BUMP_LEVEL"
+          else
+            LEVEL="minor"
+          fi
+          echo "bump_level=$LEVEL" >> "$GITHUB_OUTPUT"
+          echo "Using bump level: $LEVEL"
+
+      - name: Update tools to latest versions (filtered by bump level)
+        if: steps.check.outputs.updates_available == 'true'
+        env:
+          BUMP_LEVEL: ${{ steps.level.outputs.bump_level }}
+        run: |
+          echo "Updating tools at bump level: $BUMP_LEVEL"
+          python3 scripts/dev/update_versions.py --update-all --level="$BUMP_LEVEL"
 
           echo ""
           echo "Syncing changes to Dockerfiles..."
@@ -142,71 +178,98 @@ jobs:
         if: steps.commit.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          BUMP_LEVEL: ${{ steps.level.outputs.bump_level }}
         run: |
-          BRANCH="${{ steps.commit.outputs.branch }}"
+          # Compose PR body with the pre-update classification manifest
+          # embedded. Reviewers see the exact bumps and their levels without
+          # having to diff versions.yaml by hand. The `classify_before.json`
+          # file is the one captured before --update-all ran.
+          {
+            echo "## Weekly Tool & Pre-commit Updates"
+            echo ""
+            echo "Bump level applied: \`$BUMP_LEVEL\` (cumulative — includes all lower levels)."
+            echo ""
+            echo "### What's Updated"
+            echo ""
+            echo "- **Security tools**: \`update_versions.py --update-all --level=$BUMP_LEVEL\`, Dockerfiles synced"
+            echo "- **Pre-commit hooks**: \`pre-commit autoupdate\`, formatting applied"
+            echo ""
+            echo "### Auto-Merge Policy"
+            echo ""
+            echo "Labeled \`auto-merge-ok\`. A separate soak-window job runs every 6 hours"
+            echo "and merges this PR once it is at least 24h old, all required status"
+            echo "checks (including \`tool-contract-tests\`) are green, and the"
+            echo "\`auto-merge-ok\` label is still present."
+            echo ""
+            echo "To cancel auto-merge, remove the \`auto-merge-ok\` label. To force an"
+            echo "immediate merge, run the workflow manually with \`task=auto-merge\` and"
+            echo "\`--min-age-hours 0\`."
+            echo ""
+            if [ -f classify_before.json ]; then
+              echo "<details><summary>Bumps in this PR (from \`--classify\`)</summary>"
+              echo ""
+              echo '```json'
+              cat classify_before.json
+              echo '```'
+              echo ""
+              echo "</details>"
+              echo ""
+            fi
+            echo "---"
+            echo ""
+            echo "**Automated PR** — Generated by maintenance workflow (tool-update task)"
+            echo "**Schedule**: Every Sunday at 00:00 UTC"
+            echo "**Workflow**: \`.github/workflows/maintenance.yml\`"
+          } > pr_body.txt
 
-          # Create PR body
-          cat > pr_body.txt << 'PR_BODY'
-          ## Weekly Tool & Pre-commit Updates
-
-          This PR automatically updates security tools and pre-commit hooks to their latest versions.
-
-          ### What's Updated
-
-          - **Security tools**: Updated via `update_versions.py --update-all`, Dockerfiles synced
-          - **Pre-commit hooks**: Updated via `pre-commit autoupdate`, formatting applied
-
-          ### Auto-Merge Policy
-
-          This PR will auto-merge if:
-          - All CI tests pass
-          - No conflicts with main branch
-          - Version consistency check passes
-
-          ---
-
-          **Automated PR** - Generated by maintenance workflow (tool-update task)
-          **Schedule**: Every Sunday at 00:00 UTC
-          **Workflow**: `.github/workflows/maintenance.yml`
-          PR_BODY
-
-          # Create PR
           gh pr create \
-            --title "chore(deps): weekly auto-update $(date +%Y-%m-%d)" \
+            --title "chore(deps): weekly auto-update $(date +%Y-%m-%d) (level=$BUMP_LEVEL)" \
             --body-file pr_body.txt \
             --base main \
             --head "$BRANCH" \
             --label "dependencies" \
-            --label "automated"
+            --label "automated" \
+            --label "auto-merge-ok"
 
-          # Enable auto-merge
-          PR_NUMBER=$(gh pr view "$BRANCH" --json number --jq '.number')
-          gh pr merge "$PR_NUMBER" --auto --squash
+          # NOTE: `gh pr merge --auto --squash` is intentionally NOT called
+          # here. The soak-window job (auto-merge-tool-bumps, cron */6h)
+          # owns the merge decision now — see docs/RELEASE.md.
 
       - name: Summary
         if: always()
+        env:
+          HAS_CHANGES: ${{ steps.commit.outputs.has_changes }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          BUMP_LEVEL: ${{ steps.level.outputs.bump_level }}
+          UPDATES_AVAILABLE: ${{ steps.check.outputs.updates_available }}
         run: |
           {
             echo "## Weekly Tool Update Summary"
             echo ""
+            echo "Bump level: \`${BUMP_LEVEL:-minor}\` (cumulative)"
+            echo ""
 
-            if [[ "${{ steps.commit.outputs.has_changes }}" == "true" ]]; then
-              echo "**Updates applied successfully**"
+            if [ "$HAS_CHANGES" = "true" ]; then
+              echo "**Pull request opened**"
               echo ""
-              echo "- Branch created: \`${{ steps.commit.outputs.branch }}\`"
-              echo "- Pull request created and set to auto-merge"
-              echo "- Will merge automatically when CI passes"
+              echo "- Branch: \`$BRANCH\`"
+              echo "- Labels: \`dependencies\`, \`automated\`, \`auto-merge-ok\`"
+              echo "- Soak window: 24h (soak job runs every 6 hours)"
+              echo "- Required gate: \`tool-contract-tests\` must pass"
               echo ""
-              if [[ "${{ steps.check.outputs.updates_available }}" == "true" ]]; then
-                echo "- Security tools: updated"
+              if [ "$UPDATES_AVAILABLE" = "true" ]; then
+                echo "- Security tools: updated at level \`${BUMP_LEVEL:-minor}\`"
               else
                 echo "- Security tools: already up-to-date"
               fi
               echo "- Pre-commit hooks: checked for updates"
             else
-              echo "**All tools and hooks already up-to-date**"
+              echo "**Nothing to merge**"
               echo ""
-              echo "No updates needed this week."
+              echo "Either all tools are already up-to-date, or all outstanding bumps"
+              echo "fall outside the \`${BUMP_LEVEL:-minor}\` level filter"
+              echo "(major/unknown bumps live in the tracking issue)."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -527,3 +590,38 @@ jobs:
               repo: context.repo.repo,
               body: summary
             });
+
+  # ─── Soak-Window Auto-Merge ──────────────────────────────────────────────────
+  # Runs: every 6 hours (cron '0 */6 * * *') OR manual dispatch with task=auto-merge
+  #
+  # Finds open PRs labeled `dependencies,automated,auto-merge-ok`, and:
+  #   * merges any that are >= 24h old with all required checks green
+  #   * flips failures to `needs-review` with an explanatory comment
+  #   * leaves everything else alone
+  #
+  # The real decision logic lives in scripts/dev/auto_merge_tool_bumps.py and
+  # is unit-tested in tests/unit/test_auto_merge_tool_bumps.py.
+  auto-merge-tool-bumps:
+    name: Soak-window auto-merge for tool bumps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      (github.event_name == 'schedule' && github.event.schedule == '0 */6 * * *') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.task == 'auto-merge')
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Run soak-window sweep
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/dev/auto_merge_tool_bumps.py --min-age-hours 24

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,6 +9,112 @@ This project publishes to PyPI via GitHub Actions on git tags of the form `v*` u
 
 ---
 
+## Tool-Version Auto-Merge (between releases)
+
+Security tools bump constantly and cutting a release for every bump would
+be exhausting. Instead, the repo runs a three-layer tool-version automation
+stack that keeps `versions.yaml` + Dockerfiles fresh with minimal maintainer
+attention:
+
+- **Layer 1 — exit 0 on outdated.** The weekly version check reports
+  outdated tools but does not fail CI (outdated ≠ broken).
+- **Layer 2 — tracking issue dashboard.** `update_versions.py --check-outdated
+  --create-issues` opens/updates a single issue listing every outdated tool.
+- **Layer 3 — auto-PR + soak-window auto-merge.** The `auto-update-tools` job
+  opens a PR with patch+minor bumps. A separate job runs every 6 hours and
+  auto-merges the PR once it is ≥ 24 hours old with all required checks green.
+
+### What an auto-PR looks like
+
+Every Sunday at 00:00 UTC the `auto-update-tools` job (in
+`.github/workflows/maintenance.yml`) opens a PR like this:
+
+- **Title**: `chore(deps): weekly auto-update 2026-04-19 (level=minor)`
+- **Labels**: `dependencies`, `automated`, `auto-merge-ok`
+- **Body**: Embeds the `update_versions.py --classify` JSON so you can see
+  every bump and its semver classification (patch / minor / major / unknown)
+  in one block.
+- **Merge policy**: Not set to `--auto`. The soak-window job handles merging.
+
+Major and `unknown` bumps are left outdated — they appear as items in the
+weekly tracking issue (Layer 2) so you can investigate when you have time.
+
+### How auto-merge actually fires
+
+The `auto-merge-tool-bumps` job (cron `0 */6 * * *`) runs
+`scripts/dev/auto_merge_tool_bumps.py`, which for each open PR labeled
+`auto-merge-ok` decides:
+
+- **merge** — PR is ≥ 24h old, all required checks green → `gh pr merge --squash`
+- **flip** — A required check failed → remove `auto-merge-ok`, add
+  `needs-review`, post an explanatory comment.
+- **defer** — Anything else (soak window still active, checks running, the
+  maintainer removed `auto-merge-ok`).
+
+The decision logic is unit-tested in
+`tests/unit/test_auto_merge_tool_bumps.py`.
+
+### Cancel an auto-merge
+
+Remove the `auto-merge-ok` label from the PR. The soak job will never merge
+a PR without that label — full stop. Re-add it to resume.
+
+### Force immediate merge (verification / urgent)
+
+```bash
+# Dispatch the soak job manually with zero soak window
+gh workflow run maintenance.yml --ref main \
+  -f task=auto-merge
+```
+
+For a *truly* zero-wait test of the machinery, run the script locally:
+
+```bash
+python3 scripts/dev/auto_merge_tool_bumps.py --min-age-hours 0 --dry-run
+```
+
+### Manual dispatch with a specific bump level
+
+```bash
+# Just patches (safest)
+gh workflow run maintenance.yml --ref main -f task=tool-update -f bump_level=patch
+
+# Patches + minors + majors (skips only 'unknown')
+gh workflow run maintenance.yml --ref main -f task=tool-update -f bump_level=major
+
+# Everything including synthetic bumps (falco 0.0.0, akto mini-testing-X)
+gh workflow run maintenance.yml --ref main -f task=tool-update -f bump_level=all
+```
+
+### One-time branch-protection setup (required)
+
+The contract-test gate only has teeth when `tool-contract-tests` is a
+required status check:
+
+1. GitHub UI → Settings → Branches → `main` branch protection rule
+2. Under "Require status checks to pass before merging," search for and
+   add: **`tool-contract-tests`** (exact string — pinned via both
+   `jobs.tool-contract-tests:` key and `name: tool-contract-tests` in
+   `ci.yml`).
+3. Leave the other required checks (`quick-checks`, `test-sharded (*)`,
+   `lint-quick`, `coverage-aggregate`) in place.
+4. Save.
+
+> If `tool-contract-tests` does not appear in the required-checks
+> dropdown, open and close one PR that touches `versions.yaml` first.
+> GitHub only surfaces status checks in the UI after they have run at
+> least once.
+
+### Known transient behavior
+
+Weekly, a patch/minor bump opens **both** an auto-PR (Sun 00:00) and a
+tracking issue (Sun 02:00). This overlap lasts ~24-26 hours until the PR
+merges; the issue then auto-closes. Not a bug — the issue dashboard is a
+complete picture of outstanding work, and the overlap window is the
+trade-off for not filtering `--create-issues` by bump level.
+
+---
+
 ## Method 1: Automated Release (Recommended)
 
 **Use the automated-release workflow for one-click releases with guaranteed tool updates.**

--- a/scripts/dev/auto_merge_tool_bumps.py
+++ b/scripts/dev/auto_merge_tool_bumps.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Soak-window auto-merge for tool-version bump PRs.
+
+This script is Layer 3 of the tool-version automation stack (Layer 1 = exit-0
+on outdated, Layer 2 = --create-issues dashboard, Layer 3 = auto-PR + soak
+auto-merge). It runs on a cron schedule every 6 hours and takes three actions:
+
+  * merge — PR is >= min_age_hours old, has label auto-merge-ok, and all
+    required status checks are green. Squash-merge it.
+  * flip  — PR has label auto-merge-ok but a required status check failed.
+    Remove auto-merge-ok, add needs-review, post an explanatory comment so
+    the maintainer sees the failed check on the next dashboard scan.
+  * defer — Everything else: still in soak window, checks still running,
+    maintainer already intervened. Leave the PR alone.
+
+The decision logic is isolated in the pure `should_merge()` function — it
+takes a parsed PR dict + current time + soak window and returns an action.
+That isolation is load-bearing for testability: the unit tests can fabricate
+PR payloads and assert decisions without touching the GitHub API.
+
+Usage:
+  python3 scripts/dev/auto_merge_tool_bumps.py [--min-age-hours N] [--dry-run]
+
+Required env: GH_TOKEN (provided automatically in GitHub Actions).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Literal
+
+Action = Literal["merge", "defer", "flip"]
+
+# Conclusions that mean "this check definitively failed". We treat all of
+# these as blocking — a cancelled or timed-out required check is just as
+# much a regression signal as an outright FAILURE.
+_FAILED_CONCLUSIONS = frozenset(
+    {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE"}
+)
+
+# Conclusions that count as "green" for merge purposes. SKIPPED and NEUTRAL
+# are explicitly green — the contract-tests job SKIPs install+pytest when no
+# versions.yaml/Dockerfile.* change; that's still a pass.
+_GREEN_CONCLUSIONS = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
+
+AUTO_MERGE_LABEL = "auto-merge-ok"
+NEEDS_REVIEW_LABEL = "needs-review"
+
+
+def _parse_iso(timestamp: str) -> datetime:
+    """Parse the ISO-8601 UTC timestamp that `gh` returns for createdAt."""
+    # `gh` emits "2026-04-19T00:00:00Z"; Python 3.11+ fromisoformat handles
+    # the trailing Z since 3.11 but we normalize to +00:00 for 3.10 safety.
+    return datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+
+def should_merge(pr: dict, now: datetime, min_age_hours: int) -> Action:
+    """
+    Decide what to do with a candidate PR.
+
+    Args:
+        pr: PR dict as emitted by `gh pr list --json createdAt,labels,statusCheckRollup`.
+        now: Current time (UTC, tz-aware).
+        min_age_hours: Minimum PR age before auto-merge is allowed.
+
+    Returns:
+        "merge" | "defer" | "flip"
+    """
+    labels = {label["name"] for label in pr.get("labels", [])}
+    if AUTO_MERGE_LABEL not in labels:
+        # Maintainer has already intervened (dropped the label) or it was
+        # never added — leave the PR to the human.
+        return "defer"
+
+    checks = pr.get("statusCheckRollup") or []
+
+    # Fail-fast: any definitively-failed required check flips the label to
+    # needs-review. We do this BEFORE the age check so a PR with an obvious
+    # failure gets a comment and relabel immediately instead of waiting 24h.
+    for check in checks:
+        if check.get("conclusion") in _FAILED_CONCLUSIONS:
+            return "flip"
+
+    age_hours = (now - _parse_iso(pr["createdAt"])).total_seconds() / 3600.0
+    if age_hours < min_age_hours:
+        return "defer"
+
+    # Still in the soak window cleared. Every check must be green (SUCCESS /
+    # SKIPPED / NEUTRAL) — checks still running mean we wait another cycle.
+    if not checks:
+        # No checks reported yet — too early, even if the PR is old.
+        return "defer"
+    for check in checks:
+        if check.get("conclusion") not in _GREEN_CONCLUSIONS:
+            return "defer"
+
+    return "merge"
+
+
+def list_candidate_prs() -> list[dict]:
+    """Fetch open PRs labeled `auto-merge-ok` + `automated` from the repo."""
+    proc = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--label",
+            AUTO_MERGE_LABEL,
+            "--label",
+            "automated",
+            "--json",
+            "number,createdAt,labels,statusCheckRollup,title",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data: list[dict] = json.loads(proc.stdout or "[]")
+    return data
+
+
+def merge_pr(number: int, dry_run: bool) -> None:
+    print(f"[auto-merge] PR #{number}: merge (squash)")
+    if dry_run:
+        return
+    subprocess.run(
+        ["gh", "pr", "merge", str(number), "--squash", "--delete-branch"],
+        check=True,
+    )
+
+
+def flip_pr_label(number: int, failed_checks: list[str], dry_run: bool) -> None:
+    names = ", ".join(f"`{n}`" for n in failed_checks) or "(unknown)"
+    comment = (
+        f"Auto-merge blocked: one or more required checks failed ({names}). "
+        f"Label flipped from `{AUTO_MERGE_LABEL}` to `{NEEDS_REVIEW_LABEL}`. "
+        "Investigate the failure, push a fix, and re-add `auto-merge-ok` to "
+        "resume the soak window."
+    )
+    print(f"[auto-merge] PR #{number}: flip label (failed: {names})")
+    if dry_run:
+        return
+    subprocess.run(
+        [
+            "gh",
+            "pr",
+            "edit",
+            str(number),
+            "--remove-label",
+            AUTO_MERGE_LABEL,
+            "--add-label",
+            NEEDS_REVIEW_LABEL,
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["gh", "pr", "comment", str(number), "--body", comment],
+        check=True,
+    )
+
+
+def _failed_check_names(pr: dict) -> list[str]:
+    return [
+        check.get("name", "<unnamed>")
+        for check in pr.get("statusCheckRollup") or []
+        if check.get("conclusion") in _FAILED_CONCLUSIONS
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--min-age-hours",
+        type=int,
+        default=24,
+        help="Minimum PR age (hours) before auto-merge may fire. Default: 24.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print intended actions without calling gh pr merge / edit / comment.",
+    )
+    args = parser.parse_args()
+
+    try:
+        prs = list_candidate_prs()
+    except subprocess.CalledProcessError as exc:
+        print(f"[auto-merge] gh pr list failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not prs:
+        # Silent exit — cron runs every 6h and most runs will find nothing.
+        return 0
+
+    now = datetime.now(timezone.utc)
+    for pr in prs:
+        action = should_merge(pr, now, args.min_age_hours)
+        number = int(pr["number"])
+        if action == "merge":
+            merge_pr(number, dry_run=args.dry_run)
+        elif action == "flip":
+            flip_pr_label(number, _failed_check_names(pr), dry_run=args.dry_run)
+        else:
+            print(f"[auto-merge] PR #{number}: defer")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/update_versions.py
+++ b/scripts/dev/update_versions.py
@@ -159,6 +159,71 @@ def classify_bump(current: str, latest: str) -> str:
     return "patch"
 
 
+# Cumulative bump-level inclusion. --level=minor means "include patch and minor".
+# "unknown" is only included under the explicit --level=all opt-in, because
+# synthetic version transitions (falco 0.0.0 -> 0.43.1, akto mini-testing-X -> 1.Y)
+# are the riskiest class and must not auto-merge.
+_LEVEL_INCLUDES: dict[str, frozenset[str]] = {
+    "patch": frozenset({"patch"}),
+    "minor": frozenset({"patch", "minor"}),
+    "major": frozenset({"patch", "minor", "major"}),
+    "all": frozenset({"patch", "minor", "major", "unknown"}),
+}
+
+
+def _lookup_critical(tool: str, versions: dict) -> bool:
+    """Return the critical flag for a tool from versions.yaml."""
+    for category in ("python_tools", "binary_tools", "special_tools"):
+        if tool in versions.get(category, {}):
+            return bool(versions[category][tool].get("critical", False))
+    return False
+
+
+def _select_tools_for_update(
+    results: dict[str, tuple[str, str, bool]],
+    versions: dict,
+    critical_only: bool,
+    level: str,
+) -> tuple[list[tuple[str, str, str]], list[tuple[str, str, str, str]]]:
+    """
+    Pick which outdated tools to update based on critical_only + bump level.
+
+    Args:
+        results: mapping from tool name to (current, latest, is_outdated)
+                 as emitted by check_latest_versions().
+        versions: parsed versions.yaml (for critical-flag lookup).
+        critical_only: if True, skip tools where critical is False.
+        level: one of _LEVEL_INCLUDES keys ("patch", "minor", "major", "all").
+
+    Returns:
+        (to_update, skipped) where
+          to_update = [(tool, current, latest), ...]
+          skipped   = [(tool, current, latest, reason), ...]
+    """
+    if level not in _LEVEL_INCLUDES:
+        raise ValueError(
+            f"Unknown bump level {level!r}; expected one of {sorted(_LEVEL_INCLUDES)}"
+        )
+    allowed_levels = _LEVEL_INCLUDES[level]
+
+    to_update: list[tuple[str, str, str]] = []
+    skipped: list[tuple[str, str, str, str]] = []
+
+    for tool, (current, latest, is_outdated) in results.items():
+        if not is_outdated:
+            continue
+        if critical_only and not _lookup_critical(tool, versions):
+            skipped.append((tool, current, latest, "non-critical"))
+            continue
+        bump_level = classify_bump(current, latest)
+        if bump_level not in allowed_levels:
+            skipped.append((tool, current, latest, f"level={bump_level}"))
+            continue
+        to_update.append((tool, current, latest))
+
+    return to_update, skipped
+
+
 def load_versions() -> dict:
     """Load versions.yaml."""
     if not VERSIONS_YAML.exists():
@@ -838,42 +903,44 @@ python3 scripts/dev/update_versions.py --sync
     return len(outdated_critical) + len(outdated_normal)
 
 
-def update_all_tools(critical_only: bool = False) -> int:
+def update_all_tools(
+    critical_only: bool = False,
+    level: str = "all",
+    dry_run: bool = False,
+) -> int:
     """
-    Update ALL tools to their latest versions automatically.
+    Update tools to their latest versions, optionally filtered by bump level.
 
     Args:
-        critical_only: If True, only update tools marked as critical
+        critical_only: If True, only update tools marked as critical.
+        level: Cumulative bump-level filter — "patch", "minor", "major", or
+               "all". "minor" includes patch+minor; "major" includes
+               patch+minor+major; "all" includes everything including
+               "unknown" (synthetic version transitions). Default "all"
+               preserves the pre-existing behaviour of this script.
+        dry_run: If True, report what would change without writing
+                 versions.yaml. Useful for verification and maintainer preview.
 
     Returns:
-        Number of tools updated (0 if all already up-to-date)
+        Number of tools updated (0 if all already up-to-date).
     """
     log("Checking for tool updates...")
     results = check_latest_versions()
     versions = load_versions()
 
-    updated_tools = []
-    failed_tools = []
-    skipped_tools = []
+    to_update, skipped_tools = _select_tools_for_update(
+        results, versions, critical_only=critical_only, level=level
+    )
 
-    for tool, (current, latest, is_outdated) in results.items():
-        if not is_outdated:
+    updated_tools: list[tuple[str, str, str]] = []
+    failed_tools: list[tuple[str, str, str]] = []
+
+    action_verb = "Would update" if dry_run else "Updating"
+    for tool, current, latest in to_update:
+        log(f"{action_verb} {tool}: {current} → {latest}")
+        if dry_run:
+            updated_tools.append((tool, current, latest))
             continue
-
-        # Check if tool is critical
-        is_critical = False
-        for category in ["python_tools", "binary_tools", "special_tools"]:
-            if tool in versions.get(category, {}):
-                is_critical = versions[category][tool].get("critical", False)
-                break
-
-        # Skip non-critical if flag set
-        if critical_only and not is_critical:
-            skipped_tools.append((tool, current, latest, "non-critical"))
-            continue
-
-        # Update the tool
-        log(f"Updating {tool}: {current} → {latest}")
         if update_tool_version(tool, latest):
             updated_tools.append((tool, current, latest))
             ok(f"✓ {tool} updated successfully")
@@ -884,7 +951,8 @@ def update_all_tools(critical_only: bool = False) -> int:
     # Print summary
     print("")
     if updated_tools:
-        ok(f"Successfully updated {len(updated_tools)} tool(s):")
+        summary_verb = "Would update" if dry_run else "Successfully updated"
+        ok(f"{summary_verb} {len(updated_tools)} tool(s):")
         for tool, old, new in updated_tools:
             print(f"  • {tool}: {old} → {new}")
 
@@ -894,14 +962,17 @@ def update_all_tools(critical_only: bool = False) -> int:
             print(f"  • {tool}: {old} → {new}")
 
     if skipped_tools:
-        log(
-            f"Skipped {len(skipped_tools)} non-critical tool(s) (use --all to include):"
-        )
+        log(f"Skipped {len(skipped_tools)} tool(s):")
         for tool, old, new, reason in skipped_tools:
             print(f"  • {tool}: {old} → {new} ({reason})")
 
     print("")
     if updated_tools:
+        if dry_run:
+            log(
+                "Dry run — versions.yaml was NOT modified. Re-run without --dry-run to apply."
+            )
+            return 0
         log("Next steps:")
         print("  1. Run: python3 scripts/dev/update_versions.py --sync")
         print("  2. Test: make docker-build")
@@ -969,12 +1040,27 @@ def main() -> int:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Check for changes without writing files (used with --sync)",
+        help=(
+            "Check for changes without writing files (used with --sync or "
+            "--update-all). With --update-all, prints which bumps would be "
+            "applied without modifying versions.yaml."
+        ),
     )
     parser.add_argument(
         "--critical-only",
         action="store_true",
         help="Only update critical tools (used with --update-all)",
+    )
+    parser.add_argument(
+        "--level",
+        choices=["patch", "minor", "major", "all"],
+        default="all",
+        help=(
+            "Cumulative bump-level filter for --update-all. 'patch' updates "
+            "patch bumps only; 'minor' includes patch+minor; 'major' includes "
+            "patch+minor+major (still excludes 'unknown'); 'all' includes "
+            "everything. Default: all. Used with --update-all."
+        ),
     )
     parser.add_argument(
         "--fail-if-outdated",
@@ -995,6 +1081,10 @@ def main() -> int:
 
     if args.create_issues and not args.check_outdated:
         err("--create-issues requires --check-outdated")
+        return 1
+
+    if args.level != "all" and not args.update_all:
+        err("--level requires --update-all")
         return 1
 
     # Execute commands
@@ -1045,12 +1135,15 @@ def main() -> int:
                 return 0
 
         elif args.update_all:
-            updated_count = update_all_tools(critical_only=args.critical_only)
-            if updated_count > 0:
+            updated_count = update_all_tools(
+                critical_only=args.critical_only,
+                level=args.level,
+                dry_run=args.dry_run,
+            )
+            if updated_count > 0 and not args.dry_run:
                 log(
                     "Don't forget to run: python3 scripts/dev/update_versions.py --sync"
                 )
-                return 0
             return 0
 
         elif args.validate:

--- a/tests/unit/test_auto_merge_tool_bumps.py
+++ b/tests/unit/test_auto_merge_tool_bumps.py
@@ -1,0 +1,173 @@
+"""Unit tests for should_merge() in scripts/dev/auto_merge_tool_bumps.py.
+
+The soak-window logic is the safety seam between "auto-PR was opened" and
+"auto-PR silently merges into main". It must:
+
+  * Never merge before the soak window elapses (default 24h).
+  * Flip a PR to needs-review as soon as any required check fails, even
+    inside the soak window — quicker feedback to the maintainer.
+  * Respect maintainer intervention — if the auto-merge-ok label has been
+    removed, defer forever.
+
+Getting any of these three wrong produces either surprise merges or stuck
+PRs, so the fabricated-PR test suite covers each axis explicitly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _load_module():
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "dev"
+        / "auto_merge_tool_bumps.py"
+    )
+    spec = importlib.util.spec_from_file_location("auto_merge_tool_bumps", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+auto_merge = _load_module()
+should_merge = auto_merge.should_merge
+
+
+NOW = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _pr(
+    *,
+    age_hours: float,
+    labels: list[str],
+    checks: list[dict[str, str]],
+    number: int = 42,
+) -> dict[str, Any]:
+    created_at = (NOW - timedelta(hours=age_hours)).isoformat().replace("+00:00", "Z")
+    return {
+        "number": number,
+        "createdAt": created_at,
+        "labels": [{"name": label} for label in labels],
+        "statusCheckRollup": checks,
+    }
+
+
+def test_defers_when_auto_merge_label_missing() -> None:
+    """Maintainer removed the auto-merge-ok label → never merge."""
+    pr = _pr(
+        age_hours=48,
+        labels=["dependencies", "automated"],
+        checks=[{"name": "ci", "conclusion": "SUCCESS"}],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "defer"
+
+
+def test_defers_inside_soak_window() -> None:
+    """Green checks but PR is too young → defer."""
+    pr = _pr(
+        age_hours=12,
+        labels=["auto-merge-ok"],
+        checks=[{"name": "ci", "conclusion": "SUCCESS"}],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "defer"
+
+
+def test_merges_when_soak_elapsed_and_green() -> None:
+    pr = _pr(
+        age_hours=25,
+        labels=["auto-merge-ok"],
+        checks=[
+            {"name": "quick-checks", "conclusion": "SUCCESS"},
+            {"name": "tool-contract-tests", "conclusion": "SUCCESS"},
+        ],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "merge"
+
+
+def test_skipped_and_neutral_count_as_green() -> None:
+    """A contract-tests job that SKIPped install+pytest is still a pass."""
+    pr = _pr(
+        age_hours=25,
+        labels=["auto-merge-ok"],
+        checks=[
+            {"name": "quick-checks", "conclusion": "SUCCESS"},
+            {"name": "tool-contract-tests", "conclusion": "SKIPPED"},
+            {"name": "lint-quick", "conclusion": "NEUTRAL"},
+        ],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "merge"
+
+
+def test_flips_on_failed_check_even_inside_soak() -> None:
+    """A FAILURE inside the soak window still triggers the flip — faster feedback."""
+    pr = _pr(
+        age_hours=2,
+        labels=["auto-merge-ok"],
+        checks=[
+            {"name": "quick-checks", "conclusion": "SUCCESS"},
+            {"name": "tool-contract-tests", "conclusion": "FAILURE"},
+        ],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "flip"
+
+
+def test_flips_on_cancelled_required_check() -> None:
+    pr = _pr(
+        age_hours=30,
+        labels=["auto-merge-ok"],
+        checks=[
+            {"name": "ci", "conclusion": "SUCCESS"},
+            {"name": "tool-contract-tests", "conclusion": "CANCELLED"},
+        ],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "flip"
+
+
+def test_flips_on_timed_out_check() -> None:
+    pr = _pr(
+        age_hours=30,
+        labels=["auto-merge-ok"],
+        checks=[{"name": "tool-contract-tests", "conclusion": "TIMED_OUT"}],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "flip"
+
+
+def test_defers_when_checks_still_running() -> None:
+    """PR is old enough but some required check hasn't reported yet → defer."""
+    pr = _pr(
+        age_hours=25,
+        labels=["auto-merge-ok"],
+        checks=[
+            {"name": "quick-checks", "conclusion": "SUCCESS"},
+            {"name": "tool-contract-tests", "conclusion": ""},  # in progress
+        ],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "defer"
+
+
+def test_defers_when_no_checks_reported() -> None:
+    """Brand-new PR, checks haven't started yet — don't treat empty as green."""
+    pr = _pr(
+        age_hours=25,
+        labels=["auto-merge-ok"],
+        checks=[],
+    )
+    assert should_merge(pr, NOW, min_age_hours=24) == "defer"
+
+
+def test_zero_soak_window_merges_immediately() -> None:
+    """--min-age-hours=0 is the verification mode — merges as soon as checks are green."""
+    pr = _pr(
+        age_hours=0.1,
+        labels=["auto-merge-ok"],
+        checks=[{"name": "ci", "conclusion": "SUCCESS"}],
+    )
+    assert should_merge(pr, NOW, min_age_hours=0) == "merge"

--- a/tests/unit/test_update_versions_level.py
+++ b/tests/unit/test_update_versions_level.py
@@ -1,0 +1,132 @@
+"""Unit tests for _select_tools_for_update() and the --level cumulative filter.
+
+The bump-level filter decides which tools `--update-all` actually writes to
+versions.yaml. It's the load-bearing gate that keeps major and `unknown` bumps
+out of the weekly auto-merge PR — getting it wrong would auto-merge a risky
+bump on green CI, which is exactly what the 24h soak window + contract-test
+gate exist to prevent.
+
+These tests pin the cumulative semantics:
+  --level=patch    → {patch}
+  --level=minor    → {patch, minor}
+  --level=major    → {patch, minor, major}   (unknown stays out)
+  --level=all      → {patch, minor, major, unknown}
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    script = (
+        Path(__file__).resolve().parents[2] / "scripts" / "dev" / "update_versions.py"
+    )
+    spec = importlib.util.spec_from_file_location("update_versions", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+update_versions = _load_module()
+_select_tools_for_update = update_versions._select_tools_for_update
+_LEVEL_INCLUDES = update_versions._LEVEL_INCLUDES
+
+
+# Representative mixed-bump fixture covering every classification outcome.
+# Each entry maps tool name to (current, latest, is_outdated).
+MIXED_RESULTS: dict[str, tuple[str, str, bool]] = {
+    "bandit": ("1.9.3", "1.9.4", True),  # patch
+    "semgrep": ("1.151.0", "1.159.0", True),  # minor
+    "kubescape": ("3.0.47", "4.0.5", True),  # major
+    "falco": ("0.0.0", "0.43.1", True),  # major (0.x)
+    "akto": ("mini-testing-1.53.7", "1.98.0", True),  # unknown
+    "ruff": ("0.6.0", "0.6.0", False),  # up-to-date — always skipped
+}
+
+# critical flag layout mirroring versions.yaml structure (category → tool → info).
+MIXED_VERSIONS: dict = {
+    "python_tools": {
+        "bandit": {"version": "1.9.3", "critical": False},
+        "semgrep": {"version": "1.151.0", "critical": True},
+        "ruff": {"version": "0.6.0", "critical": False},
+    },
+    "binary_tools": {
+        "kubescape": {"version": "3.0.47", "critical": True},
+        "falco": {"version": "0.0.0", "critical": False},
+    },
+    "special_tools": {
+        "akto": {"version": "mini-testing-1.53.7", "critical": False},
+    },
+}
+
+
+def _tool_names(selected: list[tuple[str, str, str]]) -> set[str]:
+    return {entry[0] for entry in selected}
+
+
+@pytest.mark.parametrize(
+    ("level", "expected_selected"),
+    [
+        ("patch", {"bandit"}),
+        ("minor", {"bandit", "semgrep"}),
+        ("major", {"bandit", "semgrep", "kubescape", "falco"}),
+        ("all", {"bandit", "semgrep", "kubescape", "falco", "akto"}),
+    ],
+)
+def test_select_tools_by_level_cumulative(
+    level: str, expected_selected: set[str]
+) -> None:
+    """--level is a cumulative filter — lower levels always include higher-priority bumps."""
+    to_update, skipped = _select_tools_for_update(
+        MIXED_RESULTS, MIXED_VERSIONS, critical_only=False, level=level
+    )
+    assert _tool_names(to_update) == expected_selected
+    # Up-to-date tools never appear in either list.
+    assert "ruff" not in _tool_names(to_update)
+    assert all(name != "ruff" for name, *_ in skipped)
+
+
+def test_select_tools_excludes_unknown_even_at_major() -> None:
+    """'unknown' is only included with explicit --level=all."""
+    to_update, skipped = _select_tools_for_update(
+        MIXED_RESULTS, MIXED_VERSIONS, critical_only=False, level="major"
+    )
+    assert "akto" not in _tool_names(to_update)
+    skipped_names = {name for name, *_ in skipped}
+    assert "akto" in skipped_names
+
+
+def test_select_tools_critical_only_narrows_after_level() -> None:
+    """critical_only filters further — tools must be critical AND within the level."""
+    to_update, skipped = _select_tools_for_update(
+        MIXED_RESULTS, MIXED_VERSIONS, critical_only=True, level="all"
+    )
+    # Only semgrep and kubescape are critical in the fixture.
+    assert _tool_names(to_update) == {"semgrep", "kubescape"}
+    # Non-critical tools should appear in skipped with reason "non-critical".
+    skipped_map = {name: reason for name, _, _, reason in skipped}
+    assert skipped_map.get("bandit") == "non-critical"
+
+
+def test_select_tools_rejects_invalid_level() -> None:
+    with pytest.raises(ValueError, match="Unknown bump level"):
+        _select_tools_for_update(
+            MIXED_RESULTS, MIXED_VERSIONS, critical_only=False, level="banana"
+        )
+
+
+def test_level_includes_hierarchy_is_monotonic() -> None:
+    """Guardrail: any future edit to _LEVEL_INCLUDES must preserve strict subset ordering."""
+    assert _LEVEL_INCLUDES["patch"] <= _LEVEL_INCLUDES["minor"]
+    assert _LEVEL_INCLUDES["minor"] <= _LEVEL_INCLUDES["major"]
+    assert _LEVEL_INCLUDES["major"] <= _LEVEL_INCLUDES["all"]
+    # 'unknown' must remain gated behind --level=all, never bleed into lower tiers.
+    assert "unknown" not in _LEVEL_INCLUDES["major"]
+    assert "unknown" in _LEVEL_INCLUDES["all"]


### PR DESCRIPTION
## Summary

Final layer of the tool-version automation stack. Layer 1 (exit-0 on outdated) and Layer 2 (`--create-issues` dashboard) shipped in v1.0.2; this PR delivers Layer 3 — auto-PR patch+minor bumps, auto-merge after a 24h soak window, contract-test gated, majors and unknowns stay issue-only.

- **`--level {patch,minor,major,all}`** cumulative filter on `update_versions.py --update-all`. Default cron now runs with `--level=minor` (patch+minor).
- **Soak-window auto-merge**: `scripts/dev/auto_merge_tool_bumps.py` runs every 6 hours, merges auto-PRs >= 24h old with green CI, flips to `needs-review` on contract-test failure. Decision logic is a pure `should_merge()` function with 10 unit tests.
- **Contract-test PR gate**: new `tool-contract-tests` job in `ci.yml` runs `tests/integration/test_tool_contracts.py` when `versions.yaml` or `Dockerfile.*` changes. Pinned name for branch protection.
- **`--classify` captured BEFORE `--update-all`** so the PR body shows real bump levels (otherwise every tool reads as level=patch after bumping).
- **Inline `gh pr merge --auto --squash` removed** from the existing auto-update-tools job — the new soak job owns merging now.

## What's in this PR

- `scripts/dev/update_versions.py` — `--level`, `--dry-run` extended to `--update-all`, `_select_tools_for_update()` helper
- `scripts/dev/auto_merge_tool_bumps.py` — new soak-window script
- `tests/unit/test_update_versions_level.py` — 8 tests (cumulative semantics + monotonicity guardrail)
- `tests/unit/test_auto_merge_tool_bumps.py` — 10 tests (soak window × label × check conclusion matrix)
- `.github/workflows/ci.yml` — `tool-contract-tests` job with step-level paths-filter
- `.github/workflows/maintenance.yml` — new cron, `bump_level` input, classify-before-update, new soak job
- `docs/RELEASE.md` — new "Tool-Version Auto-Merge" section with cancel instructions + branch-protection setup

## Test plan

- [x] `pytest tests/unit/test_update_versions_level.py tests/unit/test_auto_merge_tool_bumps.py tests/unit/test_update_versions_classify.py` — 35 passed locally
- [x] `pre-commit run --files <changed>` — all hooks pass (Black, Ruff, mypy, yamllint, actionlint, markdownlint, bandit)
- [x] `python scripts/dev/update_versions.py --help` — new `--level` flag surfaces correctly, validation rejects `--level` without `--update-all`
- [x] YAML sanity: maintenance.yml parses with 7 jobs, 4 schedules (incl. new `0 */6 * * *`), 3 dispatch inputs
- [ ] Full CI green on this PR (Ubuntu/macOS/Windows shards, coverage, lint-quick)
- [ ] After merge: manual dispatch `gh workflow run maintenance.yml --ref main -f task=tool-update -f bump_level=patch` — auto-PR opens with `auto-merge-ok` label, NO auto-merge fires
- [ ] After merge: `gh workflow run maintenance.yml --ref main -f task=auto-merge` with the PR above — soak job defers because age < 24h, confirmed via logs

## Follow-up (one-time GitHub UI step, documented in docs/RELEASE.md)

After this PR merges and at least one test PR runs the `tool-contract-tests` job, add it as a required status check on `main` (Settings → Branches → required-status-checks → **`tool-contract-tests`**). Documented in the new RELEASE.md section.