### PR TITLE
docs(claude): point to v1.0.3 handoff for next CI rebuild session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,8 @@ For release-specific issues, see [.claude/rules/release.rules.md](.claude/rules/
 
 ### Recent Major Lessons (post-v1.0.3 stabilization, 2026-04-26)
 
+> ⚠️ **Active handoff for next session**: A planning doc at `dev-only/plans/2026-04-26-ci-yaml-architectural-rebuild.md` (also in auto-memory as `HANDOFF-ci-yaml-rebuild-2026-04-26.md`) catalogs what's still architecturally broken in CI/YAML and proposes a 3-phase rebuild. **If continuing CI/workflow work, read that handoff first** — this session was reactive, the next should be architectural.
+
 The v1.0.3 release cycle exposed multiple layered bugs that had been latent for several releases. Key takeaways now embedded in path-scoped rules:
 
 - **Bug archeology pattern**: `--maxfail=5` truncation hides deeper failures. Required 5 successive PRs (#343 → #347) to dig through all layers.


### PR DESCRIPTION
## Summary

Adds a 1-paragraph pointer in `CLAUDE.md`'s "Recent Major Lessons" subsection that directs the next session to a comprehensive handoff doc. Pure documentation — no code changes.

## Why

The v1.0.3 stabilization session (14 PRs, 1 release) was REACTIVE — patched symptoms, didn't address architectural CI/YAML weaknesses. The user explicitly framed: "next session needs to fully evaluate, tear down, rebuild, fix, and enhance the broken CI/yaml structure."

A handoff doc lives in two places (one local, one auto-memory):

1. **Local-only**: `dev-only/plans/2026-04-26-ci-yaml-architectural-rebuild.md` (gitignored per project convention — internal planning, not published)
2. **Auto-memory persistent**: `~/.claude/projects/.../memory/HANDOFF-ci-yaml-rebuild-2026-04-26.md` (loads automatically in future Claude sessions on this machine; also indexed as the FIRST entry in `MEMORY.md` under "⚠️ ACTIVE HANDOFF")

This PR adds a pointer in `CLAUDE.md` so the doc is also discoverable via the project memory that loads on every session start, regardless of which machine.

## Honest status the handoff captures

**Verified fixed reliably (2/2 dispatches):**
- `Lint (full pre-commit suite)`
- `Nightly Extended Tests` (12/12 inner jobs)

**Still flaky (1/2 dispatches):**
- `Docker Smoke Tests` — different binary fails each time during Dockerfile builds (no retry logic). 50% rate, not "transient".

**NOT addressed by v1.0.3 cycle:**
- No retry logic in any of ~120 single-attempt curl downloads per release
- Drift-prone constants: `expected_tools` mirrored across 4 places, no automated check
- Implicit tag schema (`:latest = deep`, no `:latest-deep`) — bit us multiple times
- Workflow marker filter conventions inconsistent across jobs
- `--maxfail=5` truncation creates "bug archeology" requiring multi-PR cycles

## What the handoff proposes (3-phase scope)

**Phase 1 — Audit** (no changes): inventory all workflows, map gates, identify implicit knowledge.
**Phase 2 — Architectural fixes** (separate PRs): retry-everywhere defaults, single-source-of-truth for constants, explicit filter convention, tag-schema regression test, bearer Dockerfile cleanup, etc.
**Phase 3 — Process improvements**: periodic dev↔main reconciliation, pre-release validation script, image-size regression check.

## Test plan

- [x] No code changes; CLAUDE.md addition is informational
- [x] Auto-memory file already saved (loads on next session)
- [x] MEMORY.md index updated with active-handoff pointer
- [ ] CI quick-checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation with architectural guidance for future development sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->