### PR TITLE
JMOAA-40: Unified docs strategy — v1.0.5 alignment, nav expansion, SEO meta

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,19 +116,19 @@ repos:
         language: system
         types: [python]
         files: ^scripts/(core|jmo_mcp)/
-        entry: python scripts/dev/check_import_direction.py
+        entry: python3 scripts/dev/check_import_direction.py
         pass_filenames: false
       - id: doc-links
         name: doc-links (validate documentation links)
         language: system
         files: ^(CLAUDE\.md|docs/)
-        entry: python scripts/dev/check_doc_links.py
+        entry: python3 scripts/dev/check_doc_links.py
         pass_filenames: false
       - id: yaml-env-tilde
         name: "yaml-env-tilde (no literal ~/ in workflow env blocks)"
         language: system
         files: ^\.github/(workflows|actions)/.*\.ya?ml$
-        entry: python scripts/dev/check_yaml_env_tilde.py
+        entry: python3 scripts/dev/check_yaml_env_tilde.py
         pass_filenames: false
 
   # Local hook: keep requirements-dev.txt fresh when requirements-dev.in changes

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,4 +189,4 @@ JMo Security orchestrates 28 security scanners across 11 categories:
 
 ---
 
-**Last Updated:** April 2026 | **JMo Security v1.0.1**
+**Last Updated:** April 2026 | **JMo Security v1.0.5**

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,7 +12,7 @@ repo_url: https://github.com/jimmy058910/jmo-security-repo
 edit_uri: edit/main/docs/
 
 # Copyright
-copyright: Copyright &copy; 2024-2025 JMo Gaming LLC
+copyright: Copyright &copy; 2024-2026 JMo Gaming LLC
 
 # Theme
 theme:
@@ -60,9 +60,26 @@ markdown_extensions:
 # Navigation structure
 nav:
   - Home: index.md
-  - User Guide: USER_GUIDE.md
-  - Docker Guide: DOCKER_README.md
-  - Schedule Guide: SCHEDULE_GUIDE.md
+  - Getting Started:
+      - User Guide: USER_GUIDE.md
+      - Docker Guide: DOCKER_README.md
+      - Installation: MANUAL_INSTALLATION.md
+      - FAQ: FAQ.md
+  - Scanning:
+      - Profiles and Tools: PROFILES_AND_TOOLS.md
+      - Scan Optimization: SCAN_OPTIMIZATION.md
+      - Results Guide: RESULTS_GUIDE.md
+      - Diff Guide: DIFF_GUIDE.md
+      - Trends Guide: TRENDS_GUIDE.md
+      - History Guide: HISTORY_GUIDE.md
+      - Schedule Guide: SCHEDULE_GUIDE.md
+  - Compliance & Policy:
+      - Policy-as-Code: POLICY_AS_CODE.md
+      - SLSA Attestation: SLSA_GUIDE.md
+  - Integrations:
+      - MCP / AI Remediation: MCP_SETUP.md
+      - Claude Code: integrations/CLAUDE_CODE.md
+      - GitHub Copilot: integrations/GITHUB_COPILOT.md
   - Examples:
       - Overview: examples/README.md
       - Wizard Examples: examples/wizard-examples.md
@@ -71,6 +88,7 @@ nav:
       - Version Management: VERSION_MANAGEMENT.md
       - Telemetry: TELEMETRY.md
       - Release Process: RELEASE.md
+      - Troubleshooting: TROUBLESHOOTING.md
 
 # Plugins
 plugins:
@@ -79,12 +97,29 @@ plugins:
 # Extra
 extra:
   social:
+    - icon: fontawesome/solid/house
+      link: https://jmotools.com
+      name: JMo Security home
     - icon: fontawesome/brands/github
       link: https://github.com/jimmy058910
+      name: GitHub
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/jmosecurity
+      name: X/Twitter
     - icon: fontawesome/solid/paper-plane
       link: https://jmotools.com/subscribe.html
+      name: Subscribe
+    - icon: fontawesome/solid/blog
+      link: https://blog.jmotools.com
+      name: Blog
+  meta:
+    - name: keywords
+      content: >-
+        security scanner, SAST, DAST, SCA, secrets detection, compliance automation,
+        OWASP, NIST CSF, CIS, PCI DSS, MITRE ATT&CK, open source,
+        DevSecOps, CI/CD, Python, jmo-security, 28 scanners
+    - name: author
+      content: "JMo Gaming LLC"
   analytics:
     provider: google
     property: !ENV GOOGLE_ANALYTICS_KEY


### PR DESCRIPTION
## Summary

Updates docs.jmotools.com configuration and content as part of the unified documentation strategy ([JMOAA-40](/JMOAA/issues/JMOAA-40)). Brings version strings to v1.0.5, expands the MkDocs navigation to surface 10+ previously unreachable docs pages, adds SEO meta keywords, links all three properties in the footer, and fixes a pre-commit hook python→python3 issue that blocked commits on this WSL environment.

## Files Changed

- `docs/index.md` — version string v1.0.1 → v1.0.5
- `docs/mkdocs.yml` — copyright 2024-2025 → 2024-2026; expanded nav (MANUAL_INSTALLATION, PROFILES_AND_TOOLS, SCAN_OPTIMIZATION, POLICY_AS_CODE, MCP_SETUP, integrations, TROUBLESHOOTING); SEO meta keywords; cross-property social links (jmotools.com, blog.jmotools.com)
- `.pre-commit-config.yaml` — fix `python` → `python3` in doc-links, import-direction, yaml-env-tilde hooks

## Paperclip

- Issue: [JMOAA-40](/JMOAA/issues/JMOAA-40)
- Agent: Marketing Manager
- Company: Security Suite

## Testing

- All pre-commit hooks pass (yamllint, markdownlint, doc-links, import-direction)
- MkDocs nav references verified against existing files in `docs/`
- Version string updated in only one location (footer of index.md)