### PR TITLE
ci: add github-release job to release.yml + backfill workflow for v1.0.0-v1.0.5 (re-PR of #393)

### DIFF
--- a/.github/workflows/backfill-github-releases.yml
+++ b/.github/workflows/backfill-github-releases.yml
@@ -1,0 +1,51 @@
+---
+name: Backfill GitHub Releases (one-shot)
+# Run once after JMOAA-50 merges to create Releases for v1.0.0–v1.0.5.
+# Safe to re-run: skips any tag that already has a GitHub Release.
+# Archive or delete this workflow after all 6 releases are confirmed.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  backfill:
+    name: Backfill v1.0.0–v1.0.5 GitHub Releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Backfill releases from CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for TAG in v1.0.0 v1.0.1 v1.0.2 v1.0.3 v1.0.4 v1.0.5; do
+            echo ""
+            echo "=== Processing $TAG ==="
+
+            if gh release view "$TAG" > /dev/null 2>&1; then
+              echo "$TAG release already exists — skipping"
+              continue
+            fi
+
+            python3 scripts/dev/generate_release_notes.py "$TAG" > /tmp/raw-notes.txt || {
+              echo "ERROR: Failed to generate notes for $TAG — skipping"
+              continue
+            }
+            sed -n '/^# Release/,$p' /tmp/raw-notes.txt > /tmp/release-notes.md
+
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file /tmp/release-notes.md \
+              --verify-tag
+
+            echo "Created GitHub Release: $TAG"
+          done
+          echo ""
+          echo "Backfill complete."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -864,6 +864,41 @@ jobs:
           echo "2. Add secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN"
           echo "3. Set repository variable DOCKERHUB_ENABLED=true"
 
+  # Create GitHub Release from CHANGELOG.md notes
+  # Runs after PyPI publish and Docker manifest merge so the release page links
+  # to an already-available package and Docker image.
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [pypi-publish, docker-merge]
+    if: always() && startsWith(github.ref, 'refs/tags/v') && needs.pypi-publish.result == 'success'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          python3 scripts/dev/generate_release_notes.py "$TAG" > /tmp/raw-notes.txt
+          # Extract from the "# Release" heading onwards (strips diagnostic print lines)
+          sed -n '/^# Release/,$p' /tmp/raw-notes.txt > /tmp/release-notes.md
+          echo "Preview (first 20 lines):"
+          head -20 /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file /tmp/release-notes.md \
+            --verify-tag
+
   # Verify PyPI badges auto-update correctly after release
   # NOTE: This job is non-blocking (continue-on-error: true) to prevent badge
   # caching from blocking the entire release. Badges will update within 15-30


### PR DESCRIPTION
## Summary

Re-opening #393's work on a fresh PR after the dev → main reconciliation (PR #427) auto-closed it. Same content, retargeted directly to main per project policy ("PR-direct-to-main, no dev staging").

## Linked issues

Replaces closed #393 (JMOAA-50). Original branch retained: `paperclip/tm/fix-release-yml-github-release`.

## Changes

- [ ] Code
- [x] CI/CD
- [ ] Docs
- [ ] Breaking change

## What this PR adds

1. New `github-release` job in `.github/workflows/release.yml` (+35 lines) — runs after `pypi-publish` + `docker-merge` to create a GitHub Release from `scripts/dev/generate_release_notes.py` output. Closes the manual gap that exists today (releases ship to PyPI + GHCR but no GitHub Release page is auto-created).
2. New `.github/workflows/backfill-github-releases.yml` (+51 lines) — one-shot workflow to retroactively create GitHub Release entries for v1.0.0 through v1.0.5.

## Note on workflow scope

This PR modifies `.github/workflows/release.yml`. Per `.claude/rules/release.rules.md`, merging via `gh pr merge` requires the `gh` CLI token to have the `workflow` scope. The repo owner can either:
- Run `gh auth refresh -h github.com -s workflow` once locally, then merge via `gh`
- Or merge via the GitHub UI (no scope needed)

## Test plan

- CI quick-checks validates lint + actionlint on the workflow files
- Post-merge: next release tag push will trigger the new `github-release` job
- `backfill-github-releases.yml` is `workflow_dispatch`-only — manually trigger after merge to create release entries for v1.0.0-v1.0.5

## Checklist

- [x] Pre-commit hooks pass
- [x] Updated docs N/A (CI-only, no user-facing behavior change)
- [x] Considered backward compat — purely additive, no existing behavior changes
- [ ] CHANGELOG entry — N/A (release-process automation, internal mechanic)