### PR TITLE
ci(pip-audit): ignore tuf GHSA-qp9x-wp8f-qgjj until sigstore supports tuf 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,16 @@ jobs:
           #   dev-only dep via `mcp` (requirements-dev.txt), not used in
           #   production paths. Source:
           #   https://api.osv.dev/v1/vulns/PYSEC-2025-183
+          # - GHSA-qp9x-wp8f-qgjj ("tuf platform-dependent delegation path
+          #   matching", CVSS 4.0 medium): fixed in tuf 7.0.0, but NOT adoptable.
+          #   tuf is a transitive dev-only dep via `sigstore` (SLSA attestation),
+          #   and every sigstore release caps tuf<7.0.0, so the fix is
+          #   unresolvable until sigstore catches up. Drop this ignore then.
+          #   Tracking: #539. Source:
+          #   https://github.com/advisories/GHSA-qp9x-wp8f-qgjj
           pip-audit -r requirements-dev.txt --progress-spinner=off \
-            --ignore-vuln PYSEC-2025-183 || {
+            --ignore-vuln PYSEC-2025-183 \
+            --ignore-vuln GHSA-qp9x-wp8f-qgjj || {
             echo "::warning::Vulnerable dependencies detected. Review and update."
             exit 1
           }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -167,6 +167,8 @@ repos:
         # advisory, no fix version, transitive dev-only via mcp. Mirrors
         # the same ignore applied in .github/workflows/ci.yml's pip-audit
         # step. See that file for the full reasoning + OSV link.
-        entry: pip-audit -r requirements-dev.txt --progress-spinner=off --ignore-vuln PYSEC-2025-183
+        # GHSA-qp9x-wp8f-qgjj (tuf, CVSS 4.0): fix in tuf 7.0.0 not adoptable
+        # while sigstore caps tuf<7. Tracking: #539.
+        entry: pip-audit -r requirements-dev.txt --progress-spinner=off --ignore-vuln PYSEC-2025-183 --ignore-vuln GHSA-qp9x-wp8f-qgjj
         pass_filenames: false
         files: ^requirements-dev\.(in|txt)$


### PR DESCRIPTION
## Summary

`pip-audit` started failing CI on **GHSA-qp9x-wp8f-qgjj** (`tuf <= 6.0.0`, "platform-dependent delegation path matching", CVSS 4.0 medium, published 2026-05-28, fixed in tuf 7.0.0). This is the only ruleset-required check (`quick-checks`), so it blocks **every** PR and main itself.

The fix (tuf 7.0.0) is **not adoptable**: `tuf` is a transitive dev-only dep via `sigstore` (SLSA attestation), and every sigstore release caps `tuf<7.0.0`:

```
sigstore==4.2.0 depends on tuf>=6.0,<7.dev0
→ sigstore>=2.0.0 + tuf>=7.0.0 is unsatisfiable (uv resolver)
```

So this adds `--ignore-vuln GHSA-qp9x-wp8f-qgjj` to the `ci.yml` pip-audit step **and** the pip-audit pre-commit hook, mirroring the existing `PYSEC-2025-183` (disputed pyjwt) ignore pattern.

## Verification

`pip-audit -r requirements-dev.txt --ignore-vuln PYSEC-2025-183 --ignore-vuln GHSA-qp9x-wp8f-qgjj` → `No known vulnerabilities found, 1 ignored` (exit 0).

## Follow-up

- Drop the ignore once sigstore ships a tuf-7-compatible release — tracked in #539.
- Dependabot alert #120 flags the same CVE (separate surface; same root constraint).
- Unblocks #537.

Refs #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python dependency vulnerability scanning configurations in CI workflows and pre-commit hooks to ignore an additional security advisory while maintaining existing security checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jimmy058910/jmo-security-repo/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->