### PR TITLE
ci(maintenance): skip Repository Completeness PR-comment on fork PRs

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -599,7 +599,12 @@ jobs:
           echo "No critical issues found (total: $TOTAL_COUNT)"
 
       - name: Post summary to PR
-        if: github.event_name == 'pull_request'
+        # Skip on fork PRs: GitHub grants fork-PR runs a read-only GITHUB_TOKEN,
+        # so issue-comment creation fails with HttpError 403 ("Resource not
+        # accessible by integration") and reds-X the whole job for every
+        # external contribution. Internal-branch PRs still get the comment; the
+        # full analysis is always available via the uploaded artifact above.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Problem

The **Repository Completeness Analysis** job's final step, "Post summary to PR", uses `actions/github-script` to post a comment. On **fork PRs**, GitHub grants the workflow a **read-only `GITHUB_TOKEN`** (security default), so the create-comment call fails with:

```
HttpError: Resource not accessible by integration
```

This reds-X the whole job on **every external contribution**, even though the analysis itself passes. First-time / good-first-issue contributors see a scary failing check on their PR. Surfaced on #537 (Lucas-FManager's docs PR).

## Fix

Guard the step with `github.event.pull_request.head.repo.fork == false` so it runs only on internal-branch PRs. Fork PRs still get the full analysis via the uploaded artifact; the job simply skips the comment it could never post.

## Scope

One-step `if:` change + explanatory comment. Non-fork PR behavior is unchanged. No effect on the scheduled/cron runs of this workflow.