### PR TITLE
fix(tests): time-bomb fixture in test_get_compliance_trend (Windows nightly)

### DIFF
--- a/tests/unit/test_history_db_future_integrations.py
+++ b/tests/unit/test_history_db_future_integrations.py
@@ -62,7 +62,14 @@ def db_with_sample_scans(temp_db):
 
     scan_ids = []
     current_time = int(time.time())  # Capture current time for consistent mocking
-    base_time = current_time - (30 * 86400)  # 30 days ago
+    # 28 days, NOT 30 — `test_get_compliance_trend` queries with `days=30`, and the
+    # production code at history_db.py:3232-3234 captures its own `time.time()` when
+    # the query runs. Any elapsed time between fixture init (these inserts) and the
+    # query (test body) advances the cutoff, evicting a scan placed exactly at
+    # `current_time - 30d`. Windows GHA runners are slow enough that this races
+    # deterministically (failure surface: nightly Scheduled Tests, run 25242314516).
+    # 2-day safety margin keeps all 5 scans (28/21/14/7/0 days ago) inside `days=30`.
+    base_time = current_time - (28 * 86400)
 
     for i in range(5):
         # Create scan metadata


### PR DESCRIPTION
## Summary

Nightly Scheduled Tests (run [25242314516](https://github.com/jimmy058910/jmo-security-repo/actions/runs/25242314516), Windows 3.12) failed with a single test:

\`\`\`
FAILED tests/unit/test_history_db_future_integrations.py::TestComplianceHelpers::test_get_compliance_trend
AssertionError: assert 4 == 5
\`\`\`

**Root cause: race between fixture clock and query clock.**

The fixture \`db_with_sample_scans\` (line 65) inserts the oldest scan at exactly \`current_time - (30 * 86400)\`, then the test calls \`get_compliance_trend(..., days=30)\`. The production code at \`history_db.py:3232-3234\` captures its own \`int(time.time())\` when the query runs:

\`\`\`python
end_time = int(time.time())              # query 'now', AFTER fixture setup
start_time = end_time - (days * 86400)   # cutoff has advanced past fixture_now - 30d
WHERE timestamp >= start_time AND timestamp <= end_time
\`\`\`

The boundary scan (scan-0000) ends up at \`fixture_now - 30d\`, but the query window starts at \`query_now - 30d > fixture_now - 30d\` — so scan-0000 is evicted.

Why Windows 3.12 specifically: slower GHA runner + nightly explicitly disables \`pytest-rerunfailures\` (\`-p no:rerunfailures\` to prevent the xdist deadlock documented in \`testing.cross-platform.rules.md\`), so a single race-loss now fails the run rather than silently retrying.

Why this *just started* failing: 4 successive nightlies passed (4/29 → 5/1) before today's deterministic miss. The race was always there — Windows 3.12 timing finally crossed the threshold consistently.

## Fix

\`\`\`diff
-    base_time = current_time - (30 * 86400)  # 30 days ago
+    base_time = current_time - (28 * 86400)  # 2-day safety margin
\`\`\`

All 5 scans now land at 28/21/14/7/0 days ago — comfortably inside the \`days=30\` query window with margin for fixture+test execution time on the slowest runner.

Added comment in the fixture explains the constraint so a future contributor doesn't 'fix' it back to 30.

## Scope discipline

- **One file, ~8 lines changed.** No test logic touched, only the fixture base_time + comment.
- **Sibling fixture \`db_with_recurring_findings\` (line 169) NOT touched** — it has the same \`60 * 86400\` boundary, but \`get_recurring_findings\` has no time-window query, so no time-bomb risk. (Verified.)
- **Production code untouched.** \`get_compliance_trend\` is correct as-is; the bug was in the fixture's choice of boundary value.

## Test plan

- [x] Local: \`pytest tests/unit/test_history_db_future_integrations.py -v\` → 21 passed in 1.00s
- [x] Pre-commit clean (black, ruff, mypy, bandit)
- [ ] CI green on this PR
- [ ] Post-merge: dispatch nightly via \`gh workflow run scheduled.yml --ref main -f task=nightly\` and confirm Windows 3.12 cross-platform tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by addressing timing issues in compliance trend testing that could cause intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->