### PR TITLE
fix(ci, dashboard): pin uv, fix 2 jest tests, wire npm test into dashboard-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Validate requirements-dev.txt Python version
         run: |
-          python -m pip install uv
+          python -m pip install uv==0.11.15  # pinned: matches lockfile regen version (companion to PR #488)
           python scripts/dev/update_dependencies.py --validate
 
       - name: Check deps-compile freshness
@@ -60,7 +60,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
-          python -m pip install uv
+          python -m pip install uv==0.11.15  # pinned: matches lockfile regen version (companion to PR #488)
           uv pip compile --universal --python-version 3.12 -o requirements-dev.txt requirements-dev.in
           git diff --exit-code -- requirements-dev.txt || (echo "requirements-dev.txt is out of date. Run: make deps-compile" && exit 1)
 
@@ -677,11 +677,6 @@ jobs:
   # build` per scripts/dashboard/package.json:"build", which is the same path
   # the release pipeline bundles, so build success here implies release
   # bundleability.
-  #
-  # NOTE: `npm test` is intentionally NOT included here. 2 of 147 jest tests
-  # currently fail under the present component state (pagination drift on
-  # FindingsTable.test.tsx); tracked separately so this smoke job stays
-  # unblocked. See follow-up issue.
   dashboard-smoke:
     name: dashboard-smoke
     runs-on: ubuntu-latest
@@ -718,6 +713,11 @@ jobs:
         if: steps.changes.outputs.dashboard == 'true'
         working-directory: scripts/dashboard
         run: npm run build
+
+      - name: Test dashboard (jest)
+        if: steps.changes.outputs.dashboard == 'true'
+        working-directory: scripts/dashboard
+        run: npm test
 
       - name: Skip note (no dashboard changes)
         if: steps.changes.outputs.dashboard != 'true'

--- a/scripts/dashboard/tests/components/FindingsTable.test.tsx
+++ b/scripts/dashboard/tests/components/FindingsTable.test.tsx
@@ -177,8 +177,8 @@ describe('FindingsTable', () => {
       const rows = screen.getAllByRole('row')
       const firstDataRow = rows[1]
 
-      // Priority 30 should be first (ascending)
-      expect(within(firstDataRow).getByText('30')).toBeInTheDocument()
+      // Priority 90 should be first (DESC default for priority column)
+      expect(within(firstDataRow).getByText('90')).toBeInTheDocument()
     })
 
     it('should sort by ruleId when rule column clicked', () => {
@@ -445,8 +445,8 @@ describe('FindingsTable', () => {
       render(<FindingsTable findings={findings} />)
 
       const rows = screen.getAllByRole('row')
-      // 100 findings × 1 row each + 1 header row = 101 rows (when not expanded)
-      expect(rows.length).toBe(101)
+      // pageSize defaults to 25; first page shows 25 data rows + 1 header row = 26
+      expect(rows.length).toBe(26)
     })
   })
 })


### PR DESCRIPTION
## Summary

- **ci.yml (uv pin):** Pin `uv` to `0.11.15` at both `python -m pip install uv` sites (lines 43 and 63). Prevents resolver drift between CI runs where different uv versions produce structurally different lockfiles, causing false freshness failures. Version matches the lockfile regen performed alongside PR #488. Follows up #298.
- **FindingsTable.test.tsx (jest fixes, closes #462):**
  - Line 181: Fix priority sort assertion — `toggleSort` defaults priority column to DESC on first click (`FindingsTable.tsx:200`), so the first data row holds priority 90 (highest), not 30. Updated comment to match.
  - Line 449: Fix large-dataset row count — `pageSize` initialises as state with default 25 (`FindingsTable.tsx:16`); first page shows 25 data rows + 1 header = 26 rows, not 101.
- **ci.yml (dashboard-smoke):** Delete the stale NOTE block explaining why `npm test` was omitted (no longer accurate once the jest fixes land). Add a `Test dashboard (jest)` step after the build step, using the same `steps.changes.outputs.dashboard == 'true'` guard.

## Verification

- `cd scripts/dashboard && npm ci && npm test` → **147/147 tests pass** (was 145/147)
- `pre-commit run --files .github/workflows/ci.yml scripts/dashboard/tests/components/FindingsTable.test.tsx` → all hooks passed (yamllint, actionlint, yaml checks)

## References

- Closes #462
- Follows up #298 (uv pinning quick-win)
- uv version from lockfile regen companion to PR #488