### PR TITLE
fix(ci)(tests): post-v1.0.3 nightly fixes — expected_tools drift + UID + Windows perf flake

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1006,14 +1006,19 @@ jobs:
           # MANUAL_INSTALL_TOOLS (akto, afl++, mobsf, falco) which are listed
           # in PROFILE_TOOLS["deep"] but intentionally not in the image —
           # users install them manually (see docs/MANUAL_INSTALLATION.md).
+          # Counts post-v1.0.3 (bearer removed from PROFILE_TOOLS in PR #339):
+          #   deep:     28 profile - 4 manual = 24 in image
+          #   balanced: 17 in profile (no manual tools)
+          #   slim:     13 in profile (no manual tools)
+          #   fast:      9 (unchanged)
           - variant: deep
-            expected_tools: 25   # 29 profile - 4 manual-only = 25
+            expected_tools: 24   # 28 profile - 4 manual-only = 24
             profile: deep
           - variant: balanced
             expected_tools: 17
             profile: balanced
           - variant: slim
-            expected_tools: 14
+            expected_tools: 13
             profile: slim
           - variant: fast
             expected_tools: 9

--- a/tests/e2e/test_docker_workflows.py
+++ b/tests/e2e/test_docker_workflows.py
@@ -25,13 +25,20 @@ import pytest
 from tests.conftest import skip_on_windows
 
 # Docker image variants to test.
-# expected_tools mirrors scheduled.yml validate-variants matrix (source of truth):
-# deep = PROFILE_TOOLS["deep"] (29) minus MANUAL_INSTALL_TOOLS (akto, afl++, mobsf, falco).
+# expected_tools mirrors scheduled.yml validate-variants matrix (source of truth).
+# Counts align with PROFILE_TOOLS in scripts/core/tool_registry.py minus
+# MANUAL_INSTALL_TOOLS (akto, afl++, mobsf, falco) for variants that include them.
+# Post-v1.0.3 (dev → main reconciliation): bearer was removed from PROFILE_TOOLS,
+# so all variants that previously included bearer dropped by 1:
+#   deep:     29 → 28 in PROFILE_TOOLS, minus 4 manual = 24 expected installable
+#   balanced: 18 → 17 in PROFILE_TOOLS (no manual tools)
+#   slim:     14 → 13 in PROFILE_TOOLS (no manual tools)
+#   fast:      9 →  9 (bearer was never in fast)
 DOCKER_REGISTRY = "ghcr.io/jimmy058910/jmo-security"
 DOCKER_VARIANTS = [
-    pytest.param("deep", 25, id="deep"),
-    pytest.param("balanced", 18, id="balanced"),
-    pytest.param("slim", 14, id="slim"),
+    pytest.param("deep", 24, id="deep"),
+    pytest.param("balanced", 17, id="balanced"),
+    pytest.param("slim", 13, id="slim"),
     pytest.param("fast", 9, id="fast"),
 ]
 
@@ -466,6 +473,17 @@ class TestDockerNonRootExecution:
         src_dir = tmp_path / "src"
         src_dir.mkdir()
         (src_dir / "test.py").write_text("x = 1", encoding="utf-8")
+
+        # UID-mismatch fix (mirrors test_docker_variant_scan + scheduled.yml:1083):
+        # GitHub runners use UID 1001; this test mounts as `--user 1000:1000` (the
+        # `jmo` container user). Without world-accessible bits, the container's
+        # UID 1000 can't traverse the host-owned tmp_path → EACCES → which
+        # Python 3.12+ propagates from Path.exists() in scripts/core/config.py.
+        # Safe because tmp_path is a pytest-managed run-scoped directory.
+        # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        os.chmod(str(tmp_path), 0o777)
+        # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        os.chmod(str(src_dir), 0o777)
 
         # Run as user 1000:1000
         result = subprocess.run(

--- a/tests/unit/test_history_db_performance.py
+++ b/tests/unit/test_history_db_performance.py
@@ -152,6 +152,13 @@ def test_large_scan_storage_performance(perf_db, large_findings_set, tmp_path):
     assert elapsed_retrieval < 0.1  # <100ms retrieval
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows GitHub Actions runners exhibit highly variable file-system "
+    "performance (200ms target observed at 700-1500ms in CI). The sibling test "
+    "test_history_list_performance_10k_scans is already skipped here for the "
+    "same reason. Test runs reliably on Linux/macOS CI to catch regressions.",
+)
 def test_single_scan_insert_performance(perf_db, tmp_path):
     """
     Test single scan insert performance (target: <200ms).


### PR DESCRIPTION
## Summary

After v1.0.3 released (commit 69ec931, tag v1.0.3 pushed), the validation Nightly Extended Tests dispatch (run 24947221954) and the next scheduled cron run (24948002779) exposed three additional failures — all consequences of the dev → main reconciliation merge (#339), not of the v1.0.3 release itself.

## Three root causes (all in this PR)

### 1. \`expected_tools\` count drift across deep/balanced/slim

PR #262 (merged into dev April 14, brought to main via #339) removed \`bearer\` from \`PROFILE_TOOLS\`:

| Variant | Before #339 | After #339 | expected_tools (test) | expected_tools (workflow) | Correct |
|---------|-------------|------------|----------------------|--------------------------|---------|
| fast | 9 | 9 | 9 ✓ | 9 ✓ | 9 |
| slim | 14 | 13 | 14 ← stale | 14 ← stale | **13** |
| balanced | 18 | 17 | 18 ← stale | 17 ✓ (partially fixed) | **17** |
| deep | 29 | 28 (-4 manual = 24) | 25 ← stale | 25 ← stale | **24** |

The bearer binary is still installed in \`Dockerfile.deep\`/\`balanced\` (kept on purpose during the merge — removing was a user-visible behavior change). It's a stranded binary not in \`PROFILE_TOOLS\`, so jmo never invokes it. Cleanup as a follow-up Dockerfile-only PR if desired.

### 2. \`test_run_as_non_root_user\` UID-mismatch

Mirrors \`test_docker_variant_scan\` pattern fixed in PR #332. The test runs Docker as \`--user 1000:1000\` (jmo container user), pytest \`tmp_path\` is created with UID 1001 (runner) and 0o700 mode → container can't traverse → EACCES → propagates from \`Path.exists()\` in \`config.py\`. Added \`os.chmod(tmp_path, 0o777)\` + \`os.chmod(src_dir, 0o777)\` with \`nosemgrep\` for intentional test infra perms.

### 3. \`test_single_scan_insert_performance\` Windows perf flake

200ms target observed at 731ms on Windows CI. Mirrors existing skip pattern on the sibling test \`test_history_list_performance_10k_scans\` (same file, already skipped on Windows). Added \`@pytest.mark.skipif(sys.platform == 'win32')\` with documented reason. Test still runs on Linux/macOS to catch regressions.

## Out of scope (separate root cause, deferred)

- **\`test_advanced_targets.test_deep_profile_scan\`**: marked \`@pytest.mark.requires_tools\` at the class level (line 22), but Nightly Extended Tests runs \`pytest tests/\` without \`-m\` filter, so it runs anyway. The CI runner lacks the deep-profile tools, scan completes with no findings, \`findings.json\` not generated, assertion fails. Real environmental gap that needs either a workflow-level tools install or marker-based exclusion. Tracking separately — not blocking the daily-failure cycle fix.

## Test plan

- [x] \`tests/unit/test_history_db_performance.py::test_single_scan_insert_performance\` skipped locally on Windows
- [x] All 3 modified files parse cleanly
- [x] expected_tools values match \`PROFILE_TOOLS\` post-merge state (verified via \`python -c \"from scripts.core.tool_registry import PROFILE_TOOLS; print({k:len(v) for k,v in PROFILE_TOOLS.items()})\"\`)
- [ ] CI quick-checks pass
- [ ] Sharded test matrix passes (especially Windows)
- [ ] Post-merge: dispatch Nightly Extended Tests → \`test_docker_variant_tools[*]\` and \`test_run_as_non_root_user\` pass

## Why this isn't blocking the v1.0.3 release

These are TEST-LEVEL fixes that affect pytest assertions and workflow matrix values. They don't require a Docker rebuild — the v1.0.3 images are correctly built (all release.yml jobs passed). The next nightly Scheduled Tests run after this PR merges should be green for everything except \`test_deep_profile_scan\` (the deferred environmental issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated expected tool counts for Docker variants to align with current tool registry
  * Fixed permission handling issues when running containers as non-root user
  * Added Windows-specific condition to skip performance test

* **Chores**
  * Adjusted workflow validation matrices for Docker tool installation expectations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->