### PR TITLE
JMOAA-50: Add github-release job to release.yml + backfill workflow for v1.0.0–v1.0.5

### DIFF
--- a/.github/workflows/backfill-github-releases.yml
+++ b/.github/workflows/backfill-github-releases.yml
@@ -1,0 +1,51 @@
+---
+name: Backfill GitHub Releases (one-shot)
+# Run once after JMOAA-50 merges to create Releases for v1.0.0–v1.0.5.
+# Safe to re-run: skips any tag that already has a GitHub Release.
+# Archive or delete this workflow after all 6 releases are confirmed.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    name: Backfill v1.0.0–v1.0.5 GitHub Releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Backfill releases from CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for TAG in v1.0.0 v1.0.1 v1.0.2 v1.0.3 v1.0.4 v1.0.5; do
+            echo ""
+            echo "=== Processing $TAG ==="
+
+            if gh release view "$TAG" > /dev/null 2>&1; then
+              echo "$TAG release already exists — skipping"
+              continue
+            fi
+
+            python3 scripts/dev/generate_release_notes.py "$TAG" > /tmp/raw-notes.txt || {
+              echo "ERROR: Failed to generate notes for $TAG — skipping"
+              continue
+            }
+            sed -n '/^# Release/,$p' /tmp/raw-notes.txt > /tmp/release-notes.md
+
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file /tmp/release-notes.md \
+              --verify-tag
+
+            echo "Created GitHub Release: $TAG"
+          done
+          echo ""
+          echo "Backfill complete."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -864,6 +864,41 @@ jobs:
           echo "2. Add secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN"
           echo "3. Set repository variable DOCKERHUB_ENABLED=true"
 
+  # Create GitHub Release from CHANGELOG.md notes
+  # Runs after PyPI publish and Docker manifest merge so the release page links
+  # to an already-available package and Docker image.
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [pypi-publish, docker-merge]
+    if: always() && startsWith(github.ref, 'refs/tags/v') && needs.pypi-publish.result == 'success'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          python3 scripts/dev/generate_release_notes.py "$TAG" > /tmp/raw-notes.txt
+          # Extract from the "# Release" heading onwards (strips diagnostic print lines)
+          sed -n '/^# Release/,$p' /tmp/raw-notes.txt > /tmp/release-notes.md
+          echo "Preview (first 20 lines):"
+          head -20 /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file /tmp/release-notes.md \
+            --verify-tag
+
   # Verify PyPI badges auto-update correctly after release
   # NOTE: This job is non-blocking (continue-on-error: true) to prevent badge
   # caching from blocking the entire release. Badges will update within 15-30


### PR DESCRIPTION
## Summary
Adds the missing `github-release` job to `release.yml` so future v* tag pushes automatically create a GitHub Release from CHANGELOG.md. Also adds a one-shot `backfill-github-releases.yml` workflow (workflow_dispatch) to create the 6 missing Releases for v1.0.0–v1.0.5 after this merges.

## Files Changed
- `.github/workflows/release.yml` — new `github-release` job after `docker-merge`, gated on `pypi-publish` success
- `.github/workflows/backfill-github-releases.yml` — one-shot workflow_dispatch backfill for v1.0.0–v1.0.5

## Paperclip
- Issue: JMOAA-50
- Agent: Tools Monitor
- Company: Security Suite

## Testing
- Ran `python3 scripts/dev/generate_release_notes.py v1.0.0` and `v1.0.5` locally — both produce clean markdown output
- Verified `sed -n '/^# Release/,$p'` extraction strips diagnostic print lines correctly
- All pre-commit hooks pass (yamllint, actionlint, yaml-env-tilde)

## Implementation Notes
- `github-release` job uses `needs: [pypi-publish, docker-merge]` with `if: always() && ... needs.pypi-publish.result == 'success'` so the release is created even if Docker arm64 build partially fails
- Job-level `permissions: contents: write` overrides the global `contents: read` block
- Notes extraction: `python3 scripts/dev/generate_release_notes.py` outputs diagnostics and notes mixed on stdout; `sed -n '/^# Release/,$p'` cleanly separates them
- Backfill workflow skips existing releases (`gh release view "$TAG" || gh release create ...`) so it is safe to re-run