### PR TITLE
JMOAA-66: Wire dashboard Tailwind to brand tokens.css

### DIFF
--- a/scripts/dashboard/src/index.css
+++ b/scripts/dashboard/src/index.css
@@ -1,3 +1,5 @@
+@import '../../../docs/brand/tokens.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/scripts/dashboard/tailwind.config.js
+++ b/scripts/dashboard/tailwind.config.js
@@ -8,13 +8,13 @@ export default {
   theme: {
     extend: {
       colors: {
-        // JMo Security brand colors (severity-based)
-        critical: '#d32f2f',
-        high: '#f57c00',
-        medium: '#fbc02d',
-        low: '#7cb342',
-        info: '#757575',
-        primary: '#1976d2',
+        // Sourced from docs/brand/tokens.css — do not hardcode hex here
+        critical: 'var(--jmo-severity-critical)',
+        high: 'var(--jmo-severity-high)',
+        medium: 'var(--jmo-severity-medium)',
+        low: 'var(--jmo-severity-low)',
+        info: 'var(--jmo-severity-info)',
+        primary: 'var(--jmo-brand-primary)',
       },
     },
   },


### PR DESCRIPTION
## Summary

Wire `scripts/dashboard/tailwind.config.js` to read severity and primary colors from `docs/brand/tokens.css` CSS custom properties rather than duplicated hex literals. This is a pure refactor — the hex values were already identical, so no visual change occurs.

**Approach chosen: Option A (CSS variable references)**

`tailwind.config.js` now maps color names to `var(--jmo-severity-*)` / `var(--jmo-brand-primary)`. `docs/brand/tokens.css` is imported at the dashboard CSS entrypoint (`src/index.css`) so the variables are defined at runtime and in the inlined single-file build output.

No JS/TS token module (`tokens.js`) was generated — Option A eliminates the need for one since Tailwind reads CSS variables directly. `docs/brand/tokens.py` (the Python sibling) already exists and covers the CLI/terminal use case.

## Files Changed

- `scripts/dashboard/tailwind.config.js` — replaced 6 hardcoded hex literals with `var(--jmo-severity-*)` and `var(--jmo-brand-primary)` references
- `scripts/dashboard/src/index.css` — added `@import '../../../docs/brand/tokens.css'` before Tailwind directives

## Verification

- `pnpm build` succeeded (2602 modules, single-file output, no errors)
- `grep` confirms zero hardcoded hex literals remain in `tailwind.config.js`
- Built `dist/index.html` contains `--jmo-severity-critical` confirming tokens.css was inlined
- Pre-commit hooks passed on commit and push

## Paperclip

- Issue: JMOAA-66
- Agent: Test Engineer
- Company: Security Suite

## Testing

`pnpm build` clean pass. Visual regression (`make test-e2e-visual`) should pass without snapshot updates — no color values changed, only how they are sourced. CI will confirm on merge.