### PR TITLE
JMOAA-67: Adopt brand email-chrome.html in newsletter template

### DIFF
--- a/docs/brand/templates/email-chrome.html
+++ b/docs/brand/templates/email-chrome.html
@@ -1,7 +1,7 @@
 <!--
   JMo Security — email chrome (header + footer wrapper)
 
-  Drop-in email template. Body content slots into <!--CONTENT-->.
+  Drop-in email template. Body content slots into the CONTENT marker below.
 
   Email HTML constraints (why this looks different from footer.html):
     - Table-based layout (most email clients ignore flexbox/grid)

--- a/scripts/core/newsletter/draft_generator.py
+++ b/scripts/core/newsletter/draft_generator.py
@@ -70,7 +70,42 @@ logger = logging.getLogger(__name__)
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PACKAGE_DIR = Path(__file__).resolve().parent
 DEFAULT_TEMPLATE = PACKAGE_DIR / "template.html"
+DEFAULT_CHROME = REPO_ROOT / "docs/brand/templates/email-chrome.html"
 DEFAULT_CUSTOMER_STORY = REPO_ROOT / "dev-only" / "customer-stories" / "active.md"
+
+# Inline style constants — values derived from docs/brand/tokens.css.
+# Inlined here because email clients strip <style> blocks.
+_EMAIL_FONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif"
+_H2_STYLE = (
+    f"font-size:15px;color:#1976d2;text-transform:uppercase;letter-spacing:0.5px;"
+    f"margin:28px 0 10px;border-bottom:1px solid #eeeeee;padding-bottom:6px;"
+    f"font-family:{_EMAIL_FONT};"
+)
+_P_STYLE = f"margin:0 0 14px;font-size:15px;color:#424242;font-family:{_EMAIL_FONT};"
+_UL_STYLE = "padding-left:20px;margin:0 0 14px;"
+_LI_STYLE = f"margin-bottom:8px;font-size:15px;color:#424242;font-family:{_EMAIL_FONT};"
+_STRONG_STYLE = "color:#212121;"
+_CODE_STYLE = (
+    "font-family:ui-monospace,'SF Mono','Cascadia Code',monospace;"
+    "background:#f5f5f5;padding:2px 6px;border-radius:4px;font-size:13px;"
+)
+_A_STYLE = "color:#1976d2;text-decoration:none;"
+
+# Chrome {{var}} → string.Template ${var} mapping.
+# Send-time Resend placeholders become {{{triple-brace}}} which string.Template ignores.
+_CHROME_VAR_MAP = (
+    ("{{unsubscribe_url}}", "{{{unsubscribe}}}"),
+    ("{{preferences_url}}", "{{{preferences_url}}}"),
+    ("{{subject}}", "${subject}"),
+    ("{{preheader}}", "${preheader}"),
+    ("{{issue_label}}", "${issue_label}"),
+    ("{{sender_address}}", "${sender_address}"),
+)
+
+SENDER_ADDRESS_PLACEHOLDER = (
+    "JMo Security Tools &middot; open-source project &middot; "
+    '<a href="https://jmotools.com" style="color:#616161;">jmotools.com</a>'
+)
 
 
 @dataclass(frozen=True)
@@ -108,6 +143,7 @@ def generate_draft(
     customer_story_path: Optional[Path] = None,
     version: Optional[str] = None,
     template_path: Optional[Path] = None,
+    chrome_path: Optional[Path] = None,
     repo_root: Optional[Path] = None,
     include_customer_story: bool = True,
 ) -> NewsletterDraft:
@@ -126,8 +162,10 @@ def generate_draft(
     """
     repo = repo_root or REPO_ROOT
     template = template_path or DEFAULT_TEMPLATE
+    chrome = chrome_path or DEFAULT_CHROME
 
-    template_text = template.read_text(encoding="utf-8")
+    template_body = template.read_text(encoding="utf-8")
+    chrome_text = chrome.read_text(encoding="utf-8")
     changelog_text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
 
     if version:
@@ -171,8 +209,26 @@ def generate_draft(
     )
     badge_label = "Release Notes" if len(entries) == 1 else "Release Round-Up"
 
-    rendered_html = string.Template(template_text).substitute(
+    preheader = _build_preheader(primary, entries)
+    issue_label = (
+        f"v{primary.version}" if len(entries) == 1 else _multi_version_label(entries)
+    )
+
+    # Merge newsletter body into chrome content slot (standalone line only —
+    # the chrome file comment also contains the slot marker inline).
+    combined = re.sub(
+        r"(?m)^\s*<!--CONTENT-->\s*$",
+        lambda _: template_body,
+        chrome_text,
+        count=1,
+    )
+    for old, new in _CHROME_VAR_MAP:
+        combined = combined.replace(old, new)
+
+    rendered_html = string.Template(combined).substitute(
         subject=html.escape(subject),
+        preheader=html.escape(preheader),
+        issue_label=html.escape(issue_label),
         badge_label=html.escape(badge_label),
         headline=html.escape(f"JMo Security v{headline_version}"),
         meta_line=_meta_line(entries),
@@ -182,6 +238,7 @@ def generate_draft(
             f"https://github.com/jimmy058910/jmo-security-repo/releases/tag/v{primary.version}"
         ),
         primary_cta_label=f"View v{primary.version} on GitHub",
+        sender_address=SENDER_ADDRESS_PLACEHOLDER,
     )
 
     plain_text = _html_to_plain_text(rendered_html)
@@ -299,21 +356,21 @@ def _markdown_to_email_html(md: str) -> str:
             if in_list:
                 out.append("</ul>")
                 in_list = False
-            out.append(f"<h2>{html.escape(line[4:].strip())}</h2>")
+            out.append(f'<h2 style="{_H2_STYLE}">{html.escape(line[4:].strip())}</h2>')
             continue
 
         if line.startswith("## "):
             if in_list:
                 out.append("</ul>")
                 in_list = False
-            out.append(f"<h2>{html.escape(line[3:].strip())}</h2>")
+            out.append(f'<h2 style="{_H2_STYLE}">{html.escape(line[3:].strip())}</h2>')
             continue
 
         if line.startswith("- ") or line.startswith("* "):
             if not in_list:
-                out.append("<ul>")
+                out.append(f'<ul style="{_UL_STYLE}">')
                 in_list = True
-            out.append(f"  <li>{_inline_md(line[2:])}</li>")
+            out.append(f'  <li style="{_LI_STYLE}">{_inline_md(line[2:])}</li>')
             continue
 
         if not line.strip():
@@ -330,7 +387,7 @@ def _markdown_to_email_html(md: str) -> str:
 
         text = _inline_md(line.strip())
         if text:
-            out.append(f"<p>{text}</p>")
+            out.append(f'<p style="{_P_STYLE}">{text}</p>')
 
     if in_list:
         out.append("</ul>")
@@ -341,9 +398,21 @@ def _markdown_to_email_html(md: str) -> str:
 def _inline_md(text: str) -> str:
     """Apply inline markdown (bold, code, links) to an already-escaped fragment."""
     text = html.escape(text)
-    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
-    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
-    text = re.sub(r"\[([^\]]+)\]\(([^)\s]+)\)", r'<a href="\2">\1</a>', text)
+    text = re.sub(
+        r"\*\*(.+?)\*\*",
+        rf'<strong style="{_STRONG_STYLE}">\1</strong>',
+        text,
+    )
+    text = re.sub(
+        r"`([^`]+)`",
+        rf'<code style="{_CODE_STYLE}">\1</code>',
+        text,
+    )
+    text = re.sub(
+        r"\[([^\]]+)\]\(([^)\s]+)\)",
+        rf'<a href="\2" style="{_A_STYLE}">\1</a>',
+        text,
+    )
     return text
 
 
@@ -356,7 +425,7 @@ def _render_customer_story_block(story_md: Optional[str]) -> str:
     if not story_md or not story_md.strip():
         return ""
     body_html = _markdown_to_email_html(story_md)
-    return f"<h2>Customer Story</h2>\n{body_html}\n"
+    return f'<h2 style="{_H2_STYLE}">Customer Story</h2>\n{body_html}\n'
 
 
 def _extract_customer_quote(story_md: Optional[str]) -> Optional[str]:
@@ -429,6 +498,15 @@ def _multi_version_label(entries: list[ReleaseEntry]) -> str:
     return f"{entries[-1].version} \u2192 {entries[0].version}"
 
 
+def _build_preheader(primary: ReleaseEntry, entries: list[ReleaseEntry]) -> str:
+    """Build hidden inbox-preview text (kept under ~90 chars)."""
+    if len(entries) == 1:
+        tag = _first_subsection_title(primary.raw_markdown) or "what's new"
+        return f"JMo Security v{primary.version} is out \u2014 {tag}"
+    versions = _multi_version_label(entries)
+    return f"JMo Security {versions} \u2014 catch up on what shipped"
+
+
 # ---------------------------------------------------------------------------
 # HTML -> plain text fallback
 # ---------------------------------------------------------------------------
@@ -452,6 +530,9 @@ _BLOCK_TAGS_TO_NEWLINE = (
 def _html_to_plain_text(rendered_html: str) -> str:
     """Best-effort HTML -> plain-text conversion for the email fallback body."""
     text = rendered_html
+    text = re.sub(
+        r"<!--[\s\S]*?-->", "", text
+    )  # strip HTML comments (e.g. chrome header)
     text = re.sub(r"<style[\s\S]*?</style>", "", text, flags=re.IGNORECASE)
     text = re.sub(r"<head[\s\S]*?</head>", "", text, flags=re.IGNORECASE)
     text = re.sub(r"<script[\s\S]*?</script>", "", text, flags=re.IGNORECASE)

--- a/scripts/core/newsletter/template.html
+++ b/scripts/core/newsletter/template.html
@@ -1,141 +1,99 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${subject}</title>
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      line-height: 1.65;
-      color: #1a202c;
-      max-width: 620px;
-      margin: 0 auto;
-      padding: 24px 16px;
-      background: #f7fafc;
-    }
-    .card {
-      background: #ffffff;
-      border-radius: 12px;
-      padding: 32px 36px;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.07);
-    }
-    .greeting {
-      font-size: 15px;
-      color: #2d3748;
-      margin-bottom: 18px;
-    }
-    .badge {
-      display: inline-block;
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: #fff;
-      padding: 4px 14px;
-      border-radius: 20px;
-      font-size: 13px;
-      font-weight: 600;
-      letter-spacing: 0.3px;
-      margin-bottom: 16px;
-    }
-    h1 { font-size: 24px; margin: 0 0 6px 0; color: #1a202c; }
-    .meta { font-size: 13px; color: #718096; margin-bottom: 24px; }
-    h2 {
-      font-size: 15px;
-      color: #667eea;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      margin: 28px 0 10px;
-      border-bottom: 1px solid #e2e8f0;
-      padding-bottom: 6px;
-    }
-    p { margin: 0 0 14px; font-size: 15px; }
-    ul { padding-left: 20px; margin: 0 0 14px; }
-    li { margin-bottom: 8px; font-size: 15px; }
-    strong { color: #2d3748; }
-    code {
-      background: #edf2f7;
-      color: #553c9a;
-      padding: 2px 6px;
-      border-radius: 4px;
-      font-family: 'Menlo', 'Courier New', monospace;
-      font-size: 13px;
-    }
-    blockquote {
-      border-left: 3px solid #667eea;
-      margin: 12px 0 16px;
-      padding: 6px 16px;
-      background: #f7fafc;
-      color: #2d3748;
-      font-style: italic;
-    }
-    blockquote .attribution {
-      display: block;
-      margin-top: 8px;
-      font-size: 13px;
-      font-style: normal;
-      color: #718096;
-    }
-    .cta-row { text-align: center; margin: 32px 0 20px; }
-    .cta {
-      background: #667eea;
-      color: #ffffff !important;
-      padding: 12px 28px;
-      border-radius: 8px;
-      text-decoration: none;
-      font-weight: 600;
-      font-size: 15px;
-      display: inline-block;
-    }
-    .cta-secondary {
-      background: transparent;
-      color: #667eea !important;
-      border: 1px solid #cbd5e0;
-      margin-left: 6px;
-    }
-    .footer {
-      margin-top: 28px;
-      font-size: 12px;
-      color: #a0aec0;
-      text-align: center;
-      border-top: 1px solid #e2e8f0;
-      padding-top: 20px;
-    }
-    .footer a { color: #a0aec0; }
-  </style>
-</head>
-<body>
-  <div class="card">
-    <p class="greeting">Hey {{{first_name|there}}},</p>
+<!--
+  Newsletter body content — injected into docs/brand/templates/email-chrome.html at build time.
 
-    <div class="badge">${badge_label}</div>
-    <h1>${headline}</h1>
-    <div class="meta">${meta_line}</div>
+  Build-time placeholders (dollar-brace format — Python string.Template, filled by draft_generator.py):
+    subject, preheader, issue_label, badge_label, headline, meta_line,
+    release_body_html, customer_story_block, primary_cta_url, primary_cta_label,
+    sender_address
 
-    <h2>What's New</h2>
-    ${release_body_html}
+  Send-time placeholders (triple-brace format — Resend hydrates per-recipient at broadcast time):
+    first_name|there           — personalized greeting fallback
+    unsubscribe_url and preferences_url live in the chrome footer — do not duplicate here.
 
-    ${customer_story_block}
+  Inline styles only. Gmail and most mobile clients strip <style> blocks.
+  All color values are inlined from docs/brand/tokens.css:
+    --jmo-brand-primary:      #1976d2
+    --jmo-brand-primary-dark: #0d47a1
+    --jmo-neutral-800:        #424242  (body text)
+    --jmo-neutral-900:        #212121  (headings / strong)
+    --jmo-neutral-500:        #9e9e9e  (muted)
+    --jmo-neutral-200:        #eeeeee  (dividers)
+    --jmo-neutral-100:        #f5f5f5  (code bg)
 
-    <h2>Help Spread the Word</h2>
-    <p>JMo Security is open source and built in the open. If it has saved you a few hours of stitching scanners together, the best ways to support the project are:</p>
-    <ul>
-      <li><strong>Star the repo</strong> &mdash; signal-boosts visibility for other practitioners.</li>
-      <li><strong>File an issue or contribute</strong> &mdash; new tool adapters, dashboard polish, and docs are all great first PRs.</li>
-      <li><strong>Share a war story</strong> &mdash; reply to this email if JMo caught something interesting; we feature reader stories in future digests.</li>
-    </ul>
+  Severity callout colors (token-sourced — no new hardcoded hex values):
+    critical: color:#d32f2f;font-weight:600   (--jmo-severity-critical)
+    high:     color:#f57c00;font-weight:600   (--jmo-severity-high)
+    medium:   color:#fbc02d;font-weight:600   (--jmo-severity-medium, use sparingly on white)
+    low:      color:#7cb342;font-weight:600   (--jmo-severity-low)
+    info:     color:#757575                   (--jmo-severity-info)
+-->
 
-    <div class="cta-row">
-      <a class="cta" href="${primary_cta_url}">${primary_cta_label}</a>
-      <a class="cta cta-secondary" href="https://github.com/jimmy058910/jmo-security-repo">Star on GitHub</a>
-    </div>
+        <!-- Greeting -->
+        <p style="font-size:15px;color:#424242;margin:0 0 20px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+          Hey {{{first_name|there}}},
+        </p>
 
-    <div class="footer">
-      <p>
-        You're receiving this because you subscribed at jmotools.com.<br>
-        <a href="{{{unsubscribe}}}">Unsubscribe</a> &nbsp;&middot;&nbsp;
-        <a href="https://jmotools.com">jmotools.com</a> &nbsp;&middot;&nbsp;
-        <a href="https://github.com/jimmy058910/jmo-security-repo">GitHub</a>
-      </p>
-    </div>
-  </div>
-</body>
-</html>
+        <!-- Badge -->
+        <p style="margin:0 0 10px;">
+          <span style="display:inline-block;background-color:#0d47a1;color:#ffffff;padding:4px 12px;border-radius:20px;font-size:12px;font-weight:600;letter-spacing:0.3px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+            ${badge_label}
+          </span>
+        </p>
+
+        <!-- Headline -->
+        <h1 style="font-size:24px;font-weight:700;color:#212121;margin:0 0 6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+          ${headline}
+        </h1>
+
+        <!-- Meta line (release date + changelog link) -->
+        <p style="font-size:13px;color:#757575;margin:0 0 28px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+          ${meta_line}
+        </p>
+
+        <!-- Release notes section -->
+        <h2 style="font-size:15px;color:#1976d2;text-transform:uppercase;letter-spacing:0.5px;margin:0 0 10px;border-bottom:1px solid #eeeeee;padding-bottom:6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+          What&#8217;s New
+        </h2>
+
+        ${release_body_html}
+
+        ${customer_story_block}
+
+        <!-- Community CTA -->
+        <h2 style="font-size:15px;color:#1976d2;text-transform:uppercase;letter-spacing:0.5px;margin:28px 0 10px;border-bottom:1px solid #eeeeee;padding-bottom:6px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+          Help Spread the Word
+        </h2>
+
+        <p style="margin:0 0 14px;font-size:15px;color:#424242;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+          JMo Security is open source and built in the open. If it has saved you a few hours of stitching scanners together, the best ways to support the project are:
+        </p>
+
+        <ul style="padding-left:20px;margin:0 0 14px;">
+          <li style="margin-bottom:8px;font-size:15px;color:#424242;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+            <strong style="color:#212121;">Star the repo</strong> &mdash; signal-boosts visibility for other practitioners.
+          </li>
+          <li style="margin-bottom:8px;font-size:15px;color:#424242;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+            <strong style="color:#212121;">File an issue or contribute</strong> &mdash; new tool adapters, dashboard polish, and docs are all great first PRs.
+          </li>
+          <li style="margin-bottom:8px;font-size:15px;color:#424242;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+            <strong style="color:#212121;">Share a war story</strong> &mdash; reply to this email if JMo caught something interesting; we feature reader stories in future digests.
+          </li>
+        </ul>
+
+        <!-- CTA buttons — table-based for email client compatibility -->
+        <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:32px 0 20px;">
+          <tr>
+            <td style="padding-right:8px;">
+              <a href="${primary_cta_url}"
+                 style="display:inline-block;background-color:#1976d2;color:#ffffff;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600;font-size:15px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+                ${primary_cta_label}
+              </a>
+            </td>
+            <td>
+              <a href="https://github.com/jimmy058910/jmo-security-repo"
+                 style="display:inline-block;background-color:#ffffff;color:#1976d2;border:1px solid #e0e0e0;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600;font-size:15px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+                Star on GitHub
+              </a>
+            </td>
+          </tr>
+        </table>

--- a/tests/unit/test_newsletter_draft.py
+++ b/tests/unit/test_newsletter_draft.py
@@ -42,29 +42,53 @@ Smaller follow-up.
 - Edge case in parser
 """
 
-MIN_TEMPLATE = """\
-<html>
+# Minimal chrome that exercises all {{var}} placeholders the generator maps.
+MIN_CHROME = """\
+<!DOCTYPE html>
+<html lang="en">
+<head><title>{{subject}}</title></head>
 <body>
+<div style="display:none;">{{preheader}}</div>
+<table>
+  <tr>
+    <td>JMo Security</td>
+    <td>{{issue_label}}</td>
+  </tr>
+  <tr>
+    <td>
+      <!--CONTENT-->
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="{{unsubscribe_url}}">Unsubscribe</a>
+      <a href="{{preferences_url}}">Preferences</a>
+      <p>{{sender_address}}</p>
+    </td>
+  </tr>
+</table>
+</body>
+</html>
+"""
+
+# Newsletter body only — injected into MIN_CHROME at build time.
+MIN_TEMPLATE = """\
 <p>Hey {{{first_name|there}}},</p>
 <h1>${headline}</h1>
 <div>${meta_line}</div>
 <div class="badge">${badge_label}</div>
-<title>${subject}</title>
 <section>${release_body_html}</section>
 ${customer_story_block}
 <a href="${primary_cta_url}">${primary_cta_label}</a>
-<a href="{{{unsubscribe}}}">Unsubscribe</a>
-</body>
-</html>
 """
 
 
 @pytest.fixture
 def repo_root(tmp_path: Path) -> Path:
-    """Build a tiny pretend-repo with a CHANGELOG and template."""
+    """Build a tiny pretend-repo with a CHANGELOG, template body, and chrome."""
     (tmp_path / "CHANGELOG.md").write_text(CHANGELOG_FIXTURE, encoding="utf-8")
-    template_path = tmp_path / "template.html"
-    template_path.write_text(MIN_TEMPLATE, encoding="utf-8")
+    (tmp_path / "template.html").write_text(MIN_TEMPLATE, encoding="utf-8")
+    (tmp_path / "chrome.html").write_text(MIN_CHROME, encoding="utf-8")
     return tmp_path
 
 
@@ -145,19 +169,20 @@ def test_inline_md_escapes_html_first():
 
 def test_inline_md_supports_bold_code_links():
     out = dg._inline_md("**bold** with `code` and [link](https://example.com)")
-    assert "<strong>bold</strong>" in out
-    assert "<code>code</code>" in out
-    assert '<a href="https://example.com">link</a>' in out
+    assert "<strong" in out and "bold</strong>" in out
+    assert "<code" in out and "code</code>" in out
+    assert 'href="https://example.com"' in out and ">link</a>" in out
 
 
 def test_markdown_to_email_html_handles_bullets():
     md = "### Heading\n\n- one\n- two\n\nplain paragraph"
     out = dg._markdown_to_email_html(md)
-    assert "<h2>Heading</h2>" in out
-    assert "<ul>" in out
-    assert "<li>one</li>" in out
-    assert "<li>two</li>" in out
-    assert "<p>plain paragraph</p>" in out
+    assert "Heading</h2>" in out
+    assert "<h2" in out
+    assert "<ul" in out
+    assert "one</li>" in out
+    assert "two</li>" in out
+    assert "plain paragraph</p>" in out
 
 
 def test_html_to_plain_text_strips_tags_and_renders_links():
@@ -180,6 +205,7 @@ def test_generate_draft_default_release_only(repo_root: Path, tmp_path: Path):
         output_dir=out_dir,
         repo_root=repo_root,
         template_path=repo_root / "template.html",
+        chrome_path=repo_root / "chrome.html",
         include_customer_story=False,
     )
     assert draft.version == "2.0.0"
@@ -206,6 +232,7 @@ def test_generate_draft_with_customer_story(repo_root: Path, tmp_path: Path):
         output_dir=tmp_path / "drafts",
         repo_root=repo_root,
         template_path=repo_root / "template.html",
+        chrome_path=repo_root / "chrome.html",
         customer_story_path=story_path,
     )
     assert "Customer Story" in draft.html
@@ -219,6 +246,7 @@ def test_generate_draft_missing_story_silently_omits(repo_root: Path, tmp_path: 
         output_dir=tmp_path / "drafts",
         repo_root=repo_root,
         template_path=repo_root / "template.html",
+        chrome_path=repo_root / "chrome.html",
         customer_story_path=tmp_path / "does-not-exist.md",
     )
     assert "Customer Story" not in draft.html
@@ -229,6 +257,7 @@ def test_generate_draft_date_range(repo_root: Path, tmp_path: Path):
         output_dir=tmp_path / "drafts",
         repo_root=repo_root,
         template_path=repo_root / "template.html",
+        chrome_path=repo_root / "chrome.html",
         date_range_start=datetime.date(2026, 4, 1),
         date_range_end=datetime.date(2026, 7, 1),
         include_customer_story=False,
@@ -243,6 +272,7 @@ def test_generate_draft_pinned_version(repo_root: Path, tmp_path: Path):
         output_dir=tmp_path / "drafts",
         repo_root=repo_root,
         template_path=repo_root / "template.html",
+        chrome_path=repo_root / "chrome.html",
         version="1.9.0",
         include_customer_story=False,
     )
@@ -256,6 +286,7 @@ def test_generate_draft_empty_date_range_raises(repo_root: Path, tmp_path: Path)
             output_dir=tmp_path / "drafts",
             repo_root=repo_root,
             template_path=repo_root / "template.html",
+            chrome_path=repo_root / "chrome.html",
             date_range_start=datetime.date(2030, 1, 1),
             date_range_end=datetime.date(2030, 12, 31),
             include_customer_story=False,


### PR DESCRIPTION
## Summary

Refactors the newsletter template to consume the canonical brand chrome (`docs/brand/templates/email-chrome.html`) rather than duplicating header/footer markup. A single edit to `email-chrome.html` now propagates to every newsletter draft without manual sync.

The implementation uses **build-time string substitution**: `draft_generator.py` reads the chrome at draft-generation time, inserts the newsletter body into the `<!--CONTENT-->` slot, maps chrome `{{vars}}` to `string.Template` format, then runs a single substitution pass. No new dependencies.

Key changes:
- `template.html` rebuilt as a body-content fragment only (no HTML doc, no `<style>` block — all inline styles, Gmail-safe)
- All severity callout colors (`#d32f2f`, `#f57c00`, `#fbc02d`, `#7cb342`, `#757575`) sourced from `tokens.css` — no new hardcoded hex values
- `_markdown_to_email_html` and `_inline_md` now emit inline styles using brand token values (was relying on stripped `<style>` block)
- New template vars: `preheader`, `issue_label`, `sender_address`
- `_html_to_plain_text` strips HTML comments (prevents chrome developer notes appearing in text fallback)
- Fixed a broken HTML comment in `email-chrome.html` (embedded `<!--CONTENT-->` reference would prematurely close the file comment in generated output)

## Files Changed

- `scripts/core/newsletter/template.html` — rebuilt as newsletter body content slot (inline styles, brand tokens)
- `scripts/core/newsletter/draft_generator.py` — chrome integration, new vars, inline styles in HTML/markdown converters
- `tests/unit/test_newsletter_draft.py` — `MIN_CHROME` fixture, `chrome_path` param, updated structural assertions
- `docs/brand/templates/email-chrome.html` — fix embedded `<!--CONTENT-->` reference in file comment

## Paperclip

- Issue: JMOAA-67
- Agent: Content Manager
- Company: Security Suite

## Testing

- `pytest tests/unit/test_newsletter_draft.py` — 23/23 pass
- `python3 -m scripts.core.newsletter.draft_generator --no-customer-story --print` — smoke-tested against real CHANGELOG and chrome, verified: brand navy header `#0d47a1`, brand blue CTAs `#1976d2`, Resend send-time vars survive, no `<style>` block, no purple `#667eea`