### PR TITLE
ci(maintenance): fail-fast if Actions cannot create PRs

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -86,6 +86,44 @@ jobs:
             echo "All tools already up-to-date"
           fi
 
+      - name: Verify Actions can create PRs
+        # Fail-fast guardrail: the repo-level setting "Allow GitHub Actions to
+        # create and approve pull requests" (Settings → Actions → Workflow
+        # permissions) gates `gh pr create` from GITHUB_TOKEN independently of
+        # the workflow `permissions:` block. When OFF, the workflow burns
+        # ~3 min on tool bumps + commit before failing at the PR step — and
+        # leaves an orphan branch behind (cleaned up by the failure-handler
+        # step, but visible enough to confuse triage). Catch it in step ~5.
+        #
+        # Defensive: the GitHub Actions API endpoint nominally requires
+        # `administration: read` which GITHUB_TOKEN doesn't grant by default.
+        # If the API call fails (insufficient scope), warn and proceed —
+        # `gh pr create`'s own error message is the next layer of defense.
+        # The label-create step (PR #396) and orphan-branch cleanup step
+        # already exist for the latent-failure path; this is purely a UX
+        # improvement on the first 5 seconds of the job.
+        #
+        # Background: run 26347764859 (2026-05-23) hit this — setting was OFF
+        # so PR creation failed at step 12. Re-enabling at the UI fixed it.
+        if: steps.check.outputs.updates_available == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          if perms=$(gh api "repos/$REPO/actions/permissions/workflow" \
+              --jq '.can_approve_pull_request_reviews' 2>/dev/null); then
+            if [ "$perms" != "true" ]; then
+              echo "::error::GitHub Actions is not permitted to create PRs in this repo."
+              echo "::error::Enable at: Settings -> Actions -> General -> Workflow permissions"
+              echo "::error::Check: 'Allow GitHub Actions to create and approve pull requests'"
+              exit 1
+            fi
+            echo "PR-creation permission verified ($perms)."
+          else
+            echo "::warning::Could not query Actions permission setting (token may lack admin:read scope)."
+            echo "::warning::Proceeding — 'gh pr create' will surface the real error if blocked."
+          fi
+
       - name: Capture classification manifest (before update)
         # MUST run before --update-all, otherwise the manifest sees
         # current==latest for every bumped tool and reports level=patch


### PR DESCRIPTION
## Summary

Adds a precheck step to the `auto-update-tools` job in `maintenance.yml` that catches the repo-level **"Allow GitHub Actions to create and approve pull requests"** setting being OFF before wasting ~3 min on tool bumps and commit. The workflow `permissions:` block does NOT override this repo-level gate (GitHub added it in 2022 to block automated PR-spam attacks).

- Fails fast in step ~5 instead of step ~12 when the setting regresses
- Defensive fallback: if `GITHUB_TOKEN` lacks `administration:read` scope, emits a warning and proceeds — never introduces a new failure mode
- Pre-existing self-healing layers (label-create from #396, orphan-branch cleanup) remain — this is one more layer

## Background

Run [26347764859](https://github.com/jimmy058910/jmo-security-repo/actions/runs/26347764859) (2026-05-23 Sunday cron) failed at step 12 `gh pr create`:

> pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)

Setting was OFF for unknown reasons. Toggled back ON in Settings → Actions → Workflow permissions; re-ran with `task=tool-update`; run [26348578993](https://github.com/jimmy058910/jmo-security-repo/actions/runs/26348578993) succeeded end-to-end (opened #494).

This PR catches the next time the setting regresses in ~5 seconds rather than ~3 minutes.

## Test plan

- [x] Pre-commit clean (yamllint + actionlint + yaml-env-tilde all pass)
- [x] Bash script logic validated locally — with `can_approve_pull_request_reviews: true` prints `verified` and exits 0
- [x] Run 26348578993 confirmed the underlying setting fix works end-to-end (PR #494 opened cleanly)
- [ ] Next Sunday's cron will exercise the new step in CI

## Convention notes

- Follows the CWE-78 hardening pattern from `release.rules.md` — `${{ github.repository }}` is routed through an `env:` block (`REPO: ...`) instead of being interpolated directly into bash.
- Reuses the existing `if: steps.check.outputs.updates_available == 'true'` gate, so the check is skipped when there's no PR to create anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved repository maintenance automation by adding comprehensive permission validation checks before automated pull request creation. The workflow now explicitly verifies required GitHub Actions permissions and provides clear error messaging when permissions are unavailable, enhancing workflow reliability and streamlining troubleshooting for maintenance operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jimmy058910/jmo-security-repo/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->