### PR TITLE
chore: community-PR-readiness polish (Tier A + B)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# CODEOWNERS — auto-requests review from listed owners on PRs touching matching paths.
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Single-maintainer project today: catch-all to the repository owner.
+# When the project gains co-maintainers, add path-scoped lines above the catch-all,
+# e.g.:
+#   /scripts/core/adapters/  @jimmy058910 @some-other-maintainer
+#   /scripts/dashboard/      @jimmy058910 @frontend-maintainer
+
+* @jimmy058910

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,24 @@
 ## Summary
 
-Describe the change in 1–2 sentences.
+Describe the change in 1-2 sentences.
+
+## Linked issues
+
+<!-- Use GitHub closing keywords (Closes/Fixes #N) so the issue auto-closes on merge. -->
+
+Closes #
+Related to #
 
 ## Changes
 
 - [ ] Code
 - [ ] Tests
 - [ ] Docs
+- [ ] Breaking change (CLI flag, output format, public API, schema)
 
 ## Motivation / Context
 
-Why is this change needed? Reference related issues.
+Why is this change needed?
 
 ## How to test
 
@@ -21,3 +29,4 @@ Provide quick steps or commands to verify the change locally.
 - [ ] Ran `make fmt && make lint && make test`
 - [ ] Updated docs (README/QUICKSTART/USER_GUIDE) if behavior changed
 - [ ] Considered backward compatibility for CLI flags/outputs
+- [ ] Added a `CHANGELOG.md` entry if this is user-facing

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+This project adopts the **Contributor Covenant, version 2.1**, available at:
+
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>
+
+The Covenant defines the standards of behavior expected from contributors,
+maintainers, and anyone interacting with this project (issues, pull requests,
+discussions, chat, code review, etc.). All participants are bound by it.
+
+## Scope
+
+This Code applies within all project spaces and in public spaces when an
+individual is representing the project or its community.
+
+## Reporting
+
+To report a concern about behavior in this project, open a private GitHub
+Security Advisory:
+
+<https://github.com/jimmy058910/jmo-security-repo/security/advisories/new>
+
+The advisory channel is monitored only by maintainers and is the same private
+intake used for security vulnerabilities. Reports will be acknowledged within
+48 hours.
+
+## Enforcement
+
+Maintainers will follow the Contributor Covenant's
+[Enforcement Guidelines](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines)
+when responding to reports. Possible outcomes range from a private warning to
+a permanent ban from project spaces, scaled to severity.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/),
+which is available under the
+[Creative Commons Attribution 4.0 license](https://creativecommons.org/licenses/by/4.0/).
+
+For answers to common questions about this Code, see the
+[Contributor Covenant FAQ](https://www.contributor-covenant.org/faq/).
+Translations are available at
+<https://www.contributor-covenant.org/translations/>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,7 @@
 
 **DO NOT** create public GitHub issues for security vulnerabilities.
 
-Instead, please report security issues privately via:
-
-- **Email:** [security contact - update with your email]
-- **GitHub Security Advisories:** <https://github.com/jimmy058910/jmo-security-repo/security/advisories/new>
+Please report security issues privately via [GitHub Security Advisories](https://github.com/jimmy058910/jmo-security-repo/security/advisories/new). This creates a private report visible only to maintainers and triggers GitHub's standard CVE coordination workflow.
 
 We aim to respond to security reports within **48 hours** and provide a fix within **7 days** for critical vulnerabilities.
 


### PR DESCRIPTION
## Summary

File-level community-PR-readiness polish from the recent `.github/` audit. Settings changes (ruleset extension + merge-style lock) applied separately via `gh api`.

## Linked issues

None — proactive maintenance. Community PR volume is currently speculative; this PR adds the deflectors that work even at zero volume (CODEOWNERS auto-requests review on Dependabot PRs too, PR template forces clearer descriptions on solo work).

## What's in this PR

**Tier A**
- `SECURITY.md` — Removed `[security contact - update with your email]` placeholder; collapsed into the existing GH Security Advisories pointer (already the canonical private channel on the next line).

**Tier B**
- `.github/CODEOWNERS` — Catch-all to `@jimmy058910`; auto-requests review on every PR. Structured comments for future co-maintainers.
- `CODE_OF_CONDUCT.md` — Adopts Contributor Covenant 2.1 *by reference* (~30 lines vs verbatim re-host ~150 lines). Same governing standard, less maintenance. Reporting via GH Security Advisories (same private intake).
- `.github/PULL_REQUEST_TEMPLATE.md` — Added Linked Issues section (Closes/Related), Breaking-change checkbox, CHANGELOG checkbox (CLAUDE.md treats CHANGELOG as a release gate for user-facing changes).

## What's NOT in this PR (settings, not files)

Applied via `gh api`:
- Existing ruleset `Protect main branch (minimal)` extended with `pull_request` (required, 0 approvals — solo dev), `non_fast_forward` (block force push), `deletion` (block branch deletion).
- Repo merge style locked to squash-only (disable merge-commit + rebase-merge).

## Tier C/D explicitly deferred per longevity-bias

- `.yml` issue forms — current `.md` forms work for low volume
- `actions/stale@v9` workflow — issue backlog manageable
- `claude-code-action` deployment — community volume "totally speculative" per audit conversation

## How to test

- New PRs will use the updated template (Linked Issues, breaking-change, CHANGELOG)
- This PR itself should auto-request `@jimmy058910` via CODEOWNERS
- `SECURITY.md` line 9 placeholder is gone
- `CONTRIBUTING.md`'s reference to "a standard code of conduct" now resolves to `CODE_OF_CONDUCT.md`

## Checklist

- [x] Ran pre-commit hooks (markdownlint passed, no code to lint)
- [x] Updated docs (this PR IS the docs)
- [x] No backward compat impact (config/policy files only)
- [ ] CHANGELOG entry — N/A (internal config, not user-facing behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Code of Conduct establishing community standards
  * Updated security vulnerability reporting process to use GitHub Security Advisories

* **Chores**
  * Added code ownership configuration
  * Enhanced pull request template with CHANGELOG entry requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->