### PR TITLE
JMOAA-53: Newsletter content template + draft generator

### DIFF
--- a/scripts/core/newsletter/README.md
+++ b/scripts/core/newsletter/README.md
@@ -1,0 +1,89 @@
+# JMo newsletter content pipeline
+
+Content-assembly pipeline for JMo Updates broadcasts. Builds a static HTML +
+plain-text draft from three inputs that can be reviewed before being uploaded
+to Resend.
+
+## Layout
+
+| Path | What it is |
+|------|------------|
+| `template.html` | Shared HTML email template. Mixes Python `${...}` build-time placeholders with Resend `{{{property\|fallback}}}` send-time placeholders. |
+| `draft_generator.py` | Pulls release notes from `CHANGELOG.md`, optionally splices in a customer story, renders the template, and emits an `.html` + `.txt` pair. |
+| `__init__.py` | Re-exports `generate_draft`, `NewsletterDraft`, `ReleaseEntry`. |
+
+The companion module `scripts/core/newsletter_broadcast.py` (one level up)
+owns the Resend upload step. Nothing in this package talks to Resend — review
+the static files first, then hand them to `newsletter_broadcast`.
+
+## Customer-story convention
+
+Customer stories live at `dev-only/customer-stories/active.md`. The
+`dev-only/` directory is gitignored so stories never enter source control —
+agents draft them locally before each broadcast and archive them after the
+send.
+
+`active.md` is plain markdown. The first markdown blockquote (`> ...`) is
+extracted as the subject-line tagline. Example:
+
+```markdown
+# Pipeline saved at SOC team
+
+> JMo caught a hardcoded GCP service-account key in a Terraform module
+> two days before our compliance audit.
+
+— **Internal SOC engineer**, *enterprise team*
+```
+
+When `active.md` is missing, the customer-story section is silently omitted
+and the subject-line falls back to the first `### subsection` heading from
+the release notes.
+
+## Subject-line formula
+
+| Customer story present? | Subject line |
+|-------------------------|--------------|
+| Yes | `JMo v{version} released — {first_blockquote_line}` (truncated to ~60 chars) |
+| No  | `JMo v{version} released — {first_release_subsection_title}` |
+
+## Substitution layers
+
+The template intentionally has two substitution layers:
+
+- **Build-time** (`${name}`) — filled in by `draft_generator` when the static
+  draft is assembled. Never touched by Resend.
+- **Send-time** (`{{{property|fallback}}}`) — Resend hydrates these per
+  recipient when the broadcast fires. Currently used for `first_name` and
+  the standard `unsubscribe` link.
+
+This separation keeps recipient personalization out of the agent flow:
+`draft_generator` only touches build-time content, and Resend handles all
+send-time hydration.
+
+## CLI
+
+```bash
+# Most-recent CHANGELOG release, default customer-story path
+python -m scripts.core.newsletter.draft_generator --output-dir ./drafts
+
+# All releases inside a date window (e.g. monthly digest)
+python -m scripts.core.newsletter.draft_generator \
+  --start 2026-04-01 --end 2026-04-30 \
+  --output-dir ./drafts
+
+# Skip the customer-story section explicitly
+python -m scripts.core.newsletter.draft_generator \
+  --no-customer-story --output-dir ./drafts
+```
+
+## Programmatic use
+
+```python
+from pathlib import Path
+from scripts.core.newsletter import generate_draft
+
+draft = generate_draft(output_dir=Path("./drafts"))
+print(draft.subject)
+print(draft.html_path)  # ./drafts/newsletter-v1_0_5.html
+print(draft.text_path)  # ./drafts/newsletter-v1_0_5.txt
+```

--- a/scripts/core/newsletter/__init__.py
+++ b/scripts/core/newsletter/__init__.py
@@ -1,0 +1,22 @@
+"""JMo newsletter content-assembly package.
+
+Public API:
+
+- ``generate_draft`` — build a newsletter draft (HTML + plain text) from
+  CHANGELOG release notes, an optional customer story, and the shared HTML
+  template.
+- ``NewsletterDraft`` — dataclass holding the assembled subject/HTML/text.
+
+The companion module :mod:`scripts.core.newsletter_broadcast` is responsible
+for uploading the assembled HTML to Resend as a broadcast draft. The two
+modules are intentionally decoupled so that content review (this package) and
+broadcast plumbing (Resend) can move independently.
+"""
+
+from scripts.core.newsletter.draft_generator import (
+    NewsletterDraft,
+    ReleaseEntry,
+    generate_draft,
+)
+
+__all__ = ["NewsletterDraft", "ReleaseEntry", "generate_draft"]

--- a/scripts/core/newsletter/draft_generator.py
+++ b/scripts/core/newsletter/draft_generator.py
@@ -1,0 +1,568 @@
+"""Newsletter draft generator for JMo Security.
+
+Assembles the full HTML + plain-text content for a JMo Updates broadcast from
+three input sources, producing a static file pair that can be reviewed before
+being uploaded to Resend as a broadcast draft.
+
+Inputs
+------
+1. **Release notes** — pulled from the repo `CHANGELOG.md` for either a single
+   version (`version="1.0.5"`) or every release whose header date falls inside
+   a `[date_range_start, date_range_end]` window.
+2. **Customer story** — optional markdown file (default
+   `dev-only/customer-stories/active.md`). The directory `dev-only/` is
+   gitignored, so customer stories live outside source control by design — see
+   the package README for the convention. When the file is missing, the
+   customer-story section is omitted from the rendered email.
+3. **Community CTA** — hard-coded in `template.html` (see
+   `scripts/core/newsletter/template.html`).
+
+Substitution layers
+-------------------
+The HTML template has two distinct substitution layers:
+
+- **Build-time (Python)**: `${name}` placeholders that this module fills in
+  when the draft is assembled (version, release body, customer-story HTML).
+- **Send-time (Resend)**: `{{{property|fallback}}}` triple-brace placeholders
+  that Resend hydrates per-recipient when the broadcast fires (e.g.
+  `{{{first_name|there}}}`, `{{{unsubscribe}}}`). These are passed through
+  untouched.
+
+CLI
+---
+::
+
+    # Default: most-recent CHANGELOG release, default customer-story path
+    python -m scripts.core.newsletter.draft_generator \\
+        --output-dir results/newsletter-drafts
+
+    # Date-range mode (all releases whose header date is in [start, end])
+    python -m scripts.core.newsletter.draft_generator \\
+        --start 2026-04-01 --end 2026-04-30 \\
+        --output-dir results/newsletter-drafts
+
+    # Skip the customer-story section explicitly
+    python -m scripts.core.newsletter.draft_generator \\
+        --no-customer-story --output-dir /tmp
+
+The static files written are review-ready: open the `.html` in a browser, the
+`.txt` in any plain editor. They are NOT automatically uploaded to Resend; the
+companion module `scripts/core/newsletter_broadcast.py` handles broadcast
+creation and is invoked separately once the content has been reviewed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import html
+import logging
+import re
+import string
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_DIR = Path(__file__).resolve().parent
+DEFAULT_TEMPLATE = PACKAGE_DIR / "template.html"
+DEFAULT_CUSTOMER_STORY = REPO_ROOT / "dev-only" / "customer-stories" / "active.md"
+
+
+@dataclass(frozen=True)
+class ReleaseEntry:
+    """A single CHANGELOG release block parsed from `CHANGELOG.md`."""
+
+    version: str
+    release_date: str
+    raw_markdown: str
+
+
+@dataclass(frozen=True)
+class NewsletterDraft:
+    """Assembled draft ready for review or Resend upload."""
+
+    subject: str
+    html: str
+    text: str
+    version: str
+    release_date: str
+    html_path: Optional[Path] = None
+    text_path: Optional[Path] = None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_draft(
+    *,
+    output_dir: Optional[Path] = None,
+    date_range_start: Optional[datetime.date] = None,
+    date_range_end: Optional[datetime.date] = None,
+    customer_story_path: Optional[Path] = None,
+    version: Optional[str] = None,
+    template_path: Optional[Path] = None,
+    repo_root: Optional[Path] = None,
+    include_customer_story: bool = True,
+) -> NewsletterDraft:
+    """Build a newsletter draft and optionally write the HTML + text files.
+
+    Resolution order for which release(s) to include:
+
+    1. If ``version`` is given, include only that single release.
+    2. Else if a date range is given, include every release whose header date
+       is inside ``[date_range_start, date_range_end]`` (inclusive).
+    3. Else default to the single most recent release in the changelog.
+
+    The function never raises when the customer-story file is missing; it
+    silently omits that block. Pass ``include_customer_story=False`` to skip
+    even when the file exists.
+    """
+    repo = repo_root or REPO_ROOT
+    template = template_path or DEFAULT_TEMPLATE
+
+    template_text = template.read_text(encoding="utf-8")
+    changelog_text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    if version:
+        entries = [_extract_release_by_version(changelog_text, version)]
+    elif date_range_start or date_range_end:
+        entries = _extract_releases_by_date_range(
+            changelog_text,
+            start=date_range_start,
+            end=date_range_end,
+        )
+        if not entries:
+            raise RuntimeError(
+                f"No CHANGELOG releases found between "
+                f"{date_range_start} and {date_range_end}"
+            )
+    else:
+        entries = [_most_recent_release(changelog_text)]
+
+    primary = entries[0]
+    release_body_html = "\n\n".join(
+        _markdown_to_email_html(e.raw_markdown) for e in entries
+    )
+
+    customer_story_md = None
+    if include_customer_story:
+        story_path = customer_story_path or DEFAULT_CUSTOMER_STORY
+        if story_path.exists():
+            customer_story_md = story_path.read_text(encoding="utf-8")
+            logger.info("Loaded customer story from %s", story_path)
+        else:
+            logger.info(
+                "No customer-story file at %s — section will be omitted", story_path
+            )
+
+    customer_story_block = _render_customer_story_block(customer_story_md)
+    customer_quote = _extract_customer_quote(customer_story_md)
+
+    subject = _build_subject(primary, customer_quote)
+    headline_version = (
+        primary.version if len(entries) == 1 else _multi_version_label(entries)
+    )
+    badge_label = "Release Notes" if len(entries) == 1 else "Release Round-Up"
+
+    rendered_html = string.Template(template_text).substitute(
+        subject=html.escape(subject),
+        badge_label=html.escape(badge_label),
+        headline=html.escape(f"JMo Security v{headline_version}"),
+        meta_line=_meta_line(entries),
+        release_body_html=release_body_html,
+        customer_story_block=customer_story_block,
+        primary_cta_url=(
+            f"https://github.com/jimmy058910/jmo-security-repo/releases/tag/v{primary.version}"
+        ),
+        primary_cta_label=f"View v{primary.version} on GitHub",
+    )
+
+    plain_text = _html_to_plain_text(rendered_html)
+
+    html_path: Optional[Path] = None
+    text_path: Optional[Path] = None
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        slug = primary.version.replace(".", "_")
+        html_path = output_dir / f"newsletter-v{slug}.html"
+        text_path = output_dir / f"newsletter-v{slug}.txt"
+        html_path.write_text(rendered_html, encoding="utf-8")
+        text_path.write_text(plain_text, encoding="utf-8")
+        logger.info("Wrote draft HTML to %s", html_path)
+        logger.info("Wrote draft text to %s", text_path)
+
+    return NewsletterDraft(
+        subject=subject,
+        html=rendered_html,
+        text=plain_text,
+        version=primary.version,
+        release_date=primary.release_date,
+        html_path=html_path,
+        text_path=text_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CHANGELOG parsing
+# ---------------------------------------------------------------------------
+
+_RELEASE_HEADER_RE = re.compile(
+    r"^## \[(?P<version>[^\]]+)\](?:\s*-\s*(?P<date>\d{4}-\d{2}-\d{2}))?",
+    re.MULTILINE,
+)
+
+
+def _iter_release_entries(changelog_text: str) -> Iterator[ReleaseEntry]:
+    """Yield ``ReleaseEntry`` objects for every ``## [x.y.z] - YYYY-MM-DD`` block.
+
+    Entries with no date (e.g. the ``## [Unreleased]`` placeholder) are skipped.
+    """
+    matches = list(_RELEASE_HEADER_RE.finditer(changelog_text))
+    for idx, match in enumerate(matches):
+        version = match.group("version").strip()
+        date_str = match.group("date")
+        if not date_str:
+            continue  # skip "Unreleased"
+        start = match.start()
+        end = (
+            matches[idx + 1].start() if idx + 1 < len(matches) else len(changelog_text)
+        )
+        yield ReleaseEntry(
+            version=version,
+            release_date=date_str,
+            raw_markdown=changelog_text[start:end].strip(),
+        )
+
+
+def _extract_release_by_version(changelog_text: str, version: str) -> ReleaseEntry:
+    for entry in _iter_release_entries(changelog_text):
+        if entry.version == version:
+            return entry
+    raise RuntimeError(f"CHANGELOG.md has no entry for version {version!r}")
+
+
+def _extract_releases_by_date_range(
+    changelog_text: str,
+    *,
+    start: Optional[datetime.date],
+    end: Optional[datetime.date],
+) -> list[ReleaseEntry]:
+    out: list[ReleaseEntry] = []
+    for entry in _iter_release_entries(changelog_text):
+        try:
+            entry_date = datetime.date.fromisoformat(entry.release_date)
+        except ValueError:
+            continue
+        if start and entry_date < start:
+            continue
+        if end and entry_date > end:
+            continue
+        out.append(entry)
+    out.sort(key=lambda e: e.release_date, reverse=True)
+    return out
+
+
+def _most_recent_release(changelog_text: str) -> ReleaseEntry:
+    for entry in _iter_release_entries(changelog_text):
+        return entry  # _iter_release_entries yields in CHANGELOG order
+    raise RuntimeError("CHANGELOG.md has no dated release entries")
+
+
+# ---------------------------------------------------------------------------
+# Markdown -> email HTML
+# ---------------------------------------------------------------------------
+
+
+def _markdown_to_email_html(md: str) -> str:
+    r"""Convert CHANGELOG markdown to email-safe HTML.
+
+    Handles ``### subhead``, ``## subhead`` (skipping the top-level
+    ``## [version]`` line), ``**bold**``, ``\`code\```, ``[text](url)`` links,
+    and ``-``/``*`` bullets. Anything more exotic falls through as plain text.
+    """
+    lines = md.split("\n")
+    out: list[str] = []
+    in_list = False
+
+    for line in lines:
+        if _RELEASE_HEADER_RE.match(line):
+            continue
+
+        if line.startswith("### "):
+            if in_list:
+                out.append("</ul>")
+                in_list = False
+            out.append(f"<h2>{html.escape(line[4:].strip())}</h2>")
+            continue
+
+        if line.startswith("## "):
+            if in_list:
+                out.append("</ul>")
+                in_list = False
+            out.append(f"<h2>{html.escape(line[3:].strip())}</h2>")
+            continue
+
+        if line.startswith("- ") or line.startswith("* "):
+            if not in_list:
+                out.append("<ul>")
+                in_list = True
+            out.append(f"  <li>{_inline_md(line[2:])}</li>")
+            continue
+
+        if not line.strip():
+            if in_list:
+                out.append("</ul>")
+                in_list = False
+            continue
+
+        if in_list:
+            if line.startswith("  "):
+                continue  # skip nested-list continuations
+            out.append("</ul>")
+            in_list = False
+
+        text = _inline_md(line.strip())
+        if text:
+            out.append(f"<p>{text}</p>")
+
+    if in_list:
+        out.append("</ul>")
+
+    return "\n".join(out)
+
+
+def _inline_md(text: str) -> str:
+    """Apply inline markdown (bold, code, links) to an already-escaped fragment."""
+    text = html.escape(text)
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\[([^\]]+)\]\(([^)\s]+)\)", r'<a href="\2">\1</a>', text)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Customer story
+# ---------------------------------------------------------------------------
+
+
+def _render_customer_story_block(story_md: Optional[str]) -> str:
+    if not story_md or not story_md.strip():
+        return ""
+    body_html = _markdown_to_email_html(story_md)
+    return f"<h2>Customer Story</h2>\n{body_html}\n"
+
+
+def _extract_customer_quote(story_md: Optional[str]) -> Optional[str]:
+    """Return a short subject-line-friendly quote pulled from the story.
+
+    Strategy: first markdown blockquote line (``>``), trimmed to ~60 chars.
+    Falls back to the first non-heading sentence if no blockquote is present.
+    """
+    if not story_md:
+        return None
+    for line in story_md.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(">"):
+            quote = stripped.lstrip(">").strip().strip('"').strip()
+            if quote:
+                return _truncate_subject_fragment(quote)
+    for line in story_md.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith(("#", ">", "-", "*")):
+            return _truncate_subject_fragment(stripped)
+    return None
+
+
+def _truncate_subject_fragment(text: str, max_len: int = 60) -> str:
+    if len(text) <= max_len:
+        return text
+    cut = text[: max_len - 1].rsplit(" ", 1)[0]
+    return f"{cut}\u2026"
+
+
+# ---------------------------------------------------------------------------
+# Subject line and meta
+# ---------------------------------------------------------------------------
+
+
+def _build_subject(primary: ReleaseEntry, customer_quote: Optional[str]) -> str:
+    if customer_quote:
+        return f"JMo v{primary.version} released \u2014 {customer_quote}"
+    fallback_tagline = _first_subsection_title(primary.raw_markdown) or "what's new"
+    return f"JMo v{primary.version} released \u2014 {fallback_tagline}"
+
+
+def _first_subsection_title(release_md: str) -> Optional[str]:
+    for line in release_md.splitlines():
+        if line.startswith("### "):
+            return line[4:].strip()
+    return None
+
+
+def _meta_line(entries: list[ReleaseEntry]) -> str:
+    if len(entries) == 1:
+        e = entries[0]
+        return (
+            f"Released {html.escape(e.release_date)} &nbsp;&middot;&nbsp; "
+            f'<a href="https://github.com/jimmy058910/jmo-security-repo/blob/main/CHANGELOG.md">'
+            f"Full changelog</a>"
+        )
+    versions = ", ".join(f"v{e.version}" for e in entries)
+    earliest = entries[-1].release_date
+    latest = entries[0].release_date
+    return (
+        f"Releases {html.escape(versions)} ({html.escape(earliest)} \u2192 "
+        f"{html.escape(latest)}) &nbsp;&middot;&nbsp; "
+        f'<a href="https://github.com/jimmy058910/jmo-security-repo/blob/main/CHANGELOG.md">'
+        f"Full changelog</a>"
+    )
+
+
+def _multi_version_label(entries: list[ReleaseEntry]) -> str:
+    return f"{entries[-1].version} \u2192 {entries[0].version}"
+
+
+# ---------------------------------------------------------------------------
+# HTML -> plain text fallback
+# ---------------------------------------------------------------------------
+
+_BLOCK_TAGS_TO_NEWLINE = (
+    "p",
+    "div",
+    "br",
+    "li",
+    "tr",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "blockquote",
+    "ul",
+    "ol",
+)
+
+
+def _html_to_plain_text(rendered_html: str) -> str:
+    """Best-effort HTML -> plain-text conversion for the email fallback body."""
+    text = rendered_html
+    text = re.sub(r"<style[\s\S]*?</style>", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"<head[\s\S]*?</head>", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"<script[\s\S]*?</script>", "", text, flags=re.IGNORECASE)
+
+    text = re.sub(
+        r"<h1[^>]*>(.*?)</h1>",
+        lambda m: f"\n\n{m.group(1).upper()}\n",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    text = re.sub(
+        r"<h2[^>]*>(.*?)</h2>",
+        lambda m: f"\n\n-- {m.group(1)} --\n",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    text = re.sub(
+        r"<li[^>]*>(.*?)</li>",
+        lambda m: f"\n  - {m.group(1).strip()}",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    text = re.sub(
+        r'<a [^>]*href="([^"]+)"[^>]*>(.*?)</a>',
+        r"\2 (\1)",
+        text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+
+    for tag in _BLOCK_TAGS_TO_NEWLINE:
+        text = re.sub(rf"</?{tag}[^>]*>", "\n", text, flags=re.IGNORECASE)
+
+    text = re.sub(r"<[^>]+>", "", text)
+    text = html.unescape(text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n[ \t]+", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_date(value: str) -> datetime.date:
+    try:
+        return datetime.date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Expected YYYY-MM-DD, got {value!r}") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate a JMo newsletter draft (HTML + plain text).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, help="Directory to write the .html + .txt files"
+    )
+    parser.add_argument(
+        "--start", type=_parse_date, help="Date-range start (YYYY-MM-DD)"
+    )
+    parser.add_argument("--end", type=_parse_date, help="Date-range end (YYYY-MM-DD)")
+    parser.add_argument(
+        "--version", help="Pin to a single CHANGELOG version (e.g. 1.0.5)"
+    )
+    parser.add_argument(
+        "--customer-story", type=Path, help="Path to a customer-story markdown file"
+    )
+    parser.add_argument(
+        "--no-customer-story",
+        action="store_true",
+        help="Do not include the customer-story section even if the default file exists",
+    )
+    parser.add_argument(
+        "--print",
+        action="store_true",
+        help="Also print the assembled subject line and plain text to stdout",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = _build_parser().parse_args(argv)
+
+    try:
+        draft = generate_draft(
+            output_dir=args.output_dir,
+            date_range_start=args.start,
+            date_range_end=args.end,
+            version=args.version,
+            customer_story_path=args.customer_story,
+            include_customer_story=not args.no_customer_story,
+        )
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Subject:    {draft.subject}")
+    print(f"Version:    {draft.version}  ({draft.release_date})")
+    if draft.html_path:
+        print(f"HTML:       {draft.html_path}")
+    if draft.text_path:
+        print(f"Plain text: {draft.text_path}")
+    if args.print:
+        print("\n--- PLAIN TEXT ---\n")
+        print(draft.text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/core/newsletter/template.html
+++ b/scripts/core/newsletter/template.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${subject}</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      line-height: 1.65;
+      color: #1a202c;
+      max-width: 620px;
+      margin: 0 auto;
+      padding: 24px 16px;
+      background: #f7fafc;
+    }
+    .card {
+      background: #ffffff;
+      border-radius: 12px;
+      padding: 32px 36px;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.07);
+    }
+    .greeting {
+      font-size: 15px;
+      color: #2d3748;
+      margin-bottom: 18px;
+    }
+    .badge {
+      display: inline-block;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: #fff;
+      padding: 4px 14px;
+      border-radius: 20px;
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: 0.3px;
+      margin-bottom: 16px;
+    }
+    h1 { font-size: 24px; margin: 0 0 6px 0; color: #1a202c; }
+    .meta { font-size: 13px; color: #718096; margin-bottom: 24px; }
+    h2 {
+      font-size: 15px;
+      color: #667eea;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin: 28px 0 10px;
+      border-bottom: 1px solid #e2e8f0;
+      padding-bottom: 6px;
+    }
+    p { margin: 0 0 14px; font-size: 15px; }
+    ul { padding-left: 20px; margin: 0 0 14px; }
+    li { margin-bottom: 8px; font-size: 15px; }
+    strong { color: #2d3748; }
+    code {
+      background: #edf2f7;
+      color: #553c9a;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-family: 'Menlo', 'Courier New', monospace;
+      font-size: 13px;
+    }
+    blockquote {
+      border-left: 3px solid #667eea;
+      margin: 12px 0 16px;
+      padding: 6px 16px;
+      background: #f7fafc;
+      color: #2d3748;
+      font-style: italic;
+    }
+    blockquote .attribution {
+      display: block;
+      margin-top: 8px;
+      font-size: 13px;
+      font-style: normal;
+      color: #718096;
+    }
+    .cta-row { text-align: center; margin: 32px 0 20px; }
+    .cta {
+      background: #667eea;
+      color: #ffffff !important;
+      padding: 12px 28px;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 15px;
+      display: inline-block;
+    }
+    .cta-secondary {
+      background: transparent;
+      color: #667eea !important;
+      border: 1px solid #cbd5e0;
+      margin-left: 6px;
+    }
+    .footer {
+      margin-top: 28px;
+      font-size: 12px;
+      color: #a0aec0;
+      text-align: center;
+      border-top: 1px solid #e2e8f0;
+      padding-top: 20px;
+    }
+    .footer a { color: #a0aec0; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <p class="greeting">Hey {{{first_name|there}}},</p>
+
+    <div class="badge">${badge_label}</div>
+    <h1>${headline}</h1>
+    <div class="meta">${meta_line}</div>
+
+    <h2>What's New</h2>
+    ${release_body_html}
+
+    ${customer_story_block}
+
+    <h2>Help Spread the Word</h2>
+    <p>JMo Security is open source and built in the open. If it has saved you a few hours of stitching scanners together, the best ways to support the project are:</p>
+    <ul>
+      <li><strong>Star the repo</strong> &mdash; signal-boosts visibility for other practitioners.</li>
+      <li><strong>File an issue or contribute</strong> &mdash; new tool adapters, dashboard polish, and docs are all great first PRs.</li>
+      <li><strong>Share a war story</strong> &mdash; reply to this email if JMo caught something interesting; we feature reader stories in future digests.</li>
+    </ul>
+
+    <div class="cta-row">
+      <a class="cta" href="${primary_cta_url}">${primary_cta_label}</a>
+      <a class="cta cta-secondary" href="https://github.com/jimmy058910/jmo-security-repo">Star on GitHub</a>
+    </div>
+
+    <div class="footer">
+      <p>
+        You're receiving this because you subscribed at jmotools.com.<br>
+        <a href="{{{unsubscribe}}}">Unsubscribe</a> &nbsp;&middot;&nbsp;
+        <a href="https://jmotools.com">jmotools.com</a> &nbsp;&middot;&nbsp;
+        <a href="https://github.com/jimmy058910/jmo-security-repo">GitHub</a>
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/unit/test_newsletter_draft.py
+++ b/tests/unit/test_newsletter_draft.py
@@ -1,0 +1,272 @@
+"""Unit tests for ``scripts.core.newsletter.draft_generator``.
+
+Covers parser, subject-line formula, customer-story integration, plain-text
+fallback, and the safety property that Resend ``{{{property|fallback}}}``
+placeholders survive Python ``string.Template`` substitution untouched.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from scripts.core.newsletter import draft_generator as dg
+from scripts.core.newsletter.draft_generator import generate_draft
+
+CHANGELOG_FIXTURE = """\
+# Changelog
+
+## [Unreleased]
+
+## [2.0.0] - 2026-06-15
+
+### Summary
+
+Major release introducing **bold things**.
+
+### Added
+
+- New `feature_x` flag
+- [Docs link](https://example.com/docs)
+
+## [1.9.0] - 2026-05-01
+
+### Summary
+
+Smaller follow-up.
+
+### Fixed
+
+- Edge case in parser
+"""
+
+MIN_TEMPLATE = """\
+<html>
+<body>
+<p>Hey {{{first_name|there}}},</p>
+<h1>${headline}</h1>
+<div>${meta_line}</div>
+<div class="badge">${badge_label}</div>
+<title>${subject}</title>
+<section>${release_body_html}</section>
+${customer_story_block}
+<a href="${primary_cta_url}">${primary_cta_label}</a>
+<a href="{{{unsubscribe}}}">Unsubscribe</a>
+</body>
+</html>
+"""
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    """Build a tiny pretend-repo with a CHANGELOG and template."""
+    (tmp_path / "CHANGELOG.md").write_text(CHANGELOG_FIXTURE, encoding="utf-8")
+    template_path = tmp_path / "template.html"
+    template_path.write_text(MIN_TEMPLATE, encoding="utf-8")
+    return tmp_path
+
+
+def test_parse_iter_skips_unreleased():
+    entries = list(dg._iter_release_entries(CHANGELOG_FIXTURE))
+    versions = [e.version for e in entries]
+    assert versions == ["2.0.0", "1.9.0"]
+
+
+def test_extract_release_by_version_known():
+    entry = dg._extract_release_by_version(CHANGELOG_FIXTURE, "1.9.0")
+    assert entry.version == "1.9.0"
+    assert entry.release_date == "2026-05-01"
+    assert "Edge case in parser" in entry.raw_markdown
+
+
+def test_extract_release_by_version_unknown_raises():
+    with pytest.raises(RuntimeError, match="no entry"):
+        dg._extract_release_by_version(CHANGELOG_FIXTURE, "9.9.9")
+
+
+def test_extract_releases_by_date_range_inclusive():
+    entries = dg._extract_releases_by_date_range(
+        CHANGELOG_FIXTURE,
+        start=datetime.date(2026, 5, 1),
+        end=datetime.date(2026, 6, 15),
+    )
+    versions = [e.version for e in entries]
+    # Sorted newest-first
+    assert versions == ["2.0.0", "1.9.0"]
+
+
+def test_extract_releases_by_date_range_excludes_outside_window():
+    entries = dg._extract_releases_by_date_range(
+        CHANGELOG_FIXTURE,
+        start=datetime.date(2026, 5, 2),
+        end=datetime.date(2026, 6, 14),
+    )
+    assert entries == []
+
+
+def test_subject_uses_customer_quote_when_present():
+    entry = dg._extract_release_by_version(CHANGELOG_FIXTURE, "2.0.0")
+    subject = dg._build_subject(entry, customer_quote="caught a real bug")
+    assert subject == "JMo v2.0.0 released \u2014 caught a real bug"
+
+
+def test_subject_falls_back_to_first_subsection_when_no_quote():
+    entry = dg._extract_release_by_version(CHANGELOG_FIXTURE, "2.0.0")
+    subject = dg._build_subject(entry, customer_quote=None)
+    assert subject == "JMo v2.0.0 released \u2014 Summary"
+
+
+def test_extract_customer_quote_prefers_blockquote():
+    md = '> "JMo flagged a hardcoded key two days before audit."\n\n— Engineer'
+    quote = dg._extract_customer_quote(md)
+    assert quote == "JMo flagged a hardcoded key two days before audit."
+
+
+def test_extract_customer_quote_truncates_long_lines():
+    md = "> " + "x" * 200
+    quote = dg._extract_customer_quote(md)
+    assert quote is not None
+    assert len(quote) <= 60
+    assert quote.endswith("\u2026")
+
+
+def test_extract_customer_quote_returns_none_when_empty():
+    assert dg._extract_customer_quote(None) is None
+    assert dg._extract_customer_quote("") is None
+
+
+def test_inline_md_escapes_html_first():
+    out = dg._inline_md("<script>alert(1)</script>")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_inline_md_supports_bold_code_links():
+    out = dg._inline_md("**bold** with `code` and [link](https://example.com)")
+    assert "<strong>bold</strong>" in out
+    assert "<code>code</code>" in out
+    assert '<a href="https://example.com">link</a>' in out
+
+
+def test_markdown_to_email_html_handles_bullets():
+    md = "### Heading\n\n- one\n- two\n\nplain paragraph"
+    out = dg._markdown_to_email_html(md)
+    assert "<h2>Heading</h2>" in out
+    assert "<ul>" in out
+    assert "<li>one</li>" in out
+    assert "<li>two</li>" in out
+    assert "<p>plain paragraph</p>" in out
+
+
+def test_html_to_plain_text_strips_tags_and_renders_links():
+    sample = '<p>Hello <a href="https://example.com">there</a></p>'
+    text = dg._html_to_plain_text(sample)
+    assert "<p>" not in text
+    assert "Hello there (https://example.com)" in text
+
+
+def test_html_to_plain_text_drops_style_blocks():
+    sample = "<style>body { color: red; }</style><p>Visible</p>"
+    text = dg._html_to_plain_text(sample)
+    assert "color" not in text
+    assert "Visible" in text
+
+
+def test_generate_draft_default_release_only(repo_root: Path, tmp_path: Path):
+    out_dir = tmp_path / "drafts"
+    draft = generate_draft(
+        output_dir=out_dir,
+        repo_root=repo_root,
+        template_path=repo_root / "template.html",
+        include_customer_story=False,
+    )
+    assert draft.version == "2.0.0"
+    assert draft.release_date == "2026-06-15"
+    assert draft.html_path is not None
+    assert draft.text_path is not None
+    assert draft.html_path.exists()
+    assert draft.text_path.exists()
+    assert "Released 2026-06-15" in draft.html
+    # Resend send-time placeholders survive untouched
+    assert "{{{first_name|there}}}" in draft.html
+    assert "{{{unsubscribe}}}" in draft.html
+    # Customer story block omitted when not requested
+    assert "Customer Story" not in draft.html
+
+
+def test_generate_draft_with_customer_story(repo_root: Path, tmp_path: Path):
+    story_path = tmp_path / "active.md"
+    story_path.write_text(
+        "# A real story\n\n> Caught a hardcoded key.\n\n— **engineer**",
+        encoding="utf-8",
+    )
+    draft = generate_draft(
+        output_dir=tmp_path / "drafts",
+        repo_root=repo_root,
+        template_path=repo_root / "template.html",
+        customer_story_path=story_path,
+    )
+    assert "Customer Story" in draft.html
+    assert "Caught a hardcoded key" in draft.html
+    # Subject was driven by the customer quote, not the changelog subsection
+    assert "Caught a hardcoded key" in draft.subject
+
+
+def test_generate_draft_missing_story_silently_omits(repo_root: Path, tmp_path: Path):
+    draft = generate_draft(
+        output_dir=tmp_path / "drafts",
+        repo_root=repo_root,
+        template_path=repo_root / "template.html",
+        customer_story_path=tmp_path / "does-not-exist.md",
+    )
+    assert "Customer Story" not in draft.html
+
+
+def test_generate_draft_date_range(repo_root: Path, tmp_path: Path):
+    draft = generate_draft(
+        output_dir=tmp_path / "drafts",
+        repo_root=repo_root,
+        template_path=repo_root / "template.html",
+        date_range_start=datetime.date(2026, 4, 1),
+        date_range_end=datetime.date(2026, 7, 1),
+        include_customer_story=False,
+    )
+    # Both 1.9.0 and 2.0.0 fall in the window; primary is the most recent
+    assert draft.version == "2.0.0"
+    assert "v1.9.0" in draft.html  # multi-version meta line
+
+
+def test_generate_draft_pinned_version(repo_root: Path, tmp_path: Path):
+    draft = generate_draft(
+        output_dir=tmp_path / "drafts",
+        repo_root=repo_root,
+        template_path=repo_root / "template.html",
+        version="1.9.0",
+        include_customer_story=False,
+    )
+    assert draft.version == "1.9.0"
+    assert "Edge case in parser" in draft.html
+
+
+def test_generate_draft_empty_date_range_raises(repo_root: Path, tmp_path: Path):
+    with pytest.raises(RuntimeError, match="No CHANGELOG releases"):
+        generate_draft(
+            output_dir=tmp_path / "drafts",
+            repo_root=repo_root,
+            template_path=repo_root / "template.html",
+            date_range_start=datetime.date(2030, 1, 1),
+            date_range_end=datetime.date(2030, 12, 31),
+            include_customer_story=False,
+        )
+
+
+def test_truncate_subject_fragment_preserves_short_text():
+    assert dg._truncate_subject_fragment("short") == "short"
+
+
+def test_truncate_subject_fragment_word_boundary():
+    out = dg._truncate_subject_fragment("the quick brown fox jumps", max_len=15)
+    assert out.endswith("\u2026")
+    assert " " not in out[-2:-1]  # truncation snapped at word boundary


### PR DESCRIPTION
## Summary

Adds the HTML email template and content-assembly pipeline for JMo Updates broadcasts. Pulls release notes from `CHANGELOG.md`, optionally splices in a customer story from a markdown file, and emits review-ready HTML + plain-text artifacts before any Resend upload.

The template uses two distinct substitution layers that intentionally do not collide:

- **Build-time** (`${name}`) — Python `string.Template` placeholders filled in by `draft_generator` (version, release body, customer story).
- **Send-time** (`{{{property|fallback}}}`) — Resend triple-brace placeholders for per-recipient hydration (`first_name`, `unsubscribe`). These pass through untouched.

## Files Changed

- `scripts/core/newsletter/template.html` — shared HTML email template with both substitution layers
- `scripts/core/newsletter/draft_generator.py` — content-assembly pipeline: CHANGELOG parser, customer-story handler, plain-text fallback, CLI
- `scripts/core/newsletter/__init__.py` — public API exports
- `scripts/core/newsletter/README.md` — package conventions, customer-story location, subject-line formula
- `tests/unit/test_newsletter_draft.py` — 23 unit tests covering parser, subject formula, customer-story logic, plain-text generation, and the placeholder-isolation property

## Decisions on the open questions from the issue

| Question | Decision | Rationale |
|---|---|---|
| Customer-stories source | `dev-only/customer-stories/active.md` (markdown file in the gitignored `dev-only/` tree) | Stays out of source control, easy for agents to draft per-broadcast, no GitHub-issue-label dependency |
| Plain-text fallback | Auto-generated from rendered HTML via tag stripping with structural cues (h1 -> ALL CAPS, h2 -> `-- name --`, list items -> `- `, anchors -> `text (url)`) | Removes hand-curation step; manual override always available later |
| Brand assets | Reuse the inline CSS from `newsletter_broadcast.py` — purple gradient (#667eea -> #764ba2), system font stack, 620px max width, jmotools.com footer | Already practitioner-friendly; aligns with the existing welcome-email aesthetic |
| Subject-line formula | `JMo v{version} released - {customer_quote_or_first_subsection_title}` | Matches "developer-to-developer" voice; customer quote auto-extracts from the first markdown blockquote in the story |

## Testing

- `python3 -m pytest tests/unit/test_newsletter_draft.py` — 23/23 pass locally
- Smoke-tested CLI against the real `CHANGELOG.md`: `python -m scripts.core.newsletter.draft_generator --output-dir /tmp/...` produces a clean HTML + text pair for v1.0.5
- Verified `{{{first_name|there}}}` and `{{{unsubscribe}}}` survive the build-time substitution untouched (asserted in `test_generate_draft_default_release_only`)
- All pre-commit hooks pass: black, ruff, mypy, bandit, markdownlint, import-direction

## Paperclip

- Issue: JMOAA-53
- Agent: CEO
- Company: Security Suite