### PR TITLE
test(e2e): bump test_docker_variant_tools timeout 180s -> 600s

### DIFF
--- a/tests/e2e/test_docker_workflows.py
+++ b/tests/e2e/test_docker_workflows.py
@@ -101,6 +101,11 @@ class TestDockerVariants:
             if not pull_image(image):
                 pytest.skip(f"Could not pull image: {image}")
 
+        # Timeout 600s matches pull_image's timeout and accommodates the deep variant's
+        # cold-start cost (25 tools each running their own --version subprocess inside
+        # the container; nightly runners often aren't image-cached, amplifying startup).
+        # Prior value of 180s was insufficient per run 24758090406 (Nightly Extended Tests,
+        # 2026-04-22) which hung on the deep variant and was killed by pytest-timeout.
         result = subprocess.run(
             [
                 "docker",
@@ -115,7 +120,7 @@ class TestDockerVariants:
             ],
             capture_output=True,
             text=True,
-            timeout=180,
+            timeout=600,
         )
 
         if result.returncode != 0:


### PR DESCRIPTION
## Summary

Fix Nightly Extended Tests failure on `test_docker_variant_tools[deep]`. Follow-up to PR #320 (which bumped 120s → 180s — insufficient).

## Evidence

Run [24758090406](https://github.com/jimmy058910/jmo-security-repo/actions/runs/24758090406) (Nightly Extended Tests, 2026-04-22 03:08 UTC) hung in `subprocess.run` at `tests/e2e/test_docker_workflows.py:104` and was killed by pytest-timeout with a `+++++++++ Timeout +++++++++` marker. The deep variant checks 25 tools inside the container, each running its own `--version` subprocess.

## Reasoning

- `pull_image()` already has `timeout=600` — matches the known cost for cold image pulls
- The deep variant's cold-start cost (25 tool `--version` calls) on nightly runners without image cache consistently exceeds 180s
- Test fails fast on real errors (non-zero exit code, invalid JSON), so the longer timeout doesn't mask genuine failures

## Scope

One-line change to the `subprocess.run` timeout value + a four-line comment explaining the rationale so future-me doesn't re-bump this or cut it back.

## Test plan

- [x] `pre-commit run`: black ✓, ruff ✓, mypy ✓
- [ ] Post-merge: next Nightly Extended Tests cycle should pass the Docker variant test