### PR TITLE
release: v1.0.5 — quick-wins-2 (MANUAL UX + maxfail rollup + 7 prior items)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to JMo Security will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-04-27
+
+### Summary
+
+Quality-of-life follow-up to v1.0.4's CI/YAML rebuild. Closes the 5 deferred items from the v1.0.4 release notes plus 4 new items surfaced during post-release verification, bundled across 2 PRs (#371 + #373). No new features — every change improves a rough edge: clearer `jmo tools check` output (manual-install tools now distinct from missing), faster bug-archeology cycles in nightly tests (`--maxfail` 5→20 + `$GITHUB_STEP_SUMMARY` failure rollup), accurate aggregate branch coverage (completes PR #357's scope-limit), fixed `Performance Benchmarks` job missing `pytest-benchmark` dep, atomic version sync across `Dockerfiles` + workflows, and removal of the deprecated `:full` Docker tag alias.
+
 ### Changed
 
 - **`jmo tools check` now distinguishes manual-install tools from genuinely missing tools across all output paths**: 4 tools in `PROFILE_TOOLS["deep"]` (`afl++`, `mobsf`, `akto`, `falco`) are intentionally NOT in the auto-install set — they require manual installation due to platform/size constraints (documented in `docs/MANUAL_INSTALLATION.md`). Pre-fix, every `jmo tools check` invocation lumped these in the red "7 tool(s) missing" line, conflating "you forgot to install this" with "this is expected to be absent in containerized usage". Now:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jmo-security"
-version = "1.0.4"
+version = "1.0.5"
 description = "JMo Security Audit Suite (terminal-first, multi-tool, unified outputs, multi-target scanning)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -46,7 +46,7 @@ from scripts.core.unicode_utils import (
 logger = logging.getLogger(__name__)
 
 # Version (from pyproject.toml)
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 
 def _merge_dict(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/cli/report_orchestrator.py
+++ b/scripts/cli/report_orchestrator.py
@@ -38,7 +38,7 @@ from scripts.core.telemetry import (
 logger = logging.getLogger(__name__)
 
 # Version (from pyproject.toml)
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 SEV_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]
 

--- a/scripts/cli/wizard.py
+++ b/scripts/cli/wizard.py
@@ -130,7 +130,7 @@ def _get_db_path() -> Path:
 
 
 # Version (from pyproject.toml)
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 # Standardized error message templates for tool issues
 # These provide consistent, actionable guidance for different failure scenarios

--- a/scripts/cli/wizard_generators.py
+++ b/scripts/cli/wizard_generators.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # Docker image configuration - use versioned tag for reproducibility
 # This should be updated with each release
 JMO_DOCKER_IMAGE = "ghcr.io/jimmy058910/jmo-security"
-JMO_DOCKER_TAG = "v1.0.4"  # Pin to release version, not :latest
+JMO_DOCKER_TAG = "v1.0.5"  # Pin to release version, not :latest
 JMO_DOCKER_IMAGE_FULL = f"{JMO_DOCKER_IMAGE}:{JMO_DOCKER_TAG}"
 
 

--- a/scripts/jmo_mcp/__init__.py
+++ b/scripts/jmo_mcp/__init__.py
@@ -18,5 +18,5 @@ Architecture:
 - Transport: stdio, HTTP, SSE
 """
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 __all__ = ["jmo_server"]

--- a/tests/core/test_cli_validator.py
+++ b/tests/core/test_cli_validator.py
@@ -899,7 +899,7 @@ class TestVersionChecks:
             with open(pyproject_path, "rb") as f:
                 current_version = tomllib.load(f)["project"]["version"]
         else:
-            current_version = "1.0.4"  # fallback if pyproject not found in test context
+            current_version = "1.0.5"  # fallback if pyproject not found in test context
 
         with patch("scripts.core.validators.cli_validator._run_jmo") as mock_run:
             mock_run.return_value = _mock_completed(


### PR DESCRIPTION
## Summary

Bumps \`pyproject.toml\` 1.0.4 → 1.0.5 and finalizes the [Unreleased] block as [1.0.5] - 2026-04-27. Tagging v1.0.5 after this merges will trigger \`release.yml\` to rebuild Docker images with v1.0.4's CI install hardening (PR #358) carried forward as the new baseline.

## Content

v1.0.5 packages 9 changes across 2 PRs (#371 + #373):

| Category | Item | Source |
|----------|------|--------|
| Changed | \`jmo tools check\` distinguishes MANUAL from MISSING (all output paths) | PR #373 |
| Fixed | Windows perf-test flakes (skipif pattern → broader \`-m \"not slow\"\` filter) | #362 / #371 |
| Fixed | \`pytest-benchmark\` missing dev dep — Performance Benchmarks job restored | PR #361 |
| Fixed | Branch coverage in \`coverage-aggregate\` merge (completes #357 scope) | PR #371 |
| Removed | \`:full\` Docker tag alias removed (1-release deprecation cushion ended) | PR #371 |
| Internal | \`update_versions.py --sync\` now extends to workflow \`env:\` blocks | PR #371 |
| Internal | \`nightly-cross-platform\` filter \`-m \"not slow\"\` (broader pattern) | PR #371 |
| Internal | Stale \`0.4.0\` example refresh in \`docs/RELEASE.md\` | PR #371 |
| Internal | \`--maxfail\` 5→20 on big-suite Nightly jobs + \`\$GITHUB_STEP_SUMMARY\` rollup | PR #373 |

## Files bumped (per PR #360 canonical list)

- \`pyproject.toml:7\` — \`version = \"1.0.5\"\`
- \`scripts/cli/jmo.py:49\` — \`__version__ = \"1.0.5\"\`
- \`scripts/cli/wizard.py:133\` — \`__version__ = \"1.0.5\"\`
- \`scripts/cli/report_orchestrator.py:41\` — \`__version__ = \"1.0.5\"\`
- \`scripts/jmo_mcp/__init__.py:21\` — \`__version__ = \"1.0.5\"\`
- \`scripts/cli/wizard_generators.py:23\` — \`JMO_DOCKER_TAG = \"v1.0.5\"\`
- \`tests/core/test_cli_validator.py:902\` — fallback string
- \`CHANGELOG.md\` — \`## [Unreleased]\` → \`## [1.0.5] - 2026-04-27\` + Summary section

## Out of scope (intentional, follow PR #370 precedent)

- \`CLAUDE.md\` \"Version\" field bump → happens in a follow-up \"docs(claude)\" PR after the tag is published, since CLAUDE.md tracks \"latest released\" not \"latest about-to-tag\".
- \`docs/RELEASE.md\` 1.0.4 example → the parenthetical \"(substitute the version you just tagged)\" hint added in PR #371 covers the staleness by design.

## Test plan

- [x] All version anchors bumped uniformly (grep \`1.0.4\` cross-checked vs PR #360 list).
- [x] Pre-commit clean (Black, Ruff, mypy, Bandit, markdownlint, doc-links, import-direction, check-toml).
- [x] \`tests/core/test_cli_validator.py\` 82/82 pass after fallback bump.
- [ ] CI sharded tests pass.
- [ ] After merge: \`git tag -a v1.0.5 -m \"...\" && git push origin v1.0.5\` triggers release.yml.
- [ ] Verify all release jobs green (target: 22/22 + 8/8 Docker like v1.0.4 — first-ever clean release).