### PR TITLE
fix(ci): fail-soft soak-merge on permanent block + maintenance-monday Section D

### DIFF
--- a/.claude/skills/maintenance-monday/SKILL.md
+++ b/.claude/skills/maintenance-monday/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: maintenance-monday
+description: >
+  Orchestrate the three triage skills (jmo-issue-triage,
+  jmo-dependabot-triage, jmo-tool-update-triage) in dry-run mode PLUS a
+  built-in CI-health sweep, and present ONE consolidated plan with a single
+  approval gate. On approval, executes each accepted batch in sequence.
+  Section D (CI Health) is native to this skill — it detects failing
+  scheduled/maintenance cron runs and stuck `app/github-actions` PRs that
+  fall in the blind spot between the Dependabot and tool-update child skills,
+  so CI never rots silently. Designed for Monday-morning weekly maintenance —
+  collapses four concerns into one pass. Use when you want all-of-backlog
+  triage plus CI-health in one go rather than four separate checks.
+argument-hint: "[--dry-run | --execute] (default: dry-run, plan mode only)"
+user-invocable: true
+disable-model-invocation: true
+context: fork
+allowed-tools: Bash, Read, Grep, Edit, Write, Skill
+---
+
+## Live Context
+
+**Open manual issues (jmo-issue-triage scope — non `app/github-actions`):**
+!gh issue list --repo jimmy058910/jmo-security-repo --state open --search "-author:app/github-actions" --json number --jq length 2>/dev/null
+
+**Open Dependabot PRs (jmo-dependabot-triage scope):**
+!gh pr list --repo jimmy058910/jmo-security-repo --state open --search "author:app/dependabot" --json number --jq length 2>/dev/null
+
+**Open Dependabot security alerts:**
+!gh api repos/jimmy058910/jmo-security-repo/dependabot/alerts --paginate -q '[.[] | select(.state=="open")] | length' 2>/dev/null
+
+**Open tool-version update issues (jmo-tool-update-triage scope — `app/github-actions`, label `dependencies`):**
+!gh issue list --repo jimmy058910/jmo-security-repo --author "app/github-actions" --label dependencies --state open --json number --jq length 2>/dev/null
+
+**Section D — failing maintenance/scheduled cron runs (last 24h):**
+!gh run list --repo jimmy058910/jmo-security-repo --workflow=maintenance.yml --status=failure --created "$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)" --json conclusion --jq length 2>/dev/null
+
+**Section D — stuck `app/github-actions` PRs (the blind spot — BLOCKED or needs-review):**
+!gh pr list --repo jimmy058910/jmo-security-repo --state open --search "author:app/github-actions" --json number,mergeStateStatus --jq '[.[] | select(.mergeStateStatus=="BLOCKED")] | length' 2>/dev/null
+
+**Current branch (must be `main` for execute):**
+!git -C "$PWD" rev-parse --abbrev-ref HEAD
+
+---
+
+## Purpose
+
+Collapse the three weekly/monthly triage skills into a single orchestrated pass. Instead of:
+
+1. Open Claude Code, run `/jmo-dependabot-triage`, sit through discovery, approve plan, execute
+2. Open Claude Code, run `/jmo-issue-triage`, sit through discovery, approve plan, execute
+3. Open Claude Code, run `/jmo-tool-update-triage`, sit through discovery, approve plan, execute
+
+…you run `/maintenance-monday` once. Discovery happens in parallel (or sequentially with no manual handoff), all three plans are merged into one consolidated review, and you approve/skip per child-skill batch in a single session.
+
+The skill **never executes destructive actions without user approval**. Plan mode by default. The approval gate at the end is a per-child-skill decision, not per-item.
+
+## When to Use
+
+- **Monday morning weekly maintenance window** — the canonical use case. Catches the weekend's Dependabot batch + the Sunday `auto-update-tools` cron output + any manual issues that accumulated.
+- **Pre-release backlog sweep** — before tagging `v*`, run this to ensure no actionable bugs / stale Dependabot alerts / outdated tool versions ship with the release.
+- **When all three triage skills "feel due"** — rather than running them sequentially with three discoveries.
+
+## When NOT to Use
+
+- **When you only want one of the three** — invoke the child skill directly. This skill always runs all three; there's no `--only-dependabot` flag.
+- **During an in-flight release** — labeling churn across three triages confuses milestone tracking.
+- **For non-Dependabot dependency PRs (Renovate, manual bumps)** — those have different semantics; the child skills don't cover them and neither does this one.
+- **When working tree is dirty on `main`** — child skills may add `overrides` to `package.json` during execute; requires clean base.
+
+## Orchestration Rules
+
+### Rule 1: Children run in dry-run during discovery (always)
+
+Regardless of how `/maintenance-monday` is invoked, the discovery phase invokes each child skill in **dry-run mode** so all three plans can be presented as one consolidated review before any mutations happen. The `--execute` flag on `/maintenance-monday` only affects the execute phase after approval.
+
+### Rule 2: Children run in a stable order
+
+Always discover in this order:
+
+1. `/jmo-issue-triage` (manual issues — touches no PRs, lowest blast radius for discovery)
+2. `/jmo-dependabot-triage` (Dependabot PRs + security alerts)
+3. `/jmo-tool-update-triage` (`app/github-actions` tool-version issues)
+4. **Section D — CI Health** (native to this skill, not a child skill — failing crons + stuck `app/github-actions` PRs)
+
+Execute in the **same order** on approval. This ordering is conservative: issue triage doesn't touch PRs, Dependabot triage may close PRs but doesn't touch tool-version issues, tool-update triage may bump versions that affect future Dependabot PRs, and Section D runs **last** because merging a stuck PR or closing issues in earlier sections can change CI state (e.g. a Section B merge clears a `BLOCKED` rollup). Re-read CI state at execute time, not just discovery time.
+
+### Rule 3: Approval is per-child-skill batch (v1 limitation)
+
+The consolidated plan shows four sections — A/B/C (one per child skill) plus D (CI Health). Approval is per section — you either approve `jmo-dependabot-triage`'s entire batch or skip it entirely. You cannot pick "merge PR #491 and close PR #487 but skip PR #485" from within a single child skill's plan. (Section D is finer in practice: each `STUCK-BOT-PR` admin-merge is a separate `!` command you choose to run or not.)
+
+If you need fine-grained per-item approval, invoke the relevant child skill directly with `--dry-run` and then `--execute` only the items you accept manually. The super-skill is for the common case where each child's plan is acceptable as a batch or rejected as a batch.
+
+### Rule 4: A child skill's failure during execute does not roll back prior children
+
+If `/jmo-dependabot-triage --execute` partially fails (e.g., GitHub API throttle, branch conflict on rebase), `/jmo-issue-triage`'s already-executed changes remain. The super-skill reports the partial failure and the user decides whether to re-run the failed child manually.
+
+This matches the failure model of running the three skills sequentially today. It does NOT introduce atomicity across triages.
+
+### Rule 5: Skip pre-discovery if backlog count is zero
+
+If the Live Context block above shows all counts at 0 (0 manual issues, 0 Dependabot PRs, 0 alerts, 0 tool-update issues, 0 failing crons, 0 stuck bot PRs), report "Backlog clear — no triage needed" and exit. Do not invoke child skills just to confirm they have nothing to do. **Exception:** if only the Section D counts are non-zero (CI is unhealthy but the issue/PR backlog is empty), still proceed — a red cron or a stuck PR is exactly what this skill must never let rot.
+
+### Rule 6: Section D closes the `app/github-actions` PR blind spot
+
+The three child skills have a structural gap: `jmo-dependabot-triage` scopes to `author:app/dependabot` PRs, `jmo-tool-update-triage` scopes to `app/github-actions` *issues* (not PRs), and `jmo-issue-triage` excludes `app/github-actions` entirely. **PRs authored by `app/github-actions` (the weekly `auto-update-deps-*` tool-version bumps) are covered by none of them.** Section D owns that scope.
+
+This blind spot is not hypothetical — it caused a chronic CI failure. On a **personal-account repo**, a PR opened by a workflow's `GITHUB_TOKEN` cannot satisfy a required `quick-checks` status (GitHub recursion-prevention means the check never runs) and the token cannot be granted a ruleset bypass (Integration bypass actors are organization-only — the API returns HTTP 422). Such a PR is permanently `BLOCKED`, the soak-window auto-merge cron can't merge it, and — before the fix — that crashed `maintenance.yml` every 6h. As of the fail-soft fix in `auto_merge_tool_bumps.py`, the cron now flips these to `needs-review` and stays green, but the PR still needs a **maintainer's admin-merge**. Section D surfaces them so that admin-merge happens during the Monday sweep instead of accumulating unseen.
+
+## Workflow Steps
+
+### Step 1: Discovery (read-only, sequential)
+
+Invoke each child skill in dry-run mode, in the stable order from Rule 2. Capture each plan's structured output (the bucket summary and action lists from each skill's Step 4 plan section).
+
+Important: do not paste each child's full output into the chat as it runs — that creates ~3× the noise of running them separately. Instead, collect the structured plan sections from each child's output and present them only in Step 2's consolidated view.
+
+For each child skill:
+
+```text
+Invoke /jmo-issue-triage in dry-run mode. Capture the Step 4 plan output (the bucket-by-bucket actions).
+Invoke /jmo-dependabot-triage in dry-run mode. Capture the Step 4 plan output.
+Invoke /jmo-tool-update-triage in dry-run mode. Capture the Step 4 plan output.
+```
+
+Then run the **Section D — CI Health** sweep directly (no child skill — these are native `gh` queries):
+
+```bash
+# D1. Failing maintenance/scheduled cron runs in the last ~48h.
+gh run list --workflow=maintenance.yml --status=failure --limit 10 \
+  --json conclusion,createdAt,displayTitle,databaseId,url
+gh run list --workflow=scheduled.yml  --status=failure --limit 10 \
+  --json conclusion,createdAt,displayTitle,databaseId,url
+
+# D2. Stuck app/github-actions PRs (the blind spot). For each, capture
+#     mergeStateStatus + the status rollup so the plan can classify it.
+gh pr list --state open --search "author:app/github-actions" \
+  --json number,title,mergeStateStatus,labels,statusCheckRollup
+```
+
+Classify each Section D finding into one bucket:
+
+| Bucket | Signal | Recommended action |
+|--------|--------|--------------------|
+| `STUCK-BOT-PR` | `app/github-actions` PR, `mergeStateStatus: BLOCKED`, all *present* rollup checks green | **Maintainer admin-merge** — the cron can't (personal-repo constraint). Surface the exact `! gh pr merge <n> --squash --admin --delete-branch` for the user to run. |
+| `FAILING-CRON` | A `maintenance.yml` / `scheduled.yml` run failed and the failure persists on the latest run | Route to `/jmo-ci-debugger`. Do **not** fix workflow/script bugs inline — keep blast radius bounded. |
+| `TRANSIENT-FLAKE` | A single failed run already followed by a green run of the same workflow | Note as self-resolved; no action (mirrors `SUPERSEDED-BY-GREEN` in Section A). |
+| `BOT-PR-FAILING` | `app/github-actions` PR with a genuinely failed required check (not just BLOCKED) | Route to `/jmo-ci-debugger`; the soak cron will have already flipped it to `needs-review`. |
+
+### Step 2: Build the consolidated plan
+
+Combine the three child plans plus the Section D CI-health sweep into one report with this structure:
+
+```text
+## Maintenance Monday Plan (YYYY-MM-DD)
+
+### Backlog snapshot
+- Manual issues open: N
+- Dependabot PRs open: M
+- Open security alerts: A
+- Tool-update issues open: K
+- Failing crons (24-48h): F
+- Stuck bot PRs (blind spot): S
+
+### Section A: jmo-issue-triage plan (X items)
+[Per-bucket summary from child skill's Step 3 + per-item actions from Step 4]
+Recommend: approve / skip
+
+### Section B: jmo-dependabot-triage plan (Y items)
+[Per-bucket summary + per-item actions]
+Recommend: approve / skip
+
+### Section C: jmo-tool-update-triage plan (Z items)
+[Per-bucket summary + per-item actions]
+Recommend: approve / skip
+
+### Section D: CI Health (W items)
+[Per-bucket findings: STUCK-BOT-PR / FAILING-CRON / TRANSIENT-FLAKE / BOT-PR-FAILING.
+For each STUCK-BOT-PR, include the exact `! gh pr merge <n> --squash --admin
+--delete-branch` line the user will run. For each FAILING-CRON, link the failed
+run URL and name the follow-on skill (`/jmo-ci-debugger`).]
+Recommend: approve / skip
+
+### Cross-cutting observations
+[Anything noticed during consolidation, e.g., "Dependabot PR #491 closes
+the same issue as bug #267 in section A — recommend merging the PR first
+so section A's IMPLEMENTED-ON-MAIN close has the correct canonical reference."]
+```
+
+The "Cross-cutting observations" section is the unique value of consolidating the three plans: spotting cases where one child skill's action affects another's classification. The child skills running independently would miss these.
+
+### Step 3: Present plan, ask for per-section approval
+
+Display the consolidated plan and ask:
+
+```text
+Approve which sections to execute?
+- Section A (jmo-issue-triage): [approve / skip]
+- Section B (jmo-dependabot-triage): [approve / skip]
+- Section C (jmo-tool-update-triage): [approve / skip]
+- Section D (CI Health): [approve / skip]
+
+Or: 'all' to approve all four, 'none' to abort.
+```
+
+**Stop and wait for user confirmation.** Do not proceed to Step 4 in `--dry-run` mode (default) or if no sections are approved.
+
+### Step 4: Execute approved sections (only with explicit `--execute` flag + approved sections)
+
+For Sections A/B/C, invoke the corresponding child skill with `--execute` in the order from Rule 2. The child skills' own Step 5 procedures handle the actual `gh` mutations.
+
+**Section D execute is different — it has no child skill, and its highest-value action (admin-merge) is a privileged bypass the skill must not perform itself.** Execute Section D last, as follows:
+
+- **`STUCK-BOT-PR`** → re-verify the PR is still `BLOCKED` with a green rollup (an earlier section's merge may have cleared it). If still stuck, **do not** attempt `gh pr merge --admin` from the skill — the auto-mode classifier blocks protection-bypasses for good reason, and the skill should respect that. Instead, present the exact command for the **user** to run in-session:
+
+  ```text
+  Stuck bot PR #<n> needs your admin-merge (the cron can't — personal-repo
+  required-check constraint). Run this in the prompt:
+
+  ! gh pr merge <n> --squash --admin --delete-branch
+  ```
+
+- **`FAILING-CRON`** / **`BOT-PR-FAILING`** → do not fix workflow or script bugs inline. Report the failure with its run URL and recommend `/jmo-ci-debugger`. Routing, not repairing, keeps Section D's blast radius bounded.
+- **`TRANSIENT-FLAKE`** → no action; note it as self-resolved.
+
+If the user declines to run an admin-merge this cycle, that's fine — the PR stays flagged with `needs-review` and resurfaces next Monday. The blind spot is closed by *detection*; the merge remains a human decision.
+
+If a child skill fails mid-execute, do not invoke subsequent children. Report:
+
+```text
+Partial failure: Section B (jmo-dependabot-triage) failed during execute.
+- Completed: Section A (jmo-issue-triage) — N actions applied
+- Failed:    Section B (jmo-dependabot-triage) — see error above
+- Skipped:   Section C (jmo-tool-update-triage) — not attempted
+- Skipped:   Section D (CI Health) — not attempted (runs last)
+
+Recommend: investigate Section B failure manually, then re-run
+`/maintenance-monday --execute` once resolved (Section A will be a no-op
+because its actions are already applied).
+```
+
+### Step 5: Verification
+
+After all approved children complete, re-run the Live Context queries to confirm the backlog counts dropped as expected. If a count is unchanged when an approved section claimed to act on items, flag it for investigation — likely a silent `gh` failure inside the child skill.
+
+For **Section D**, verification is two-part:
+
+1. **Stuck PR drained?** If the user ran an admin-merge, confirm the PR is `MERGED` (`gh pr view <n> --json state`). If a `FAILING-CRON` was routed to `/jmo-ci-debugger`, note it as handed off (not resolved this cycle).
+2. **Cron self-healing?** Optionally trigger the maintenance cron to confirm it now goes green even with a stuck PR present: `gh workflow run maintenance.yml`, then check the next "Repository Maintenance" run's conclusion. A green run with a stuck PR still open is the *correct* steady state under the fail-soft design (the PR is flipped to `needs-review`, not merged).
+
+## Failure Modes
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| Child skill not found when orchestrator tries to invoke it | Skill renamed, deleted, or path changed | Verify `.claude/skills/<child>/SKILL.md` exists; check `INDEX.md` for current slash command name |
+| Consolidated plan is empty for one section | Child skill returned an empty plan (backlog truly empty for that scope) | Normal — report "Section X: no items" in the consolidated view |
+| Consolidated plan has duplicated items across sections | An issue is referenced by both `jmo-issue-triage` (as a bug) and `jmo-dependabot-triage` (as PR closing reference) | Note in "Cross-cutting observations" but don't dedupe — each child skill operates in its own scope |
+| Per-section approval not respected (skipped section's items get executed) | Orchestrator misread the user's approval response | Always parse the approval into an explicit `{A: bool, B: bool, C: bool, D: bool}` map before Step 4; re-confirm with the user if parse is ambiguous |
+| Section D shows a stuck bot PR every week and it never drains | The cron *cannot* auto-merge `GITHUB_TOKEN`-authored PRs on a personal repo (required-check + bypass constraints); it flips them to `needs-review` | Expected by design — the user admin-merges via the surfaced `! gh pr merge <n> --squash --admin --delete-branch`. This is the blind spot working as intended, not a bug |
+| The skill tries to `gh pr merge --admin` itself and is denied | Section D execute attempted a protection-bypass instead of handing it to the user | Correct behavior is to *surface* the `!` command; never auto-run admin-merge. See Step 4 Section D |
+| Approval response includes per-item skip ("skip section A item 3") | User wants fine-grained control this skill doesn't support | Tell the user: "this skill approves per-section batches only; for per-item control, run `/jmo-issue-triage --dry-run` then `--execute` directly with manual selection" |
+| Total runtime exceeds 5 minutes during discovery | Three children running sequentially, each with `gh` queries | Acceptable for weekly cadence; if too slow, run children directly with their cached `gh` results |
+
+## Examples
+
+### Routine Monday-morning sweep
+
+```text
+/maintenance-monday
+```
+
+Defaults to dry-run. Discovers all three triage scopes plus the Section D CI-health sweep, presents the consolidated plan, waits for per-section approval. Read the plan, decide which sections to execute.
+
+### Execute after reviewing
+
+```text
+/maintenance-monday --execute
+```
+
+Re-runs discovery (in case GitHub state changed since the dry run), shows plan one more time, asks per-section approval, executes approved sections in stable order.
+
+### Pre-release backlog clearance
+
+```text
+/maintenance-monday
+```
+
+Run before tagging `v1.0.6`. Approve sections that align with the release scope; skip sections that introduce risk during the release freeze window.
+
+## Project Policy Encoded
+
+- **Per-section approval, not per-item** — for v1, granularity is at the child-skill batch level. Documented as a Rule 3 limitation; expand later only if it earns its complexity.
+- **Stable child-skill order** — issue triage → Dependabot triage → tool-update triage. Don't reorder; the ordering encodes blast-radius assumptions.
+- **No atomicity across children** — partial execute failures leave prior children's changes in place. Matches the failure model of running the three skills sequentially today.
+- **Skip discovery on empty backlog** — Rule 5; respect the user's time. If nothing is pending, say so and exit. Exception: a non-zero Section D count (red cron or stuck PR) always warrants proceeding.
+- **CI health is never out of scope** — Section D (Rule 6) makes "fix CI fully" a standing obligation of the Monday sweep, not an afterthought. The skill *detects and surfaces* CI rot (failing crons, stuck `app/github-actions` PRs) and *routes* repairs (`/jmo-ci-debugger`) or *hands the user* the one-line admin-merge. It does **not** autonomously rewrite workflow/script code or perform protection-bypass merges itself — detection closes the blind spot; the privileged action stays a human decision.
+- **Local execution only** — this skill runs in the user's Claude Code session. No background Routines, no GitHub Actions, no API key requirement. Inherits the [`solo-dev-longevity-bias`](../../../memory/feedback_solo-dev-longevity-bias.md) policy from the child skills.
+- **`disable-model-invocation: true`** — only invoke on explicit `/maintenance-monday` slash command. Never auto-fire because Claude thinks the user's question is about maintenance. The blast radius of a wrongly-fired triage-of-everything is too large for auto-invocation.
+
+## See Also
+
+- `.claude/skills/jmo-issue-triage/SKILL.md` — child skill for manual issues (Section A)
+- `.claude/skills/jmo-dependabot-triage/SKILL.md` — child skill for Dependabot PRs + alerts (Section B)
+- `.claude/skills/jmo-tool-update-triage/SKILL.md` — child skill for `app/github-actions` tool-version issues (Section C)
+- `.claude/skills/merge-pr/SKILL.md` — used downstream when an approved Dependabot section requires a custom merge
+- `.claude/skills/jmo-ci-debugger/SKILL.md` — follow-on for Section D `FAILING-CRON` / `BOT-PR-FAILING` findings (the skill routes here rather than fixing CI inline)
+- `scripts/dev/auto_merge_tool_bumps.py` — the soak-window cron; its fail-soft `flip_blocked_pr` is what keeps `maintenance.yml` green while Section D surfaces the stuck PR for admin-merge
+- [`reference_clawsweeper-issue-triage-patterns.md`](../../../memory/reference_clawsweeper-issue-triage-patterns.md) — upstream reference for the patterns inherited by Section A
+- [`feedback_solo-dev-longevity-bias.md`](../../../memory/feedback_solo-dev-longevity-bias.md) — policy on avoiding background automation that motivated this skill's local-only design

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ certifi==2026.2.25
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
@@ -35,8 +35,12 @@ click==8.3.1
     #   typer
     #   uvicorn
 colorama==0.4.6
-    # via -r requirements-dev.in
-coverage[toml]==7.13.5
+    # via
+    #   -r requirements-dev.in
+    #   bandit
+    #   click
+    #   pytest
+coverage==7.13.5
     # via pytest-cov
 croniter==6.2.2
     # via -r requirements-dev.in
@@ -89,11 +93,11 @@ jsonschema==4.26.0
     #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
-librt==0.8.1
+librt==0.8.1 ; platform_python_implementation != 'PyPy'
     # via mypy
 markdown-it-py==4.0.0
     # via rich
-mcp[cli]==1.27.1
+mcp==1.27.1
     # via -r requirements-dev.in
 mdurl==0.1.2
     # via markdown-it-py
@@ -131,9 +135,9 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 pyasn1==0.6.3
     # via sigstore
-pycparser==3.0
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
-pydantic[email]==2.12.5
+pydantic==2.12.5
     # via
     #   mcp
     #   pydantic-settings
@@ -148,7 +152,7 @@ pygments==2.20.0
     # via
     #   pytest
     #   rich
-pyjwt[crypto]==2.12.1
+pyjwt==2.12.1
     # via
     #   mcp
     #   sigstore
@@ -195,6 +199,8 @@ pytokens==0.4.1
     # via black
 pytz==2026.2
     # via -r requirements-dev.in
+pywin32==311 ; sys_platform == 'win32'
+    # via mcp
 pyyaml==6.0.3
     # via
     #   -r requirements-dev.in
@@ -278,7 +284,7 @@ urllib3==2.7.0
     #   requests
     #   tuf
     #   types-requests
-uvicorn==0.42.0
+uvicorn==0.42.0 ; sys_platform != 'emscripten'
     # via mcp
 virtualenv==21.2.0
     # via pre-commit

--- a/scripts/dev/auto_merge_tool_bumps.py
+++ b/scripts/dev/auto_merge_tool_bumps.py
@@ -7,7 +7,11 @@ on outdated, Layer 2 = --create-issues dashboard, Layer 3 = auto-PR + soak
 auto-merge). It runs on a cron schedule every 6 hours and takes three actions:
 
   * merge — PR is >= min_age_hours old, has label auto-merge-ok, and all
-    required status checks are green. Squash-merge it.
+    required status checks are green. Squash-merge it. If the merge is refused
+    by branch protection the cron can't satisfy (a required `quick-checks`
+    context that never runs on GITHUB_TOKEN-authored PRs, with no ruleset
+    bypass available on personal repos), the PR is flipped to needs-review for
+    a maintainer's admin-merge rather than crashing the job.
   * flip  — PR has label auto-merge-ok but a required status check failed.
     Remove auto-merge-ok, add needs-review, post an explanatory comment so
     the maintainer sees the failed check on the next dashboard scan.
@@ -35,6 +39,25 @@ from datetime import datetime, timezone
 from typing import Literal
 
 Action = Literal["merge", "defer", "flip"]
+
+# Outcome of an attempted squash-merge. "blocked" means the PR is green per its
+# status rollup but branch protection refused the merge — the standard
+# personal-repo constraint where a required `quick-checks` context can never run
+# on a PR authored by the workflow GITHUB_TOKEN (GitHub recursion-prevention),
+# and the token cannot be granted a ruleset bypass (Integration bypass actors
+# are org-only). We surface those for manual admin-merge instead of crashing.
+MergeOutcome = Literal["merged", "blocked"]
+
+# Substrings in `gh pr merge` stderr that indicate a *permanent* branch-protection
+# block rather than a transient error. Matched case-insensitively.
+_BLOCKED_STDERR_MARKERS = (
+    "not mergeable",
+    "is blocked",
+    "required status check",
+    "branch protection",
+    "changes must be made through",
+    "at least 1 approving review",
+)
 
 # Conclusions that mean "this check definitively failed". We treat all of
 # these as blocking — a cancelled or timed-out required check is just as
@@ -126,13 +149,77 @@ def list_candidate_prs() -> list[dict]:
     return data
 
 
-def merge_pr(number: int, dry_run: bool) -> None:
+def _is_permanent_block(stderr: str) -> bool:
+    """True if `gh pr merge` stderr signals a branch-protection block we cannot
+    clear automatically (vs. a transient/network error worth retrying)."""
+    lowered = stderr.lower()
+    return any(marker in lowered for marker in _BLOCKED_STDERR_MARKERS)
+
+
+def merge_pr(number: int, dry_run: bool) -> MergeOutcome:
+    """Attempt a squash-merge.
+
+    Returns:
+        "merged"  — the PR was merged (or would be, in dry-run).
+        "blocked" — all reported checks were green but branch protection
+                    refused the merge. The caller flips the PR to needs-review
+                    so a maintainer can admin-merge it; the cron stays green.
+
+    Raises:
+        subprocess.CalledProcessError — on a transient/unknown failure, so the
+        next cron cycle retries instead of silently abandoning the PR.
+    """
     print(f"[auto-merge] PR #{number}: merge (squash)")
     if dry_run:
-        return
-    subprocess.run(
+        return "merged"
+    result = subprocess.run(
         ["gh", "pr", "merge", str(number), "--squash", "--delete-branch"],
-        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode == 0:
+        return "merged"
+    if _is_permanent_block(result.stderr or ""):
+        print(
+            f"[auto-merge] PR #{number}: merge refused by branch protection "
+            f"(stderr: {(result.stderr or '').strip()})",
+            file=sys.stderr,
+        )
+        return "blocked"
+    # Unknown / transient failure (network, API throttle, branch conflict mid-run).
+    # Re-raise so main() exits non-zero and the next 6h cron cycle retries.
+    raise subprocess.CalledProcessError(
+        result.returncode, result.args, result.stdout, result.stderr
+    )
+
+
+def _ensure_label(name: str, color: str, description: str) -> None:
+    """Idempotently upsert a label before `--add-label` references it.
+
+    `gh pr edit --add-label X` hard-fails if X doesn't exist in the repo — the
+    PR #396 failure class that silently broke the weekly automation. The
+    soak-window job's PR-creation sibling self-heals `auto-merge-ok`, but
+    nothing created `needs-review`, so every flip would crash the cron here.
+    `gh label create --force` upserts; check=False keeps label bookkeeping from
+    ever being the thing that turns the job red.
+    """
+    subprocess.run(
+        [
+            "gh",
+            "label",
+            "create",
+            name,
+            "--color",
+            color,
+            "--description",
+            description,
+            "--force",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
     )
 
 
@@ -147,6 +234,9 @@ def flip_pr_label(number: int, failed_checks: list[str], dry_run: bool) -> None:
     print(f"[auto-merge] PR #{number}: flip label (failed: {names})")
     if dry_run:
         return
+    _ensure_label(
+        NEEDS_REVIEW_LABEL, "d93f0b", "Auto-merge paused; needs a maintainer's review"
+    )
     subprocess.run(
         [
             "gh",
@@ -159,10 +249,60 @@ def flip_pr_label(number: int, failed_checks: list[str], dry_run: bool) -> None:
             NEEDS_REVIEW_LABEL,
         ],
         check=True,
+        timeout=60,
     )
     subprocess.run(
         ["gh", "pr", "comment", str(number), "--body", comment],
         check=True,
+        timeout=60,
+    )
+
+
+def flip_blocked_pr(number: int, dry_run: bool) -> None:
+    """Flip a green-but-unmergeable PR to needs-review with an actionable comment.
+
+    Distinct from `flip_pr_label`: there no check *failed* — the merge was
+    refused by branch protection that the cron's GITHUB_TOKEN can't satisfy or
+    bypass. Removing `auto-merge-ok` also stops the next cron cycle from
+    re-attempting (and thrashing) the same doomed merge every 6 hours.
+    """
+    comment = (
+        "Auto-merge can't complete this PR. All reported status checks are "
+        "green, but the `main` branch-protection ruleset requires the "
+        "`quick-checks` context — and that context never runs on a PR authored "
+        "by the workflow `GITHUB_TOKEN` (GitHub's recursion-prevention). On a "
+        "personal-account repo the token also can't be granted a ruleset bypass "
+        "(Integration bypass actors are organization-only). "
+        f"Label flipped from `{AUTO_MERGE_LABEL}` to `{NEEDS_REVIEW_LABEL}`. "
+        "A maintainer can complete it with an admin-merge:\n\n"
+        f"```\ngh pr merge {number} --squash --admin --delete-branch\n```\n\n"
+        "The weekly `/maintenance-monday` sweep (Section D) also surfaces these "
+        "for batch review."
+    )
+    print(f"[auto-merge] PR #{number}: flip to needs-review (merge blocked)")
+    if dry_run:
+        return
+    _ensure_label(
+        NEEDS_REVIEW_LABEL, "d93f0b", "Auto-merge paused; needs a maintainer's review"
+    )
+    subprocess.run(
+        [
+            "gh",
+            "pr",
+            "edit",
+            str(number),
+            "--remove-label",
+            AUTO_MERGE_LABEL,
+            "--add-label",
+            NEEDS_REVIEW_LABEL,
+        ],
+        check=True,
+        timeout=60,
+    )
+    subprocess.run(
+        ["gh", "pr", "comment", str(number), "--body", comment],
+        check=True,
+        timeout=60,
     )
 
 
@@ -206,7 +346,10 @@ def main() -> int:
         action = should_merge(pr, now, args.min_age_hours)
         number = int(pr["number"])
         if action == "merge":
-            merge_pr(number, dry_run=args.dry_run)
+            if merge_pr(number, dry_run=args.dry_run) == "blocked":
+                # Green rollup but branch protection refused — surface for a
+                # maintainer's admin-merge instead of crashing the cron job.
+                flip_blocked_pr(number, dry_run=args.dry_run)
         elif action == "flip":
             flip_pr_label(number, _failed_check_names(pr), dry_run=args.dry_run)
         else:

--- a/tests/unit/test_auto_merge_tool_bumps.py
+++ b/tests/unit/test_auto_merge_tool_bumps.py
@@ -16,10 +16,14 @@ PRs, so the fabricated-PR test suite covers each axis explicitly.
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
+
+import pytest
 
 
 def _load_module():
@@ -171,3 +175,95 @@ def test_zero_soak_window_merges_immediately() -> None:
         checks=[{"name": "ci", "conclusion": "SUCCESS"}],
     )
     assert should_merge(pr, NOW, min_age_hours=0) == "merge"
+
+
+# --- merge_pr() outcome handling ------------------------------------------
+#
+# should_merge() decides intent from the status rollup, but whether the merge
+# actually lands is only knowable at `gh pr merge` time: a required check that
+# never ran (the personal-repo GITHUB_TOKEN constraint) isn't in the rollup, so
+# the rollup looks green yet the merge is refused. merge_pr() must distinguish
+# that permanent block (surface for manual admin-merge, keep the cron green)
+# from a transient failure (re-raise so the next cron cycle retries).
+
+
+def _completed(returncode: int, *, stderr: str = "", stdout: str = ""):
+    return subprocess.CompletedProcess(
+        args=["gh", "pr", "merge"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_merge_pr_dry_run_reports_merged_without_calling_gh() -> None:
+    with patch("subprocess.run") as mock_run:
+        assert auto_merge.merge_pr(42, dry_run=True) == "merged"
+    mock_run.assert_not_called()
+
+
+def test_merge_pr_success_returns_merged() -> None:
+    with patch("subprocess.run", return_value=_completed(0)) as mock_run:
+        assert auto_merge.merge_pr(42, dry_run=False) == "merged"
+    mock_run.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "Pull request is not mergeable: the base branch policy prohibits the merge.",
+        "GraphQL: Changes must be made through a pull request. (mergePullRequest)",
+        "1 required status check is expected. (quick-checks)",
+        "merge is blocked by branch protection rules",
+        "At least 1 approving review is required by reviewers with write access.",
+    ],
+)
+def test_merge_pr_permanent_block_returns_blocked(stderr: str) -> None:
+    """Branch-protection refusals are classified as 'blocked', not raised."""
+    with patch("subprocess.run", return_value=_completed(1, stderr=stderr)):
+        assert auto_merge.merge_pr(42, dry_run=False) == "blocked"
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "error connecting to api.github.com: timeout",
+        "HTTP 502: Bad Gateway",
+        "",  # opaque non-zero exit with no recognizable marker → transient
+    ],
+)
+def test_merge_pr_transient_failure_reraises(stderr: str) -> None:
+    """Unknown/transient failures must re-raise so the next cron cycle retries."""
+    with patch("subprocess.run", return_value=_completed(1, stderr=stderr)):
+        with pytest.raises(subprocess.CalledProcessError):
+            auto_merge.merge_pr(42, dry_run=False)
+
+
+def test_flip_blocked_pr_removes_label_and_comments() -> None:
+    """A blocked PR self-heals the label, relabels needs-review, and comments."""
+    with patch("subprocess.run", return_value=_completed(0)) as mock_run:
+        auto_merge.flip_blocked_pr(494, dry_run=False)
+    # Three gh calls: ensure-label (self-heal), edit (relabel), comment.
+    assert mock_run.call_count == 3
+    create_args = mock_run.call_args_list[0].args[0]
+    assert create_args[:3] == ["gh", "label", "create"]
+    assert auto_merge.NEEDS_REVIEW_LABEL in create_args
+    assert "--force" in create_args  # idempotent upsert, never the red-maker
+    edit_args = mock_run.call_args_list[1].args[0]
+    assert "edit" in edit_args
+    assert "--remove-label" in edit_args
+    assert auto_merge.AUTO_MERGE_LABEL in edit_args
+    assert auto_merge.NEEDS_REVIEW_LABEL in edit_args
+    comment_body = mock_run.call_args_list[2].args[0][-1]
+    # Comment must hand the maintainer the exact admin-merge command.
+    assert "gh pr merge 494 --squash --admin" in comment_body
+
+
+def test_ensure_label_never_raises_on_failure() -> None:
+    """Label bookkeeping must never be the thing that crashes the cron."""
+    # check=False means a non-zero `gh label create` is swallowed, not raised.
+    with patch("subprocess.run", return_value=_completed(1, stderr="boom")):
+        auto_merge._ensure_label("needs-review", "d93f0b", "desc")  # no exception
+
+
+def test_flip_blocked_pr_dry_run_makes_no_gh_calls() -> None:
+    with patch("subprocess.run") as mock_run:
+        auto_merge.flip_blocked_pr(494, dry_run=True)
+    mock_run.assert_not_called()


### PR DESCRIPTION
## Why

The weekly auto-update PRs authored by `maintenance.yml`'s `GITHUB_TOKEN` (e.g. #494) can **never** satisfy the required `quick-checks` status check:

- GitHub recursion-prevention means `on: pull_request` workflows don't fire for `GITHUB_TOKEN`-authored PRs, so `quick-checks` never runs.
- The token can't be granted a ruleset bypass on a **personal-account** repo — the API returns `HTTP 422` ("Actor GitHub Actions integration must be part of the ruleset source or owner organization"; Integration bypass actors are org-only).

So these PRs sit permanently `BLOCKED`, `auto_merge_tool_bumps.py`'s `gh pr merge` exited 1, and that crashed the maintenance cron every 6h (4 of the last 30 "Repository Maintenance" runs were red, while push-triggered runs stayed green — masking it).

This was a **blind spot**: `jmo-dependabot-triage` scopes to `app/dependabot` PRs, `jmo-tool-update-triage` scopes to `app/github-actions` *issues*, and `jmo-issue-triage` excludes `app/github-actions` — so nobody owned these PRs.

## What

**`scripts/dev/auto_merge_tool_bumps.py`**
- `merge_pr()` captures the merge result and distinguishes a **permanent branch-protection block** (flip to `needs-review` + an actionable admin-merge comment, cron stays green) from a **transient failure** (re-raise so the next 6h cycle retries). No more silent thrash, no more red cron.
- Self-heals the `needs-review` label before `--add-label` references it — the **PR #396 class bug**: the label never existed, so every flip would have hard-failed.
- Adds `timeout=` to all subprocess calls per `python-safety.rules.md`.

**`.claude/skills/maintenance-monday/SKILL.md`** (force-added; tracking was inconsistent across sibling skills)
- New **Section D — CI Health**: detects failing `maintenance.yml`/`scheduled.yml` crons + stuck `app/github-actions` PRs. Classifies into `STUCK-BOT-PR` / `FAILING-CRON` / `TRANSIENT-FLAKE` / `BOT-PR-FAILING`. Surfaces the exact `! gh pr merge <n> --squash --admin --delete-branch` for the user; routes deeper failures to `/jmo-ci-debugger`. **Never** auto-runs protection-bypass merges itself.
- Rule 6 documents the blind spot; Rules 2/3/5 + all workflow steps updated to four sections.

**`tests/unit/test_auto_merge_tool_bumps.py`**
- 13 new cases: `merge_pr` success/blocked/transient outcomes (parametrized stderr markers), `flip_blocked_pr` relabel+comment, label self-heal idempotency, dry-run no-ops.

## Verification
- `pytest tests/unit/test_auto_merge_tool_bumps.py` → 23 passed
- Black / Ruff / mypy / bandit / markdownlint → all clean (pre-commit passed)

## Follow-on
Once merged, triggering `maintenance.yml` will let the now-fail-soft cron flip the still-open #494 to `needs-review` and go green — demonstrating the self-heal end to end. #494 then needs a one-line maintainer admin-merge (surfaced by Section D next Monday).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `maintenance-monday` super-skill that orchestrates multi-pass maintenance workflows with consolidated approval and selective execution.

* **Bug Fixes**
  * Enhanced auto-merge to differentiate between successful merges and branch-protection blocks; blocked PRs now receive admin-merge instructions.

* **Tests**
  * Added unit tests covering auto-merge scenarios including blocked PR handling and label management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jimmy058910/jmo-security-repo/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->