### PR TITLE
chore(deps): weekly auto-update of security tools and pre-commit hooks (May 3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
 
   # Validate GitHub Actions workflows
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
+    rev: v1.7.12
     hooks:
       - id: actionlint
         # Enable colorized output in local runs; CI may ignore colors
@@ -60,18 +60,18 @@ repos:
 
   # Markdown linting (cli2 shares .markdownlint-cli2.jsonc config with CI)
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.21.0
+    rev: v0.22.1
     hooks:
       - id: markdownlint-cli2
 
   # Python format/lint (Black MUST run before Ruff per jmo-ci-debugger #15)
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.3.1
     hooks:
       - id: black
         exclude: ^\.claude/
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -79,7 +79,7 @@ repos:
 
   # Type checking (optimized for incremental mode)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.2
     hooks:
       - id: mypy
         additional_dependencies: [types-PyYAML, types-croniter, types-requests, types-tabulate]
@@ -92,7 +92,7 @@ repos:
   # Security and shell formatting
   # Note: Using --format json avoids Windows cp1252 encoding issues with Unicode arrows
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.9.3
+    rev: 1.9.4
     hooks:
       - id: bandit
         name: bandit (scripts only)
@@ -104,7 +104,7 @@ repos:
       - id: shellcheck
         args: ["-S", "error", "-e", "SC2016,SC2028"]
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.12.0-2
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
 

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -188,8 +188,8 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 # Note: checkov and prowler have conflicting dependencies - install separately
 # Note: Ubuntu 24.04 ships pip 24.0/setuptools 68.1/wheel 0.42 (sufficient, skip upgrade)
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
-    semgrep==1.159.0 \
-    checkov==3.2.501 \
+    semgrep==1.161.0 \
+    checkov==3.2.526 \
     ruff==0.15.2 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -247,14 +247,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python security tools one by one for better error visibility
 # Note: Ubuntu 24.04 ships pip 24.0/setuptools 68.1/wheel 0.42 (sufficient, skip upgrade)
-RUN python3 -m pip install --no-cache-dir --break-system-packages bandit==1.9.3 && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages bandit==1.9.4 && \
     echo "✓ bandit installed"
 
-RUN python3 -m pip install --no-cache-dir --break-system-packages semgrep==1.159.0 && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages semgrep==1.161.0 && \
     semgrep --version && \
     echo "✓ semgrep installed"
 
-RUN python3 -m pip install --no-cache-dir --break-system-packages checkov==3.2.501 && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages checkov==3.2.526 && \
     checkov --version && \
     echo "✓ checkov installed"
 

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -114,8 +114,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Python tools (minimal for fast variant)
 # Note: Ubuntu 24.04 ships pip 24.0/setuptools 68.1/wheel 0.42 (sufficient, skip upgrade)
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
-    semgrep==1.159.0 \
-    checkov==3.2.501 \
+    semgrep==1.161.0 \
+    checkov==3.2.526 \
     ruff==0.15.2 \
     && find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -156,8 +156,8 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 # Note: checkov and prowler have conflicting dependencies - install separately
 # Note: Ubuntu 24.04 ships pip 24.0/setuptools 68.1/wheel 0.42 (sufficient, skip upgrade)
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
-    semgrep==1.159.0 \
-    checkov==3.2.501 \
+    semgrep==1.161.0 \
+    checkov==3.2.526 \
     ruff==0.15.2 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,19 +1,19 @@
 schema_version: '1.0'
 python_tools:
   bandit:
-    version: 1.9.3
+    version: 1.9.4
     pypi_package: bandit
     description: Python security linter
     update_check: pip index versions bandit
     critical: false
   semgrep:
-    version: 1.159.0
+    version: 1.161.0
     pypi_package: semgrep
     description: Multi-language SAST scanner
     update_check: pip index versions semgrep
     critical: true
   checkov:
-    version: 3.2.501
+    version: 3.2.526
     pypi_package: checkov
     description: IaC security scanner
     update_check: pip index versions checkov
@@ -57,7 +57,7 @@ python_tools:
       '
     installation: git clone (pinned version) or apt-get install lynis
   prowler:
-    version: 5.18.2
+    version: 5.25.1
     pypi_package: prowler
     description: Multi-cloud CSPM (AWS/Azure/GCP/K8s)
     update_check: pip index versions prowler
@@ -372,6 +372,58 @@ update_policies:
   automated_check_schedule: Weekly (Sunday 00:00 UTC)
   manual_review_schedule: First Monday of each month
 version_history:
+- date: '2026-05-03'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-03'
+  action: Updated prowler
+  tools_updated:
+  - tool: prowler
+    old_version: 5.18.2
+    new_version: 5.25.1
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-03'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-03'
+  action: Updated checkov
+  tools_updated:
+  - tool: checkov
+    old_version: 3.2.501
+    new_version: 3.2.526
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-03'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-03'
+  action: Updated semgrep
+  tools_updated:
+  - tool: semgrep
+    old_version: 1.159.0
+    new_version: 1.161.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-03'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-03'
+  action: Updated bandit
+  tools_updated:
+  - tool: bandit
+    old_version: 1.9.3
+    new_version: 1.9.4
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
 - date: '2026-04-21'
   action: P0/P1 critical tool version updates
   tools_updated:


### PR DESCRIPTION
## Summary

Recovering the May 3 weekly auto-update from an orphan branch. Contains cumulative version bumps the auto-update workflow generated but never PR'd:

- `bandit` 1.9.3 → 1.9.4
- `semgrep` 1.159.0 → 1.161.0
- `checkov` 3.2.501 → 3.2.526
- Plus aligned Dockerfile pinning and `.pre-commit-config.yaml` touchups

## Why this exists

The branch was generated by `.github/workflows/maintenance.yml`'s weekly bump job on 2026-05-03 but never opened as a PR (likely because of the chronic Sunday cron failures resolved in PR #396 — it ran successfully but the PR-creation step had a label-handling bug that caused silent no-op).

## Test plan

- Verify CI quick-checks pass against the merged tree
- Spot-check `versions.yaml` diff for sanity
- The Dockerfile changes are mechanical pinning updates — no logic changes

## Checklist

- [x] Generated by automation; no manual edits
- [x] Squash-merge per ruleset
- [ ] CHANGELOG — N/A for tool version bumps unless behavior-changing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Python security and code analysis tools (semgrep, checkov, bandit, prowler) to latest versions for improved vulnerability detection and code quality
* Updated pre-commit hooks including linters and formatters to their latest stable versions for enhanced development workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->