### PR TITLE
fix(versions): stop weekly issue churn for MANUAL_INSTALL_TOOLS

### DIFF
--- a/scripts/dev/update_versions.py
+++ b/scripts/dev/update_versions.py
@@ -77,6 +77,20 @@ DOCKERFILE_FAST = REPO_ROOT / "Dockerfile.fast"
 INSTALL_TOOLS = REPO_ROOT / "scripts" / "dev" / "install_tools.sh"
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 
+# Tools that require manual installation (platform limitations) and are
+# intentionally NOT baked into any Docker image. They carry synthetic versions
+# in versions.yaml (e.g. falco 0.0.0), so they ALWAYS read as "outdated" and
+# would otherwise spawn a fresh "Update <tool>" issue every weekly check-versions
+# cron run. We skip GitHub issue creation for them (the version delta is still
+# surfaced in --check-latest / --report output) to stop the recurring churn.
+#
+# Source of truth: scripts/core/tool_registry.py MANUAL_INSTALL_TOOLS. This is a
+# deliberate local mirror because scripts/dev/update_versions.py runs in CI
+# (maintenance.yml check-versions) WITHOUT `pip install -e .`, so importing the
+# scripts.core package is not reliably available there. A drift-guard unit test
+# (tests/unit/test_update_versions_manual_tools.py) asserts the two stay in sync.
+MANUAL_INSTALL_TOOLS: frozenset[str] = frozenset({"falco", "afl++", "mobsf", "akto"})
+
 # ANSI colors
 BLUE = "\033[0;34m"
 GREEN = "\033[0;32m"
@@ -817,10 +831,19 @@ def check_outdated_and_create_issues(create_issues: bool = False) -> int:
 
     outdated_critical = []
     outdated_normal = []
+    outdated_manual = []
 
     # Categorize outdated tools
     for tool, (current, latest, is_outdated) in results.items():
         if not is_outdated:
+            continue
+
+        # Manual-install tools are never baked into images and can't be
+        # auto-updated; filing a weekly issue for them is pure noise (they
+        # always read as outdated). Surface the version delta in the log but
+        # don't create an issue. See MANUAL_INSTALL_TOOLS comment above.
+        if tool in MANUAL_INSTALL_TOOLS:
+            outdated_manual.append((tool, current, latest))
             continue
 
         # Check if tool is critical
@@ -846,11 +869,24 @@ def check_outdated_and_create_issues(create_issues: bool = False) -> int:
         for tool, current, latest in outdated_normal:
             log(f"  - {tool}: {current} → {latest}")
 
+    if outdated_manual:
+        log(
+            f"Found {len(outdated_manual)} outdated MANUAL-install tools "
+            "(no issue filed; install manually):"
+        )
+        for tool, current, latest in outdated_manual:
+            log(f"  - MANUAL: {tool}: {current} → {latest}")
+
     # Create GitHub issues if requested
-    if create_issues and (outdated_critical or outdated_normal):
+    if create_issues and (outdated_critical or outdated_normal or outdated_manual):
         log("Closing superseded version update issues before creating new ones...")
+        # Include manual tools in the sweep so any lingering "Update <manual-tool>"
+        # issues (filed before we stopped creating them) get auto-closed and are
+        # never re-filed — keeps the fix self-healing without manual cleanup.
         _close_superseded_version_issues(
-            [t for t, _, _ in outdated_critical] + [t for t, _, _ in outdated_normal]
+            [t for t, _, _ in outdated_critical]
+            + [t for t, _, _ in outdated_normal]
+            + [t for t, _, _ in outdated_manual]
         )
         log("Creating GitHub issues for outdated tools...")
 
@@ -946,7 +982,9 @@ python3 scripts/dev/update_versions.py --sync
             except subprocess.CalledProcessError:
                 warn(f"Failed to create issue for {tool}")
 
-    return len(outdated_critical) + len(outdated_normal)
+    # Manual tools are counted as outdated (messaging/`--fail-if-outdated`
+    # stay honest) even though no issue is filed for them.
+    return len(outdated_critical) + len(outdated_normal) + len(outdated_manual)
 
 
 def update_all_tools(

--- a/tests/unit/test_update_versions_manual_tools.py
+++ b/tests/unit/test_update_versions_manual_tools.py
@@ -136,3 +136,39 @@ def test_only_manual_outdated_creates_no_issues():
 
     assert count == 2  # both manual tools counted as outdated
     assert created_titles == []  # but no issues filed
+
+
+def test_lingering_manual_issue_is_swept_closed():
+    """A pre-existing 'Update <manual-tool>' issue must be auto-closed (self-healing).
+
+    The superseded-issue sweep now includes manual tools, so issues filed before
+    this behavior change get closed and never re-created.
+    """
+    closed_numbers: list[str] = []
+
+    def _run(cmd, *args, **kwargs):
+        result = MagicMock(spec=subprocess.CompletedProcess)
+        result.returncode = 0
+        result.stdout = ""
+        if "list" in cmd:
+            # An old manual-tool issue is still open.
+            result.stdout = '[{"number": 529, "title": "Update falco to v0.43.1"}]'
+        elif "close" in cmd:
+            closed_numbers.append(cmd[cmd.index("close") + 1])
+        elif "create" in cmd:  # pragma: no cover - manual tools never create
+            raise AssertionError("manual tool must not create an issue")
+        return result
+
+    fake_results = {"falco": ("0.0.0", "0.43.1", True)}
+    fake_versions = {"python_tools": {}, "binary_tools": {}, "special_tools": {}}
+
+    with (
+        patch.object(
+            update_versions, "check_latest_versions", return_value=fake_results
+        ),
+        patch.object(update_versions, "load_versions", return_value=fake_versions),
+        patch.object(update_versions.subprocess, "run", side_effect=_run),
+    ):
+        update_versions.check_outdated_and_create_issues(create_issues=True)
+
+    assert "529" in closed_numbers

--- a/tests/unit/test_update_versions_manual_tools.py
+++ b/tests/unit/test_update_versions_manual_tools.py
@@ -1,0 +1,138 @@
+"""Unit tests for MANUAL_INSTALL_TOOLS handling in check_outdated_and_create_issues().
+
+The 4 manual-install tools (falco, afl++, mobsf, akto) carry synthetic versions
+in versions.yaml (e.g. falco 0.0.0), so they ALWAYS read as outdated. Before this
+behavior, the weekly check-versions cron filed a fresh "Update <tool>" GitHub issue
+for each of them every run — pure recurring noise, since they can't be auto-updated
+or baked into any Docker image. These tests pin two guarantees:
+
+1. Drift guard: update_versions.py's local MANUAL_INSTALL_TOOLS mirror stays in sync
+   with the source-of-truth set in scripts/core/tool_registry.py. The mirror exists
+   because update_versions.py runs in CI WITHOUT `pip install -e .`, so it can't
+   reliably import the scripts.core package there — but the test env CAN.
+2. Behavior: no GitHub issue is created for a manual tool, while normal/critical
+   tools still get one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _load_module():
+    script = (
+        Path(__file__).resolve().parents[2] / "scripts" / "dev" / "update_versions.py"
+    )
+    spec = importlib.util.spec_from_file_location("update_versions", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+update_versions = _load_module()
+
+
+def test_local_mirror_matches_registry_source_of_truth():
+    """The local mirror must equal scripts.core.tool_registry.MANUAL_INSTALL_TOOLS.
+
+    This runs in the dev/test env where `pip install -e .[dev]` makes the
+    scripts.core package importable. If the registry set changes, this fails
+    and forces the mirror in update_versions.py to be updated too.
+    """
+    from scripts.core.tool_registry import MANUAL_INSTALL_TOOLS as registry_manual
+
+    assert set(update_versions.MANUAL_INSTALL_TOOLS) == set(registry_manual)
+
+
+def _gh_mock_side_effect(created_titles: list[str]):
+    """Return a subprocess.run side_effect that records `gh issue create` titles.
+
+    Handles the three gh calls this code path makes:
+      - `gh issue list ... --json ...` -> returns empty JSON (no existing issues)
+      - `gh issue create --title <T> ...` -> records T, returncode 0
+      - `gh issue close ...` -> returncode 0
+    """
+
+    def _run(cmd, *args, **kwargs):
+        result = MagicMock(spec=subprocess.CompletedProcess)
+        result.returncode = 0
+        result.stdout = ""
+        if "list" in cmd:
+            result.stdout = "[]"
+        elif "create" in cmd:
+            # cmd looks like [..., "create", "--title", <title>, "--body", ...]
+            title_idx = cmd.index("--title") + 1
+            created_titles.append(cmd[title_idx])
+        return result
+
+    return _run
+
+
+def test_manual_tools_do_not_get_issues_but_normal_tools_do():
+    """A manual tool that's outdated must not spawn an issue; a normal one must."""
+    created_titles: list[str] = []
+
+    fake_results = {
+        "bandit": ("1.9.3", "1.9.4", True),  # normal, outdated -> issue
+        "falco": ("0.0.0", "0.43.1", True),  # manual, outdated -> NO issue
+        "ruff": ("0.6.0", "0.6.0", False),  # up to date -> skipped
+    }
+    fake_versions = {
+        "python_tools": {"bandit": {"critical": False}},
+        "binary_tools": {},
+        "special_tools": {"falco": {"critical": False}},
+    }
+
+    with (
+        patch.object(
+            update_versions, "check_latest_versions", return_value=fake_results
+        ),
+        patch.object(update_versions, "load_versions", return_value=fake_versions),
+        patch.object(
+            update_versions.subprocess,
+            "run",
+            side_effect=_gh_mock_side_effect(created_titles),
+        ),
+    ):
+        count = update_versions.check_outdated_and_create_issues(create_issues=True)
+
+    # Both outdated tools are counted (messaging stays honest)...
+    assert count == 2
+    # ...but only the normal tool got an issue.
+    assert any("Update bandit to " in t for t in created_titles)
+    assert not any("falco" in t for t in created_titles)
+    for manual in update_versions.MANUAL_INSTALL_TOOLS:
+        assert not any(manual in t for t in created_titles)
+
+
+def test_only_manual_outdated_creates_no_issues():
+    """If ONLY manual tools are outdated, zero issues are created."""
+    created_titles: list[str] = []
+
+    fake_results = {
+        "falco": ("0.0.0", "0.43.1", True),
+        "akto": ("mini-testing-1.53.7", "1.98.0", True),
+    }
+    fake_versions = {"python_tools": {}, "binary_tools": {}, "special_tools": {}}
+
+    with (
+        patch.object(
+            update_versions, "check_latest_versions", return_value=fake_results
+        ),
+        patch.object(update_versions, "load_versions", return_value=fake_versions),
+        patch.object(
+            update_versions.subprocess,
+            "run",
+            side_effect=_gh_mock_side_effect(created_titles),
+        ),
+    ):
+        count = update_versions.check_outdated_and_create_issues(create_issues=True)
+
+    assert count == 2  # both manual tools counted as outdated
+    assert created_titles == []  # but no issues filed


### PR DESCRIPTION
## Problem

The 4 manual-install tools (`falco`, `afl++`, `mobsf`, `akto`) carry **synthetic versions** in `versions.yaml` (e.g. `falco 0.0.0`), so `check_latest_versions()` *always* reports them as outdated. The weekly `check-versions` cron (`maintenance.yml`) therefore files a fresh `Update <tool>` GitHub issue for each, every run. They get triaged closed, then reappear days later — observed this exact churn on 2026-05-25 (#504/#505/#506/#509 closed, re-filed within hours; currently open again as #529/#526/#525/#524).

These tools **can't be auto-updated or baked into any Docker image** (that's why they're in `MANUAL_INSTALL_TOOLS`), so the issues are pure recurring noise.

## Change

`check_outdated_and_create_issues()` now:
- **Skips issue creation** for `MANUAL_INSTALL_TOOLS` while **still logging** the version delta (`MANUAL: falco: 0.0.0 → 0.43.1`) — signal preserved in `--check-latest` / `--report` output, only the GitHub-issue noise removed.
- **Includes manual tools in the superseded-issue sweep**, so any lingering `Update <manual-tool>` issues are auto-closed and never re-filed. **Self-healing** — no manual cleanup needed going forward.
- Still **counts** manual tools as outdated so messaging and `--fail-if-outdated` stay honest.

`falcoctl` (the installable Falco CLI, distinct from `falco`) is unaffected.

## Why a local mirror of MANUAL_INSTALL_TOOLS

`update_versions.py` runs in CI (`maintenance.yml` `check-versions`) with only `pip install pyyaml packaging` — **no `pip install -e .`** — so `from scripts.core.tool_registry import MANUAL_INSTALL_TOOLS` would `ModuleNotFoundError` there. The set is mirrored locally with a comment citing the source of truth, and a **drift-guard unit test** (which runs in the `-e .[dev]` test env) asserts the two stay in sync.

## Tests

`tests/unit/test_update_versions_manual_tools.py`:
- `test_local_mirror_matches_registry_source_of_truth` — drift guard vs `tool_registry.MANUAL_INSTALL_TOOLS`
- `test_manual_tools_do_not_get_issues_but_normal_tools_do` — falco skipped, bandit filed
- `test_only_manual_outdated_creates_no_issues` — zero issues when only manual tools outdated

All pass; existing `test_update_versions_{level,classify}.py` unaffected. `black` + `ruff check` clean; pre-commit passed.

## Follow-up (in this PR)

Closing the 4 currently-open manual-tool issues (#529, #526, #525, #524) as a one-time cleanup, since the new sweep only fires on the next cron run.