### PR TITLE
fix(tests): test_docker_cli_workflow — --profile-name flag + UID chmod

### DIFF
--- a/tests/e2e/test_docker_workflows.py
+++ b/tests/e2e/test_docker_workflows.py
@@ -1361,7 +1361,7 @@ class TestDockerCLIWorkflows:
             pytest.param(
                 "U9",
                 "latest",
-                ["ci", "--repo", "/scan", "--profile", "balanced"],
+                ["ci", "--repo", "/scan", "--profile-name", "balanced"],
                 "linux",
                 id="U9-docker-full-repo",
             ),
@@ -1375,35 +1375,35 @@ class TestDockerCLIWorkflows:
             pytest.param(
                 "U11",
                 "slim",
-                ["ci", "--repo", "/scan", "--profile", "fast"],
+                ["ci", "--repo", "/scan", "--profile-name", "fast"],
                 "linux",
                 id="U11-docker-slim-multi",
             ),
             pytest.param(
                 "M5",
                 "latest",
-                ["ci", "--repo", "/scan", "--profile", "balanced"],
+                ["ci", "--repo", "/scan", "--profile-name", "balanced"],
                 "darwin",
                 id="M5-docker-full-macos",
             ),
             pytest.param(
                 "M6",
                 "slim",
-                ["ci", "--repo", "/scan", "--profile", "fast"],
+                ["ci", "--repo", "/scan", "--profile-name", "fast"],
                 "darwin",
                 id="M6-docker-slim-macos",
             ),
             pytest.param(
                 "W3",
                 "latest",
-                ["ci", "--repo", "/scan", "--profile", "balanced"],
+                ["ci", "--repo", "/scan", "--profile-name", "balanced"],
                 "win32",
                 id="W3-docker-full-windows",
             ),
             pytest.param(
                 "W4",
                 "slim",
-                ["ci", "--repo", "/scan", "--profile", "fast"],
+                ["ci", "--repo", "/scan", "--profile-name", "fast"],
                 "win32",
                 id="W4-docker-slim-windows",
             ),
@@ -1416,6 +1416,17 @@ class TestDockerCLIWorkflows:
 
         results_dir = tmp_path / "results"
         results_dir.mkdir()
+
+        # UID-mismatch fix: container runs as USER jmo (UID 1000), tmp_path
+        # is owned by host runner UID 1001 with 0o700 mode → container can't
+        # write /scan/results/individual-* subdirs (PermissionError on the
+        # mkdir(mode=0o700) call inside scan_orchestrator). chmod 0o777
+        # applies to both the parent tmp_path and the results_dir we just
+        # created so the container has full traversal + write.
+        # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        os.chmod(str(tmp_path), 0o777)
+        # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+        os.chmod(str(results_dir), 0o777)
 
         docker_cmd = [
             "docker",


### PR DESCRIPTION
## Summary

Round-5 cleanup. After PR #346's tag rename (\`latest-deep\` → \`latest\`) finally let the docker_cli_workflow tests reach the actual CLI, two latent bugs surfaced:

### 1. Wrong flag name in test cli_args

The test passed \`["ci", "--repo", "/scan", "--profile", "balanced"]\`, but \`--profile\` is a BOOLEAN flag on \`jmo ci\` (\`scripts/cli/jmo.py:337-339\`, action="store_true", controls timing collection). The flag for selecting a profile is \`--profile-name\` (line 196-200), same pattern as \`cmd_scan\`.

Error from CI: \`jmo: error: unrecognized arguments: balanced\` — argparse parsed \`--profile\` as the boolean flag and \`balanced\` was left as an unrecognized positional.

Fixed in 6 parametrize entries (U9, U11, M5, M6, W3, W4): \`"--profile"\` → \`"--profile-name"\`.

### 2. UID mismatch on results dir mount (U10)

Test mounts host \`tmp_path\` (owned by runner UID 1001, mode 0o700) and container runs as UID 1000. Container's \`mkdir(/scan/results/individual-repos, mode=0o700)\` hits \`EACCES\`. Same pattern as \`test_docker_variant_scan\` (PR #332) and \`test_run_with_uid_mapping\` (PR #344). Added \`os.chmod(tmp_path, 0o777)\` + \`os.chmod(results_dir, 0o777)\` before \`docker run\`.

## Out of scope

- **Docker Smoke Tests trivy 0.70.0 download flake during build**: infrastructure issue (network or version drift), not test code. Worth investigating separately if it persists.

## Verification

These were the LAST visible failures in round-4 validation (run 24952087885). With these fixes, the next dispatch should approach 0-failure state on Nightly Extended Tests (test_advanced_targets is filtered out by PR #344's \`-m "not requires_tools"\`; smoke tests filtered out by PR #346's \`-m "not smoke"\`).

## Test plan

- [x] All 3 modified files parse cleanly
- [x] CRLF line endings preserved (matches repo convention)
- [x] CLI flag name verified against \`scripts/cli/jmo.py\` definitions
- [ ] CI quick-checks pass
- [ ] Sharded test matrix passes
- [ ] Post-merge: dispatch Nightly Extended Tests → near-zero failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Docker CLI workflow test parameters for profile selection syntax
  * Enhanced test setup with filesystem permission adjustments to ensure proper Docker container access to mounted directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->