### PR TITLE
fix(tools): catch PermissionError in `jmo tools debug` file-type probe

### DIFF
--- a/scripts/cli/tool_commands.py
+++ b/scripts/cli/tool_commands.py
@@ -278,8 +278,17 @@ def cmd_tools_debug(args: argparse.Namespace) -> int:
                 )
                 if file_result.returncode == 0:
                     print(f"File type: {file_result.stdout.strip()}")
-            except (FileNotFoundError, subprocess.TimeoutExpired):
-                pass  # 'file' command not available
+            except (
+                FileNotFoundError,
+                PermissionError,
+                subprocess.TimeoutExpired,
+                OSError,
+            ):
+                # 'file' command unavailable: missing (FileNotFoundError) on slim
+                # base images without the `file` package, or partial PATH match
+                # that resolves to a non-executable (PermissionError on execve).
+                # Catch the broader OSError umbrella to cover other edge cases.
+                pass
         else:
             print(f"Binary path: {colorize('NOT FOUND', 'red')}")
             print("\nThe tool binary could not be found in PATH or ~/.jmo/bin/")

--- a/tests/e2e/test_docker_workflows.py
+++ b/tests/e2e/test_docker_workflows.py
@@ -156,9 +156,17 @@ class TestDockerVariants:
             1 for status in tools.values() if status.get("installed", False)
         )
 
-        assert (
-            installed >= expected_tools
-        ), f"{variant} variant has {installed} tools, expected at least {expected_tools}"
+        # On assertion failure, enumerate which tools report installed=false so
+        # the log shows the specific image-drift diagnosis instead of just a
+        # count mismatch. Saves a round-trip dispatch to identify the missing
+        # tool when PROFILE_TOOLS and the Dockerfile get out of sync.
+        missing_names = sorted(
+            name for name, status in tools.items() if not status.get("installed", False)
+        )
+        assert installed >= expected_tools, (
+            f"{variant} variant has {installed} tools, expected at least "
+            f"{expected_tools}. Tools reporting installed=false: {missing_names}"
+        )
 
     @pytest.mark.parametrize("variant,_expected_tools", DOCKER_VARIANTS)
     def test_docker_variant_scan(


### PR DESCRIPTION
## Summary

Fourth PR in the scheduled-tests repair chain. Fixes 3 of the 5 remaining `Nightly Extended Tests` failures surfaced by the post-#332 validation dispatch (run 24817607599).

## Root cause

`scripts/cli/tool_commands.py:281` catches only `FileNotFoundError` and `TimeoutExpired` from the optional diagnostic `file` command invocation. When slim/balanced Docker base images don't have the `file` package installed but PATH resolution surfaces a non-executable partial match, `subprocess.run` raises `PermissionError` on `execve` instead of `FileNotFoundError`. The PermissionError then propagates out of `cmd_tools_debug`, emitting a traceback to stderr.

## Test impact

`TestDockerToolVerification.test_tool_actually_runs` runs `jmo tools debug <tool>` inside each Docker variant and asserts no "traceback" appears in output. With the PermissionError traceback leaking, the assertion fails on fast-trivy, fast-semgrep, balanced-trivy — even though those tools themselves are fine.

## Fix

Broaden the `except` clause to `(FileNotFoundError, PermissionError, TimeoutExpired, OSError)`. The `file` command output is purely diagnostic (shows file type for architecture debugging); any error should silently skip the print, not crash.

## Bonus: exposes item #2

The nightly also showed `test_docker_variant_tools[deep]` failing with "has 24 tools, expected at least 25" — but the full JSON (which would identify the missing tool) was buried behind the traceback. This fix unblocks that visibility on the next dispatch.

## Test plan

- [x] Local pre-commit passes (black reformatted one line)
- [x] Defensive pattern matches `scripts/core/config.py:220` fix shipped in PR #332
- [ ] CI quick-checks pass
- [ ] Post-merge dispatch: `test_tool_actually_runs[fast-trivy, fast-semgrep, balanced-trivy]` all PASS; deep variant JSON visible in log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the tools debugging command to gracefully handle permission and other system errors, preventing unexpected failures when diagnosing tool binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->