### PR TITLE
fix(docker): convert all 9 wget downloads to hardened curl

### DIFF
--- a/.claude/rules/docker.rules.md
+++ b/.claude/rules/docker.rules.md
@@ -87,13 +87,7 @@ curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --m
 | `--connect-timeout 30` | Bound DNS / TCP-handshake hangs. |
 | `--max-time 600` | Hard ceiling on total request time (10 min for slow CDNs). |
 
-**wget** (every invocation):
-
-```dockerfile
-wget -q --tries=3 --waitretry=5 --timeout=600 "$URL" -O /path
-```
-
-wget already exits non-zero on HTTP errors, so no `--fail` equivalent is needed.
+**Do not use wget for new downloads.** wget exits non-zero on HTTP errors but **does NOT retry on them by default** — `--tries=N` only covers connection failures. To get curl-equivalent behavior with wget, you'd need `--retry-on-http-error=429,500,502,503,504`, which is easy to forget. The post-v1.0.5 nightly cycle hit this when nuclei's release URL returned a transient HTTP error: `wget --tries=3` did not retry, the build failed, and curl with `--retry-all-errors` would have recovered. PR #350 hardened all `curl` calls but missed 9 `wget` invocations spanning nuclei / ZAP / dependency-check across all 4 Dockerfiles; the follow-up PR converts every download to the curl pattern above and adds `tests/unit/test_dockerfile_download_hardening.py` as a drift guard against re-introducing wget in builder stages.
 
 **Integrity check** (mandatory before extracting an archive — belt-and-suspenders for "200 with corrupt body" that even `--fail` can miss):
 

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -54,8 +54,8 @@ RUN HADOLINT_VERSION="2.14.0" && \
 
 # Download OWASP ZAP (DAST)
 RUN ZAP_VERSION="2.16.1" && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/zaproxy/zaproxy/releases/download/v${ZAP_VERSION}/ZAP_${ZAP_VERSION}_Linux.tar.gz" \
-    -O /tmp/zap.tar.gz && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/zaproxy/zaproxy/releases/download/v${ZAP_VERSION}/ZAP_${ZAP_VERSION}_Linux.tar.gz" \
+    -o /tmp/zap.tar.gz && \
     gzip -t /tmp/zap.tar.gz && \
     tar -xzf /tmp/zap.tar.gz -C /opt && \
     mv /opt/ZAP_${ZAP_VERSION} /opt/zaproxy
@@ -64,8 +64,8 @@ RUN ZAP_VERSION="2.16.1" && \
 RUN NUCLEI_VERSION="3.7.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
-    -O /tmp/nuclei.zip && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
+    -o /tmp/nuclei.zip && \
     unzip -t /tmp/nuclei.zip > /dev/null && \
     unzip -q /tmp/nuclei.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/nuclei && \
@@ -104,8 +104,8 @@ RUN GRYPE_VERSION="0.104.0" && \
 
 # Download OWASP Dependency-Check (SCA + License)
 RUN DC_VERSION="12.1.0" && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/jeremylong/DependencyCheck/releases/download/v${DC_VERSION}/dependency-check-${DC_VERSION}-release.zip" \
-    -O /tmp/dependency-check.zip && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/jeremylong/DependencyCheck/releases/download/v${DC_VERSION}/dependency-check-${DC_VERSION}-release.zip" \
+    -o /tmp/dependency-check.zip && \
     unzip -t /tmp/dependency-check.zip > /dev/null && \
     unzip -q /tmp/dependency-check.zip -d /opt && \
     mv /opt/dependency-check /opt/dependency-check-cli && \

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -84,8 +84,8 @@ RUN NP_VERSION="0.24.0" && \
 
 # Download OWASP ZAP (DAST)
 RUN ZAP_VERSION="2.16.1" && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/zaproxy/zaproxy/releases/download/v${ZAP_VERSION}/ZAP_${ZAP_VERSION}_Linux.tar.gz" \
-    -O /tmp/zap.tar.gz && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/zaproxy/zaproxy/releases/download/v${ZAP_VERSION}/ZAP_${ZAP_VERSION}_Linux.tar.gz" \
+    -o /tmp/zap.tar.gz && \
     gzip -t /tmp/zap.tar.gz && \
     tar -xzf /tmp/zap.tar.gz -C /opt && \
     mv /opt/ZAP_${ZAP_VERSION} /opt/zaproxy
@@ -94,8 +94,8 @@ RUN ZAP_VERSION="2.16.1" && \
 RUN NUCLEI_VERSION="3.7.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
-    -O /tmp/nuclei.zip && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
+    -o /tmp/nuclei.zip && \
     unzip -t /tmp/nuclei.zip > /dev/null && \
     unzip -q /tmp/nuclei.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/nuclei && \
@@ -148,8 +148,8 @@ RUN LYNIS_VERSION="3.1.3" && \
 
 # Download OWASP Dependency-Check (SCA + License)
 RUN DC_VERSION="12.1.0" && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/jeremylong/DependencyCheck/releases/download/v${DC_VERSION}/dependency-check-${DC_VERSION}-release.zip" \
-    -O /tmp/dependency-check.zip && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/jeremylong/DependencyCheck/releases/download/v${DC_VERSION}/dependency-check-${DC_VERSION}-release.zip" \
+    -o /tmp/dependency-check.zip && \
     unzip -t /tmp/dependency-check.zip > /dev/null && \
     unzip -q /tmp/dependency-check.zip -d /opt && \
     mv /opt/dependency-check /opt/dependency-check-cli && \

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -56,8 +56,8 @@ RUN HADOLINT_VERSION="2.14.0" && \
 RUN NUCLEI_VERSION="3.7.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
-    -O /tmp/nuclei.zip && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
+    -o /tmp/nuclei.zip && \
     unzip -t /tmp/nuclei.zip > /dev/null && \
     unzip -q /tmp/nuclei.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/nuclei && \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -56,8 +56,8 @@ RUN HADOLINT_VERSION="2.14.0" && \
 RUN NUCLEI_VERSION="3.7.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
-    -O /tmp/nuclei.zip && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
+    -o /tmp/nuclei.zip && \
     unzip -t /tmp/nuclei.zip > /dev/null && \
     unzip -q /tmp/nuclei.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/nuclei && \
@@ -83,8 +83,8 @@ RUN GRYPE_VERSION="0.104.0" && \
 
 # Download Dependency-Check (License + SCA)
 RUN DC_VERSION="12.1.0" && \
-    wget -q --tries=3 --waitretry=5 --timeout=600 "https://github.com/jeremylong/DependencyCheck/releases/download/v${DC_VERSION}/dependency-check-${DC_VERSION}-release.zip" \
-    -O /tmp/dependency-check.zip && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/jeremylong/DependencyCheck/releases/download/v${DC_VERSION}/dependency-check-${DC_VERSION}-release.zip" \
+    -o /tmp/dependency-check.zip && \
     unzip -t /tmp/dependency-check.zip > /dev/null && \
     unzip -q /tmp/dependency-check.zip -d /opt && \
     mv /opt/dependency-check /opt/dependency-check-cli && \

--- a/tests/unit/test_dockerfile_download_hardening.py
+++ b/tests/unit/test_dockerfile_download_hardening.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Drift guard: every binary download in `Dockerfile.*` builder stages must use curl.
+
+PR #350 hardened all curl invocations with `-f --retry --retry-all-errors --max-time`,
+but missed 9 wget invocations across nuclei / ZAP / dependency-check in all 4
+Dockerfiles. The post-v1.0.5 nightly Docker Smoke Tests then failed when nuclei's
+release URL returned a transient HTTP error and `wget --tries=3` didn't retry on
+HTTP errors (wget retries connection failures only by default).
+
+Standardizing on the curl pattern documented in `.claude/rules/docker.rules.md`
+gives uniform retry-on-any-error behavior. This test enforces that.
+
+Allowed:
+  - `wget` in the apt-get install lines (we keep it available as a builder tool
+    even though no download currently uses it — removing it is a separate concern).
+  - `wget` in comments.
+  - `wget` in test fixtures (`tests/e2e/fixtures/iac/Dockerfile.bad`,
+    `tests/fixtures/samples/dockerfile-issues/Dockerfile`) which are intentional
+    bad-Dockerfile examples.
+
+Forbidden:
+  - `wget` actually invoking a URL — `wget URL`, `wget -q URL`, etc.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Match a wget download invocation: `wget` followed by flags then a URL or
+# variable-quoted URL. Matches at start-of-line or after `&&`/`;`/whitespace.
+# Excludes the apt-get continuation line (which is just `    wget \`).
+WGET_DOWNLOAD_PATTERN = re.compile(
+    r"""
+    (?:^|\s|&&|;)         # boundary
+    wget                  # the command
+    \s+                   # at least one space
+    (?:-\S+\s+)*          # zero or more short/long flags
+    ["']?https?://        # URL (quoted or bare)
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+def _production_dockerfiles() -> list[Path]:
+    """Dockerfile.* files in repo root that ship in releases."""
+    return sorted(p for p in REPO_ROOT.glob("Dockerfile.*") if p.is_file())
+
+
+def test_no_wget_downloads_in_production_dockerfiles() -> None:
+    """No `wget URL` invocation may appear in any production Dockerfile.
+
+    All binary downloads must use the hardened curl pattern in
+    `.claude/rules/docker.rules.md`. wget retries connection failures only
+    and silently fails on transient HTTP 4xx/5xx; curl with
+    `--retry-all-errors` recovers.
+    """
+    violations: list[str] = []
+    for path in _production_dockerfiles():
+        text = path.read_text(encoding="utf-8")
+        for match in WGET_DOWNLOAD_PATTERN.finditer(text):
+            line_num = text[: match.start()].count("\n") + 1
+            line = text.splitlines()[line_num - 1].strip()
+            violations.append(f"{path.name}:{line_num} - {line}")
+
+    assert not violations, (
+        "Found wget invocations downloading from a URL. Use the hardened curl "
+        "pattern instead:\n"
+        "  curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "
+        '--connect-timeout 30 --max-time 600 "$URL" -o /path\n'
+        "Reason: wget --tries=N retries connection failures only, not HTTP "
+        "4xx/5xx errors. See .claude/rules/docker.rules.md 'Download Hardening "
+        "Convention'.\n"
+        "Violations:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_drift_guard_finds_a_real_wget_download_when_planted() -> None:
+    """Sanity check: the regex actually matches a known-bad pattern.
+
+    Without this, a regex bug could silently pass the main test forever.
+    """
+    sample = (
+        'RUN NUCLEI_VERSION="3.7.0" && \\\n'
+        "    wget -q --tries=3 --waitretry=5 --timeout=600 "
+        '"https://github.com/projectdiscovery/nuclei/releases/download/'
+        'v${NUCLEI_VERSION}/nuclei.zip" -O /tmp/nuclei.zip\n'
+    )
+    assert WGET_DOWNLOAD_PATTERN.search(sample) is not None, (
+        "Drift-guard regex failed to match a known-bad wget download line. "
+        "The main test would silently pass even with violations present."
+    )
+
+
+def test_drift_guard_ignores_apt_install_wget() -> None:
+    """The apt-get install continuation line `    wget \\` must NOT match.
+
+    Otherwise we'd flag every Dockerfile's build-deps install as a violation.
+    """
+    sample = (
+        "RUN apt-get update && apt-get install -y --no-install-recommends \\\n"
+        "    curl \\\n"
+        "    wget \\\n"
+        "    unzip \\\n"
+        "    && rm -rf /var/lib/apt/lists/*\n"
+    )
+    assert WGET_DOWNLOAD_PATTERN.search(sample) is None, (
+        "Drift-guard regex incorrectly matches the apt-install continuation "
+        "line. It must only match wget invocations followed by a URL."
+    )


### PR DESCRIPTION
## Summary

Last night's nightly Docker Smoke Tests failed in `Dockerfile.balanced` building nuclei: `wget` got HTTP error exit code 8 with no retry (run [25088968284](https://github.com/jimmy058910/jmo-security-repo/actions/runs/25088968284)).

**Root cause:** PR #350 ("harden all Dockerfile downloads") hardened every `curl` invocation with `--retry-all-errors` but missed 9 `wget` invocations — nuclei (×4 Dockerfiles), ZAP (×2), dependency-check (×3). `wget --tries=3` only retries connection failures by default; it does NOT retry on HTTP 4xx/5xx without `--retry-on-http-error=429,500,502,503,504`. curl with `--retry-all-errors` would have recovered from the transient error.

**Why this didn't surface in v1.0.4 / v1.0.5 release pipelines:** release.yml runs build-on-push with cached layers and tighter timing windows. Daily nightly fresh-builds with no cache are exactly the harness designed to catch this kind of CDN flake.

## Changes

- **9 wget→curl conversions** across all 4 Dockerfiles using the proven pattern (`Dockerfile.fast`, `.slim`, `.balanced`, `.deep`):
  ```dockerfile
  curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "$URL" -o /path
  ```
- **`.claude/rules/docker.rules.md`** — corrected the misleading "wget already exits non-zero on HTTP errors, so no `--fail` equivalent is needed" line (technically true, actively misleading because it omits the retry gap). Replaced with "Do not use wget for new downloads" + explanation.
- **`tests/unit/test_dockerfile_download_hardening.py`** — new drift guard that fails CI if any `wget URL` invocation re-appears in production Dockerfiles. Includes positive-match sanity test (regex must catch a known-bad pattern) and negative-match test (must NOT flag the apt-install continuation line).

## Test plan

- [x] All 3 new drift-guard tests pass locally
- [x] Existing `test_docker_tag_pattern_drift.py` still passes (sibling drift guard)
- [x] Pre-commit clean (black, ruff, mypy, bandit, markdownlint)
- [ ] CI green on this PR (full suite)
- [ ] Post-merge: dispatch nightly via `gh workflow run scheduled.yml --ref main -f task=nightly` to confirm Docker Smoke Tests passes against the hardened images

## Scope discipline

6 files exactly: 4 Dockerfile edits + 1 rules-doc fix + 1 new test. No version bump needed — existing GHCR images already have nuclei baked in (built when the download succeeded). This only fixes nightly fresh-builds and the next release's image rebuild.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Docker image builds with improved artifact download reliability through stricter error handling, explicit retry logic, and connection timeouts.

* **Documentation**
  * Updated download hardening guidelines to reflect new standards for secure and reliable artifact acquisition.

* **Tests**
  * Added automated drift guard tests to maintain strict download hardening practices across Docker configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->