### PR TITLE
docs(cli): clarify boolean --profile vs --profile-name on ci/report

### DIFF
--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -297,7 +297,7 @@ def _add_report_args(subparsers: argparse._SubParsersAction) -> Any:
     rp.add_argument(
         "--profile",
         action="store_true",
-        help="Collect per-tool timing and write timings.json",
+        help="Collect per-tool timing and write timings.json (for profile SELECTION use --profile-name on scan/ci)",
     )
     rp.add_argument(
         "--threads",
@@ -335,7 +335,9 @@ def _add_ci_args(subparsers: argparse._SubParsersAction) -> Any:
         help="Severity threshold to exit non-zero (for report)",
     )
     cp.add_argument(
-        "--profile", action="store_true", help="Collect timings.json during report"
+        "--profile",
+        action="store_true",
+        help="Collect timings.json during report (for profile SELECTION use --profile-name)",
     )
     cp.add_argument(
         "--policy",


### PR DESCRIPTION
## Summary

The `ci` and `report` subcommands both expose a **boolean** `--profile` flag (timing collection / `timings.json`), while profile **selection** uses the value-taking `--profile-name`. The prefix overlap is a footgun:

```
$ jmo ci --profile balanced
error: unrecognized arguments: balanced
```

`--profile` is `action="store_true"`, so it cannot consume `balanced`, which then parses as a stray positional.

## Why help-text only (not an API change)

- **No real bug:** grepping `tests/`, `docs/`, `.github/` found **zero** callers passing `jmo ci --profile <name>` expecting selection. `--profile-name` is the pervasive, correctly-documented selector everywhere. This is a typo-guard.
- **Rename/deprecate wouldn't fix the symptom:** a boolean still cannot accept a value, so `--profile balanced` would fail regardless.
- **A custom argparse error-interceptor is disproportionate** for a niche typo on a stable public flag.
- The one surface a confused user reads is `jmo ci --help` — so that's where the clarification belongs.

## Change

One-line `help=` clarification on the boolean `--profile` for both `ci` (`_add_ci_args`) and `report` (`_add_report_args`). No behavior change.

Complements the maintainer-facing note at `.claude/rules/release.rules.md:116`.

## Verification

- `jmo ci --help` / `jmo report --help` render the new text (confirmed)
- `black` + `ruff check` clean; pre-commit (black/ruff/mypy/bandit) passed
- No tests assert the changed help strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved CLI help text for the `--profile` flag to clarify timing collection and output behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jimmy058910/jmo-security-repo/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->