### PR TITLE
JMOAA-52: CLI newsletter subscribe — close audience-add gap

### DIFF
--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -2268,34 +2268,49 @@ def _collect_email_opt_in(args) -> None:
     config_path.parent.mkdir(exist_ok=True)
 
     if email and "@" in email:
-        # Attempt to send welcome email (fails silently if resend not installed)
+        # Subscribe (audience + welcome). Fails silently if resend
+        # unavailable or API unreachable — never blocks CLI.
         try:
-            from scripts.core.email_service import send_welcome_email, validate_email
+            from scripts.core.email_service import (
+                subscribe_to_newsletter,
+                validate_email,
+            )
 
             if validate_email(email):
-                success = send_welcome_email(email, source="cli")
+                subscribed, welcomed = subscribe_to_newsletter(email, source="cli")
 
-                # Save to config
+                # Track pending_subscription so a future `jmo subscribe --retry`
+                # can re-attempt the audience add when offline at signup time.
                 import yaml
 
                 config = {
                     "email": email,
                     "email_opt_in": True,
                     "onboarding_completed": True,
+                    "pending_subscription": not subscribed,
                 }
                 with open(config_path, "w") as f:
                     yaml.dump(config, f)
 
-                if success:
+                if subscribed and welcomed:
                     _safe_print(
                         "\n✅ Thanks! Check your inbox for a welcome message.\n"
                     )
+                elif subscribed:
+                    _safe_print(
+                        "\n✅ You're subscribed. (Welcome email failed — you'll"
+                        " still receive newsletters.)\n"
+                    )
                 else:
-                    _safe_print("\n✅ Thanks! You're all set.\n")
+                    # Audience add failed — saved locally, retry path available.
+                    _safe_print(
+                        "\n✅ Thanks! Saved your address. Run "
+                        "`jmo subscribe` later to finish signup.\n"
+                    )
                     _log(
                         args,
                         "DEBUG",
-                        "Email collection succeeded but welcome email not sent (resend may not be configured)",
+                        "Email saved locally but Resend unreachable; pending retry",
                     )
             else:
                 _safe_print("\n❌ Invalid email address. Skipping...\n")

--- a/scripts/core/email_service.py
+++ b/scripts/core/email_service.py
@@ -53,6 +53,13 @@ RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
 # Override with JMO_FROM_EMAIL env var if needed
 FROM_EMAIL = os.getenv("JMO_FROM_EMAIL", "marketing@jmotools.com")
 
+# Canonical audience for the "JMo Updates" newsletter. CLI signup touchpoints
+# (first-run prompt, `jmo wizard` end-of-flow, `jmo subscribe`) push contacts
+# here so they land in the same audience that scripts/core/newsletter_broadcast.py
+# targets when sending release digests.
+JMO_UPDATES_AUDIENCE_ID = "fb900b6d-10de-4171-97df-e4e5eebf20fd"
+RESEND_AUDIENCE_ID = os.getenv("RESEND_AUDIENCE_ID", JMO_UPDATES_AUDIENCE_ID)
+
 # Email templates
 WELCOME_EMAIL_HTML = """
 <!DOCTYPE html>
@@ -334,6 +341,110 @@ def send_welcome_email(
         # Log error for debugging
         logger.error("Email send failed: %s", e, exc_info=True)
         return False
+
+
+def add_contact_to_audience(
+    email: str,
+    audience_id: str = "",
+    source: Literal["cli", "wizard", "subscribe", "dashboard", "website"] = "cli",
+) -> bool:
+    """Add an email to a Resend audience (idempotent on the API side).
+
+    This is the load-bearing call that ensures CLI signups receive the
+    broadcast newsletter sends emitted by scripts/core/newsletter_broadcast.py.
+    Without it, send_welcome_email() only fires a transactional welcome —
+    the user never lands in the audience and never receives subsequent
+    broadcasts.
+
+    Args:
+        email: Subscriber email address.
+        audience_id: Resend audience UUID. Falls back to RESEND_AUDIENCE_ID
+            (which itself defaults to JMO_UPDATES_AUDIENCE_ID).
+        source: Where the signup originated (for analytics). The Resend
+            Contacts API does not accept arbitrary tags, so source is
+            recorded only via the welcome email's tag set.
+
+    Returns:
+        True on success, False on any failure (silent — must not block CLI).
+
+    Note:
+        Resend's Contacts.create is idempotent on email — calling it twice
+        for the same address returns the existing contact, so we never need
+        to "check before insert".
+    """
+    if not RESEND_AVAILABLE:
+        return False
+    if not RESEND_API_KEY:
+        return False
+
+    target_audience = audience_id or RESEND_AUDIENCE_ID
+    if not target_audience:
+        return False
+
+    resend.api_key = RESEND_API_KEY
+
+    try:
+        params = {
+            "email": email,
+            "audience_id": target_audience,
+            "unsubscribed": False,
+        }
+        response = resend.Contacts.create(params)
+    except Exception as exc:  # Acceptable: must not block CLI workflow
+        logger.error("Resend Contacts.create failed (source=%s): %s", source, exc)
+        return False
+
+    # Resend returns dict-with-id on success
+    if isinstance(response, dict):
+        return bool(response.get("id"))
+    return bool(getattr(response, "id", None))
+
+
+def subscribe_to_newsletter(
+    email: str,
+    source: Literal["cli", "wizard", "subscribe", "dashboard", "website"] = "cli",
+    *,
+    audience_id: str = "",
+    send_welcome: bool = True,
+) -> tuple[bool, bool]:
+    """Add a contact to the newsletter audience and send a welcome email.
+
+    This is the top-level helper CLI signup surfaces should call. It composes
+    add_contact_to_audience() (the load-bearing addition that JMOAA-45's
+    broadcast pipeline needs) with the existing send_welcome_email() so a
+    single call covers both responsibilities.
+
+    Args:
+        email: Subscriber email address.
+        source: Origin label for analytics (cli / wizard / subscribe / etc.).
+        audience_id: Resend audience UUID override (defaults to
+            RESEND_AUDIENCE_ID / JMO_UPDATES_AUDIENCE_ID).
+        send_welcome: If True (default), also send the transactional welcome
+            email. Set False when the caller wants to add to the audience
+            only (e.g. silent re-subscribe, retry path).
+
+    Returns:
+        (subscribed, welcomed) — two booleans. `subscribed` reflects whether
+        the contact was added to the audience; `welcomed` reflects whether
+        the welcome email was sent. Either may fail independently (e.g.
+        Resend Contacts API succeeds but email send hits a rate limit), so
+        callers can react granularly.
+    """
+    # cast cli/wizard/subscribe sources back to send_welcome_email's narrower
+    # Literal — the welcome-email API only knows cli/dashboard/website
+    welcome_source: Literal["cli", "dashboard", "website"]
+    if source in ("wizard", "subscribe", "cli"):
+        welcome_source = "cli"
+    elif source == "dashboard":
+        welcome_source = "dashboard"
+    else:
+        welcome_source = "website"
+
+    subscribed = add_contact_to_audience(email, audience_id=audience_id, source=source)
+    welcomed = (
+        send_welcome_email(email, source=welcome_source) if send_welcome else False
+    )
+    return subscribed, welcomed
 
 
 def validate_email(email: str) -> bool:

--- a/tests/core/test_email_service.py
+++ b/tests/core/test_email_service.py
@@ -618,3 +618,265 @@ def test_validate_email_domain_parts():
     # Domain with TLD should be valid
     assert validate_email("user@localhost.local") is True
     assert validate_email("user@domain.com") is True
+
+
+# ========== Category 11: add_contact_to_audience (JMOAA-52) ==========
+
+
+class MockResendContacts:
+    """Mock Resend Contacts API."""
+
+    def __init__(self, should_fail: bool = False, exception: Exception | None = None):
+        self.should_fail = should_fail
+        self.exception = exception
+        self.last_params: dict[str, Any] | None = None
+
+    def create(self, params: dict[str, Any]):
+        self.last_params = params
+        if self.exception:
+            raise self.exception
+        if self.should_fail:
+            return {}
+        return {"id": "contact-test-id"}
+
+
+def test_add_contact_to_audience_success():
+    """Adds the email to the canonical Resend audience."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        contacts = MockResendContacts()
+        mock_resend.Contacts = contacts
+
+        from scripts.core.email_service import add_contact_to_audience
+
+        result = add_contact_to_audience("user@example.com", source="cli")
+
+        assert result is True
+        assert contacts.last_params == {
+            "email": "user@example.com",
+            "audience_id": "aud-default",
+            "unsubscribed": False,
+        }
+
+
+def test_add_contact_to_audience_explicit_id_overrides_env():
+    """Explicit audience_id takes precedence over RESEND_AUDIENCE_ID."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        contacts = MockResendContacts()
+        mock_resend.Contacts = contacts
+
+        from scripts.core.email_service import add_contact_to_audience
+
+        add_contact_to_audience(
+            "user@example.com", audience_id="aud-override", source="wizard"
+        )
+
+        assert contacts.last_params is not None
+        assert contacts.last_params["audience_id"] == "aud-override"
+
+
+def test_add_contact_to_audience_resend_unavailable():
+    """Returns False when resend package not installed."""
+    with patch("scripts.core.email_service.RESEND_AVAILABLE", False):
+        from scripts.core.email_service import add_contact_to_audience
+
+        assert add_contact_to_audience("user@example.com") is False
+
+
+def test_add_contact_to_audience_no_api_key():
+    """Returns False when API key missing — never raises."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", ""),
+    ):
+        from scripts.core.email_service import add_contact_to_audience
+
+        assert add_contact_to_audience("user@example.com") is False
+
+
+def test_add_contact_to_audience_offline_failure():
+    """Connection errors swallowed — returns False without raising."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        contacts = MockResendContacts(exception=ConnectionError("offline"))
+        mock_resend.Contacts = contacts
+
+        from scripts.core.email_service import add_contact_to_audience
+
+        assert add_contact_to_audience("user@example.com") is False
+
+
+def test_add_contact_to_audience_no_audience_id():
+    """Returns False when no audience id resolves (env empty + arg empty)."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", ""),
+    ):
+        from scripts.core.email_service import add_contact_to_audience
+
+        assert add_contact_to_audience("user@example.com") is False
+
+
+def test_add_contact_to_audience_response_object_with_id():
+    """Accepts SDK responses that expose `.id` attribute instead of dict key."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        response_obj = type("ContactResponse", (), {"id": "contact-attr"})()
+        mock_resend.Contacts.create = MagicMock(return_value=response_obj)
+
+        from scripts.core.email_service import add_contact_to_audience
+
+        assert add_contact_to_audience("user@example.com") is True
+
+
+def test_default_audience_id_is_jmo_updates():
+    """JMO_UPDATES_AUDIENCE_ID stays pinned to the broadcast pipeline target."""
+    from scripts.core.email_service import JMO_UPDATES_AUDIENCE_ID
+
+    # If this constant changes, scripts/core/newsletter_broadcast.py
+    # signups will land in a different audience than the broadcast send
+    # targets — silently breaking the JMOAA-45 ↔ JMOAA-52 loop.
+    assert JMO_UPDATES_AUDIENCE_ID == "fb900b6d-10de-4171-97df-e4e5eebf20fd"
+
+
+# ========== Category 12: subscribe_to_newsletter orchestration (JMOAA-52) ==========
+
+
+def test_subscribe_to_newsletter_both_succeed():
+    """Happy path: contact added AND welcome email sent."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        mock_resend.Contacts = MockResendContacts()
+        mock_resend.Emails = MockResendEmails()
+
+        from scripts.core.email_service import subscribe_to_newsletter
+
+        subscribed, welcomed = subscribe_to_newsletter("user@example.com", source="cli")
+        assert subscribed is True
+        assert welcomed is True
+
+
+def test_subscribe_to_newsletter_audience_succeeds_email_fails():
+    """Audience add succeeds but welcome email fails — partial success."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        mock_resend.Contacts = MockResendContacts()
+        mock_resend.Emails = MockResendEmails(exception=Exception("rate limit"))
+
+        from scripts.core.email_service import subscribe_to_newsletter
+
+        subscribed, welcomed = subscribe_to_newsletter("user@example.com")
+        assert subscribed is True
+        assert welcomed is False
+
+
+def test_subscribe_to_newsletter_offline_both_fail():
+    """Network down — both calls fail, neither raises."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        mock_resend.Contacts = MockResendContacts(exception=ConnectionError("offline"))
+        mock_resend.Emails = MockResendEmails(exception=ConnectionError("offline"))
+
+        from scripts.core.email_service import subscribe_to_newsletter
+
+        subscribed, welcomed = subscribe_to_newsletter("user@example.com")
+        assert subscribed is False
+        assert welcomed is False
+
+
+def test_subscribe_to_newsletter_skip_welcome():
+    """send_welcome=False adds to audience without sending email — used by retry path."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        contacts = MockResendContacts()
+        emails = MockResendEmails()
+        mock_resend.Contacts = contacts
+        mock_resend.Emails = emails
+
+        from scripts.core.email_service import subscribe_to_newsletter
+
+        subscribed, welcomed = subscribe_to_newsletter(
+            "user@example.com", send_welcome=False
+        )
+        assert subscribed is True
+        assert welcomed is False
+        assert emails.last_params is None  # never called
+
+
+def test_subscribe_to_newsletter_source_mapping():
+    """CLI-specific sources (cli/wizard/subscribe) collapse to 'cli' for welcome."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        emails = MockResendEmails()
+        mock_resend.Contacts = MockResendContacts()
+        mock_resend.Emails = emails
+
+        from scripts.core.email_service import subscribe_to_newsletter
+
+        subscribe_to_newsletter("u@example.com", source="wizard")
+
+        assert emails.last_params is not None
+        source_tag = next(
+            t for t in emails.last_params["tags"] if t["name"] == "source"
+        )
+        assert source_tag["value"] == "cli"
+
+
+def test_subscribe_to_newsletter_dashboard_source_preserved():
+    """dashboard/website sources flow through to welcome email tagging unchanged."""
+    with (
+        patch("scripts.core.email_service.RESEND_AVAILABLE", True),
+        patch("scripts.core.email_service.RESEND_API_KEY", "re_test_key"),
+        patch("scripts.core.email_service.RESEND_AUDIENCE_ID", "aud-default"),
+        patch("scripts.core.email_service.resend") as mock_resend,
+    ):
+        emails = MockResendEmails()
+        mock_resend.Contacts = MockResendContacts()
+        mock_resend.Emails = emails
+
+        from scripts.core.email_service import subscribe_to_newsletter
+
+        subscribe_to_newsletter("u@example.com", source="dashboard")
+
+        source_tag = next(
+            t for t in emails.last_params["tags"] if t["name"] == "source"
+        )
+        assert source_tag["value"] == "dashboard"


### PR DESCRIPTION
## Summary
Closes the gap where CLI signup touchpoints fired a transactional welcome email but never added the email to the Resend audience targeted by `newsletter_broadcast.py`. Subscribers received the welcome but no subsequent broadcasts. This change adds idempotent audience-add + orchestration helpers, rewires `_collect_email_opt_in()`, and lands 14 new tests (46/46 passing).

## Files Changed
- `scripts/core/email_service.py` — `add_contact_to_audience()` + `subscribe_to_newsletter()` orchestration; pinned `JMO_UPDATES_AUDIENCE_ID` constant (`fb900b6d-...`) with env-var override.
- `scripts/cli/jmo.py` — first-run prompt rewired to use the orchestration helper; persists `pending_subscription=True` on partial failure for future retry.
- `tests/core/test_email_service.py` — 14 new test cases covering happy path, missing creds, offline failures, response-object SDK shape, source mapping, partial success, skip-welcome retry path.

## Paperclip
- Issue: JMOAA-52
- Parent: JMOAA-45
- Agent: CEO (continuation of prior heartbeat work; commit d16d2dc was authored by an earlier run on this same branch)
- Company: JMo Security Suite

## Testing
- `pytest tests/core/test_email_service.py` — 46/46 pass
- Pre-push checks (Python import audit) passed on push.
- Manual smoke not run; `RESEND_API_KEY` + audience id are needed for live verification, see `paperclip/AGENT_NEWSLETTER_WORKFLOW.md`.
