### PR TITLE
docs(claude): point to v1.0.4 handoff for next session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,8 @@ For release-specific issues, see [.claude/rules/release.rules.md](.claude/rules/
 
 ### Recent Major Lessons (post-v1.0.3 stabilization, 2026-04-26)
 
+> ⚠️ **Active handoff for next session**: A planning doc at `dev-only/plans/2026-04-26-tasks-10-11-then-v1.0.4-handoff.md` covers what's still TODO before v1.0.4: (Task #10) restore coverage threshold 70% after band-aid lowering, (Task #11) harden Trivy install in `tool-contract-tests` (extend PR #350 hardening convention to CI installs), then (v1.0.4 release) cut the tag to ship Phase 2 fixes to GHCR images. **If continuing this work, read that handoff first.**
+
 The v1.0.3 release cycle exposed multiple layered bugs that had been latent for several releases. Key takeaways now embedded in path-scoped rules:
 
 - **Bug archeology pattern**: `--maxfail=5` truncation hides deeper failures. Required 5 successive PRs (#343 → #347) to dig through all layers.


### PR DESCRIPTION
## Summary

Single-file pointer update mirroring commit `b70c85d` (the v1.0.3 handoff pointer pattern). Adds an "Active handoff for next session" callout to CLAUDE.md's "Recent Major Lessons" section pointing at the local handoff doc.

## What's at the handoff path

`dev-only/plans/2026-04-26-tasks-10-11-then-v1.0.4-handoff.md` (gitignored, internal-only per the project's dev-only convention) covers what's TODO before v1.0.4:

- **Task #10**: Investigate why coverage dropped 71.6% → 68.7% post-rebuild and restore the 70% threshold (PR #355 lowered to 68% as band-aid). 3 hypotheses ranked + investigation bash commands + recommended fixes.
- **Task #11**: Harden Trivy install in `tool-contract-tests` — extend PR #350's `curl --fail/--retry` convention to all CI install steps (currently a Trivy install script flake breaks main CI).
- **v1.0.4 release**: 8-step checklist with pre-release validation dispatches, version-bump file list (pyproject + 4 modules + JMO_DOCKER_TAG), tag commands, post-release verification.

## Why this matters

Future sessions opening `CLAUDE.md` will see the handoff pointer in the "Recent Major Lessons" section and know exactly what to read first — same pattern that worked for the session-1 → session-2 handoff.

## Test plan

- [x] Pre-commit green (markdownlint, doc-links, etc.)
- [ ] PR CI passes — single-line markdown change, low risk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal planning documentation to reflect handoff coordination and upcoming release roadmap.

**Note:** This is an internal documentation update with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->