### PR TITLE
Sync: dev → main (JMOAA-40 docs alignment)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,19 +116,19 @@ repos:
         language: system
         types: [python]
         files: ^scripts/(core|jmo_mcp)/
-        entry: python scripts/dev/check_import_direction.py
+        entry: python3 scripts/dev/check_import_direction.py
         pass_filenames: false
       - id: doc-links
         name: doc-links (validate documentation links)
         language: system
         files: ^(CLAUDE\.md|docs/)
-        entry: python scripts/dev/check_doc_links.py
+        entry: python3 scripts/dev/check_doc_links.py
         pass_filenames: false
       - id: yaml-env-tilde
         name: "yaml-env-tilde (no literal ~/ in workflow env blocks)"
         language: system
         files: ^\.github/(workflows|actions)/.*\.ya?ml$
-        entry: python scripts/dev/check_yaml_env_tilde.py
+        entry: python3 scripts/dev/check_yaml_env_tilde.py
         pass_filenames: false
 
   # Local hook: keep requirements-dev.txt fresh when requirements-dev.in changes

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,4 +189,4 @@ JMo Security orchestrates 28 security scanners across 11 categories:
 
 ---
 
-**Last Updated:** April 2026 | **JMo Security v1.0.1**
+**Last Updated:** April 2026 | **JMo Security v1.0.5**

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,7 +12,7 @@ repo_url: https://github.com/jimmy058910/jmo-security-repo
 edit_uri: edit/main/docs/
 
 # Copyright
-copyright: Copyright &copy; 2024-2025 JMo Gaming LLC
+copyright: Copyright &copy; 2024-2026 JMo Gaming LLC
 
 # Theme
 theme:
@@ -60,9 +60,26 @@ markdown_extensions:
 # Navigation structure
 nav:
   - Home: index.md
-  - User Guide: USER_GUIDE.md
-  - Docker Guide: DOCKER_README.md
-  - Schedule Guide: SCHEDULE_GUIDE.md
+  - Getting Started:
+      - User Guide: USER_GUIDE.md
+      - Docker Guide: DOCKER_README.md
+      - Installation: MANUAL_INSTALLATION.md
+      - FAQ: FAQ.md
+  - Scanning:
+      - Profiles and Tools: PROFILES_AND_TOOLS.md
+      - Scan Optimization: SCAN_OPTIMIZATION.md
+      - Results Guide: RESULTS_GUIDE.md
+      - Diff Guide: DIFF_GUIDE.md
+      - Trends Guide: TRENDS_GUIDE.md
+      - History Guide: HISTORY_GUIDE.md
+      - Schedule Guide: SCHEDULE_GUIDE.md
+  - Compliance & Policy:
+      - Policy-as-Code: POLICY_AS_CODE.md
+      - SLSA Attestation: SLSA_GUIDE.md
+  - Integrations:
+      - MCP / AI Remediation: MCP_SETUP.md
+      - Claude Code: integrations/CLAUDE_CODE.md
+      - GitHub Copilot: integrations/GITHUB_COPILOT.md
   - Examples:
       - Overview: examples/README.md
       - Wizard Examples: examples/wizard-examples.md
@@ -71,6 +88,7 @@ nav:
       - Version Management: VERSION_MANAGEMENT.md
       - Telemetry: TELEMETRY.md
       - Release Process: RELEASE.md
+      - Troubleshooting: TROUBLESHOOTING.md
 
 # Plugins
 plugins:
@@ -79,12 +97,29 @@ plugins:
 # Extra
 extra:
   social:
+    - icon: fontawesome/solid/house
+      link: https://jmotools.com
+      name: JMo Security home
     - icon: fontawesome/brands/github
       link: https://github.com/jimmy058910
+      name: GitHub
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/jmosecurity
+      name: X/Twitter
     - icon: fontawesome/solid/paper-plane
       link: https://jmotools.com/subscribe.html
+      name: Subscribe
+    - icon: fontawesome/solid/blog
+      link: https://blog.jmotools.com
+      name: Blog
+  meta:
+    - name: keywords
+      content: >-
+        security scanner, SAST, DAST, SCA, secrets detection, compliance automation,
+        OWASP, NIST CSF, CIS, PCI DSS, MITRE ATT&CK, open source,
+        DevSecOps, CI/CD, Python, jmo-security, 28 scanners
+    - name: author
+      content: "JMo Gaming LLC"
   analytics:
     provider: google
     property: !ENV GOOGLE_ANALYTICS_KEY


### PR DESCRIPTION
## Sync `dev` → `main` — JMOAA-40 docs PR landed on wrong base

Fast-forward PR to ship the [JMOAA-40](https://github.com/jimmy058910/jmo-security-repo/pull/378) docs work to `main`. PR #378 was merged into `dev` instead of `main`, leaving `dev` 1 commit ahead and ReadTheDocs (which builds from `main`) without the v1.0.5 nav, SEO meta, and footer cross-links.

## Single commit included

- `e5dcd8e docs: v1.0.5 alignment, nav expansion, SEO meta (JMOAA-40)` (squash from PR #378)
  - `docs/index.md` — `v1.0.1` → `v1.0.5`
  - `docs/mkdocs.yml` — copyright year, expanded nav (22 surfaced pages), SEO meta keywords + author, footer cross-property links
  - `.pre-commit-config.yaml` — `python` → `python3` for 3 hooks

## Why this is fast-forward only

```
git rev-list --count origin/main..origin/dev → 1
git rev-list --count origin/dev..origin/main → 0
```

Pure ff. No diverging commits on `main`.

## Acceptance

- [ ] All required CI checks green
- [ ] Merge brings `main` to e5dcd8e
- [ ] ReadTheDocs rebuild kicks (verified via docs.jmotools.com `last-modified` header refresh)
- [ ] `dev` and `main` realigned post-merge

## Project policy reference

[`.claude/rules/release.rules.md`](.claude/rules/release.rules.md): _"Hotfix to main: Must go through a PR (GitHub rulesets enforce `quick-checks`). Cannot push directly."_ — this PR satisfies that rule.

## Paperclip

CEO authorized via [JMOAA-40](https://app.paperclip.ing/JMOAA/issues/JMOAA-40).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated to v1.0.5.
  * Reorganized documentation structure with new sections: Getting Started, Scanning, Compliance & Policy, and Integrations.
  * Added new guide pages for installation, FAQ, scan optimization, and troubleshooting.

* **Chores**
  * Updated build tools configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->