### PR TITLE
release: v1.0.4 — Phase 2 CI/YAML rebuild + coverage merge fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to JMo Security will be documented in this file.
 
-## [Unreleased]
+## [1.0.4] - 2026-04-27
+
+### Summary
+
+CI/YAML architectural rebuild release. Ships PR #350's Dockerfile download hardening to GHCR images for the first time (every prior release had the broken single-attempt `curl -sSL` pattern; ~50% Docker Smoke Tests flake rate is now eliminated). Plus a root-cause fix for the sharded coverage merge that has been silently reporting only shard-1's coverage since pytest-split was introduced.
 
 ### Fixed
 
@@ -13,6 +17,14 @@ All notable changes to JMo Security will be documented in this file.
   - **What this means historically**: every "coverage" number reported by the `coverage-aggregate` job since the sharded-coverage refactor has been shard-1's individual coverage, not the aggregate. The 71.6% baseline was shard-1; the 68.7% "drop" in PR #355 was shard-1's value drifting after `pytest-split --splitting-algorithm least_duration` reshuffled tests when PRs #351/#353/#354 added new test files. No actual coverage was lost. The Codecov upload (`codecov-action@v5.5.2`) parses `<line>` elements directly and so was reporting accurate aggregate numbers — only the local threshold check was broken.
   - **Threshold restored 68% → 70%** (the band-aid from #355 is now removed; true aggregate coverage with the CI marker filters is ~88%, well above 70%). Lessons captured in `.claude/rules/release.rules.md`.
   - **Known scope limit**: branch coverage (`branch = true` in `pyproject.toml`) produces `branch-rate`/`branches-valid`/`branches-covered` root attrs and `condition-coverage` per `<line branch="true">`. Those remain stale at shard-1's values because correct branch merging requires parsing each shard's `missing-branches` per line and intersecting them — `condition-coverage` is a percentage, not a bitmask, so naive max-percentage merging is wrong (shard-1 covers branches A+B at 50%, shard-2 covers B+C at 50%; true union is A+B+C = 75%). The threshold check only uses `line-rate`, so this doesn't affect CI gating; Codecov re-derives line coverage from `<line>` elements and gets correct aggregates there. If a future requirement adds a branch-coverage threshold, extend the recompute to merge `missing-branches` per line.
+
+- **Docker Smoke Tests intermittent failures (50% flake rate)**: Hardened all binary downloads in `Dockerfile.{deep,balanced,slim,fast}` against transient CDN failures. The v1.0.3 cycle saw repeated `tar: Error is not recoverable: gzip: stdin: not in gzip format` build failures — `curl -sSL` exited 0 on HTTP 4xx/5xx with HTML body, handing garbage to `tar -xzf`. Each release cycle triggered ~50 single-attempt downloads (4 variants × 2 architectures × ~6-10 binaries each); even a 0.5% CDN flake rate produced at least one failure most cycles.
+  - **Root-cause flag**: All `curl` invocations now use `-fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600`. The `-f`/`--fail` flag is the actual fix — it makes curl exit non-zero on HTTP errors instead of accepting an HTML error page as the response body.
+  - **Retry on transient flakes**: All `wget` invocations now use `--tries=3 --waitretry=5 --timeout=600`. wget already exits non-zero on HTTP errors so no `--fail` equivalent is needed.
+  - **Integrity belt-and-suspenders**: Every archive extraction is now preceded by an integrity check — `gzip -t` for `.tar.gz`, `xz -t` for `.tar.xz`, `unzip -t` for `.zip`. Catches the rare case of "200 with corrupt body" (partial download, mid-stream truncation) that `--fail` cannot detect because the HTTP layer reported success.
+  - **Coverage**: 41 curl invocations + 9 wget invocations now hardened across all 4 Dockerfiles. 34 archive extractions now integrity-checked. Convention is documented in `.claude/rules/docker.rules.md` "Download Hardening Convention". This fix is shipping to GHCR images for the FIRST TIME with v1.0.4 — every prior `:1.0.x-*` image had the broken single-attempt pattern.
+
+- **3 user-facing docs referenced unpublished `:latest-<variant>` tags**: `TEST.md:206`, `tests/e2e/README.md:197` both used `docker pull ghcr.io/jimmy058910/jmo-security:latest-full` (would fail with "manifest unknown" because `:latest-full` doesn't exist — `:latest` IS the deep variant). `docs/SCHEDULE_GUIDE.md:746` used `:latest-slim` in a GitLab CI example (would also fail; bare variant tag `:slim` is the canonical reference). All three corrected. New `tests/unit/test_docker_tag_pattern_drift.py` enforces this at PR time so future regressions are caught before merge — `.claude/rules/docker.rules.md` already documented the canonical schema, but documentation alone didn't catch these specific bugs.
 
 ### Removed
 
@@ -25,16 +37,6 @@ All notable changes to JMo Security will be documented in this file.
 - **Workflow marker filter convention expanded** in `.claude/rules/testing.cross-platform.rules.md` from 4 to 9 documented filter patterns. Previous table missed `ci.yml` Quick coverage check (adds `not slow`), `ci.yml` tool-contract-tests (`requires_tools`), `scheduled.yml` Integration matrix (`integration and not slow`), and `scheduled.yml` E2E `not docker` filters. Added rules-of-thumb for when to include/exclude each marker.
 
 - **SSOT drift guard for tool counts** (`tests/unit/test_profile_tools_count_drift.py`): New unit test asserts that `tests/e2e/test_docker_workflows.py::DOCKER_VARIANTS` AND `.github/workflows/scheduled.yml` `validate-variants` matrix BOTH equal `len(PROFILE_TOOLS[v]) - len(MANUAL_INSTALL_TOOLS & PROFILE_TOOLS[v])` for each variant, computed at runtime from `scripts/core/tool_registry.py`. A YAML matrix can't `import PROFILE_TOOLS`, so both downstream constants stay hardcoded but the test enforces their relationship at PR time. Catches the cascade-drift class that took 5 PRs (#343 → #344 → #345 → #346 → #347) to resolve in v1.0.3 after bearer was removed from PROFILE_TOOLS but the constants weren't updated together.
-
-### Fixed
-
-- **3 user-facing docs referenced unpublished `:latest-<variant>` tags**: `TEST.md:206`, `tests/e2e/README.md:197` both used `docker pull ghcr.io/jimmy058910/jmo-security:latest-full` (would fail with "manifest unknown" because `:latest-full` doesn't exist — `:latest` IS the deep variant). `docs/SCHEDULE_GUIDE.md:746` used `:latest-slim` in a GitLab CI example (would also fail; bare variant tag `:slim` is the canonical reference). All three corrected. New `tests/unit/test_docker_tag_pattern_drift.py` enforces this at PR time so future regressions are caught before merge — `.claude/rules/docker.rules.md` already documented the canonical schema, but documentation alone didn't catch these specific bugs.
-
-- **Docker Smoke Tests intermittent failures (50% flake rate)**: Hardened all binary downloads in `Dockerfile.{deep,balanced,slim,fast}` against transient CDN failures. The v1.0.3 cycle saw repeated `tar: Error is not recoverable: gzip: stdin: not in gzip format` build failures — `curl -sSL` exited 0 on HTTP 4xx/5xx with HTML body, handing garbage to `tar -xzf`. Each release cycle triggered ~50 single-attempt downloads (4 variants × 2 architectures × ~6-10 binaries each); even a 0.5% CDN flake rate produced at least one failure most cycles.
-  - **Root-cause flag**: All `curl` invocations now use `-fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600`. The `-f`/`--fail` flag is the actual fix — it makes curl exit non-zero on HTTP errors instead of accepting an HTML error page as the response body.
-  - **Retry on transient flakes**: All `wget` invocations now use `--tries=3 --waitretry=5 --timeout=600`. wget already exits non-zero on HTTP errors so no `--fail` equivalent is needed.
-  - **Integrity belt-and-suspenders**: Every archive extraction is now preceded by an integrity check — `gzip -t` for `.tar.gz`, `xz -t` for `.tar.xz`, `unzip -t` for `.zip`. Catches the rare case of "200 with corrupt body" (partial download, mid-stream truncation) that `--fail` cannot detect because the HTTP layer reported success.
-  - **Coverage**: 41 curl invocations + 9 wget invocations now hardened across all 4 Dockerfiles. 34 archive extractions now integrity-checked. Convention is documented in `.claude/rules/docker.rules.md` "Download Hardening Convention".
 
 ## [1.0.3] - 2026-04-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jmo-security"
-version = "1.0.3"
+version = "1.0.4"
 description = "JMo Security Audit Suite (terminal-first, multi-tool, unified outputs, multi-target scanning)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -46,7 +46,7 @@ from scripts.core.unicode_utils import (
 logger = logging.getLogger(__name__)
 
 # Version (from pyproject.toml)
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 
 def _merge_dict(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/cli/report_orchestrator.py
+++ b/scripts/cli/report_orchestrator.py
@@ -38,7 +38,7 @@ from scripts.core.telemetry import (
 logger = logging.getLogger(__name__)
 
 # Version (from pyproject.toml)
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 SEV_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]
 

--- a/scripts/cli/wizard.py
+++ b/scripts/cli/wizard.py
@@ -130,7 +130,7 @@ def _get_db_path() -> Path:
 
 
 # Version (from pyproject.toml)
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 # Standardized error message templates for tool issues
 # These provide consistent, actionable guidance for different failure scenarios

--- a/scripts/cli/wizard_generators.py
+++ b/scripts/cli/wizard_generators.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # Docker image configuration - use versioned tag for reproducibility
 # This should be updated with each release
 JMO_DOCKER_IMAGE = "ghcr.io/jimmy058910/jmo-security"
-JMO_DOCKER_TAG = "v1.0.3"  # Pin to release version, not :latest
+JMO_DOCKER_TAG = "v1.0.4"  # Pin to release version, not :latest
 JMO_DOCKER_IMAGE_FULL = f"{JMO_DOCKER_IMAGE}:{JMO_DOCKER_TAG}"
 
 

--- a/scripts/jmo_mcp/__init__.py
+++ b/scripts/jmo_mcp/__init__.py
@@ -18,5 +18,5 @@ Architecture:
 - Transport: stdio, HTTP, SSE
 """
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __all__ = ["jmo_server"]

--- a/tests/core/test_cli_validator.py
+++ b/tests/core/test_cli_validator.py
@@ -899,7 +899,7 @@ class TestVersionChecks:
             with open(pyproject_path, "rb") as f:
                 current_version = tomllib.load(f)["project"]["version"]
         else:
-            current_version = "1.0.3"  # fallback if pyproject not found in test context
+            current_version = "1.0.4"  # fallback if pyproject not found in test context
 
         with patch("scripts.core.validators.cli_validator._run_jmo") as mock_run:
             mock_run.return_value = _mock_completed(


### PR DESCRIPTION
## Summary

v1.0.4 is a CI/YAML architectural-rebuild release. Two big shippable items + cleanup:

1. **Dockerfile download hardening (PR #350) finally ships to GHCR images.** Every prior release (`:1.0.0` through `:1.0.3` and their variants) shipped with the broken single-attempt `curl -sSL` pattern that handed gzipped HTML error pages to `tar -xzf` on CDN flakes. ~50% Docker Smoke Tests flake rate is now zero (verified across 5 nightly dispatches in session 2).
2. **`coverage-aggregate` merge fix (PR #357).** The merge function has been a complete no-op since pytest-split was introduced — `hasattr(elem, '__iter__')` returns False for ElementTree Elements, so the for-loop body was silently skipped, and `coverage.xml` was always byte-identical to shard-1's. The threshold check was reading shard-1's coverage in isolation (~68-72%) instead of the true aggregate (~88%). Empirically verified by CI run `24974869235`: `📊 Aggregate: 18631/21227 lines covered = 87.77%` → `✅ Coverage 87.8% meets 70% CI threshold`. Threshold restored 68% → 70% (PR #355's band-aid removed).
3. **CI install hardening (PR #358).** Extends PR #350's convention from Dockerfiles to all 14 `curl <upstream>/install.sh | sh` invocations across `ci.yml`, `scheduled.yml`, `release.yml`. Pinned to `versions.yaml`.

Plus drift guards, hooks, and dead-weight removal — see CHANGELOG.

## Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | version `1.0.3` → `1.0.4` |
| `scripts/cli/jmo.py` | `__version__` |
| `scripts/cli/wizard.py` | `__version__` |
| `scripts/cli/report_orchestrator.py` | `__version__` |
| `scripts/jmo_mcp/__init__.py` | `__version__` |
| `scripts/cli/wizard_generators.py` | `JMO_DOCKER_TAG = "v1.0.4"` |
| `tests/core/test_cli_validator.py:902` | fallback version (defensive only) |
| `CHANGELOG.md` | rename `[Unreleased]` → `[1.0.4] - 2026-04-27`, consolidate duplicate Fixed sections |

## Test plan

- [x] All 8 file edits pass pre-commit (black, ruff, mypy, bandit, markdownlint, import-direction, toml-check)
- [x] Version literals consistent across all 5 modules + Docker tag + pyproject.toml
- [ ] CI on this PR (`quick-checks` + sharded tests + tool-contract-tests) confirms no regressions from version bump
- [ ] Aggregate Coverage continues to read ~88% (post-PR #357 merge state)
- [ ] After merge, tagging `v1.0.4` triggers `release.yml` to PyPI publish + 8 Docker builds + multi-arch merge

## After this merges

1. Tag the release: `git tag -a v1.0.4 -m "..." && git push origin v1.0.4`
2. Watch `release.yml` through all 3 phases (PyPI → Docker build × 8 → merge × 4 → scan/benchmark)
3. Post-release verify: `docker pull ghcr.io/jimmy058910/jmo-security:1.0.4-fast` and `pip install jmo-security==1.0.4`

## Cross-references

- Predecessor: PRs #357 (coverage merge fix) and #358 (CI install hardening) just merged to main
- Handoff: `dev-only/plans/2026-04-26-tasks-10-11-then-v1.0.4-handoff.md`
- v1.0.3 release pattern: PR #341 (canonical reference)