### PR TITLE
chore(deps): fold-in 9 tool version bumps (#545-#553)

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -388,7 +388,7 @@ jobs:
           # Avoids upstream install.sh GitHub-API "latest" lookups that have
           # flaked in CI (see PR #350 + release.rules.md).
           TRIVY_VERSION: "0.70.0"
-          GRYPE_VERSION: "0.104.0"
+          GRYPE_VERSION: "0.112.0"
           SYFT_VERSION: "1.42.4"
           TRUFFLEHOG_VERSION: "3.94.3"
           HADOLINT_VERSION: "2.14.0"

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -61,7 +61,7 @@ RUN ZAP_VERSION="2.16.1" && \
     mv /opt/ZAP_${ZAP_VERSION} /opt/zaproxy
 
 # Download Nuclei (DAST + API Security)
-RUN NUCLEI_VERSION="3.7.0" && \
+RUN NUCLEI_VERSION="3.8.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -84,7 +84,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Gosec (Go SAST)
-RUN GOSEC_VERSION="2.22.10" && \
+RUN GOSEC_VERSION="2.26.1" && \
     GOSEC_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_${GOSEC_ARCH}.tar.gz" \
     -o /tmp/gosec.tar.gz && \
@@ -93,7 +93,7 @@ RUN GOSEC_VERSION="2.22.10" && \
     chmod +x /usr/local/bin/gosec
 
 # Download Grype (SCA + Vuln - Anchore)
-RUN GRYPE_VERSION="0.104.0" && \
+RUN GRYPE_VERSION="0.112.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \
@@ -126,7 +126,7 @@ RUN OPA_VERSION="1.12.0" && \
     chmod +x /usr/local/bin/opa
 
 # Download ShellCheck (pinned version instead of apt)
-RUN SHELLCHECK_VERSION="0.10.0" && \
+RUN SHELLCHECK_VERSION="0.11.0" && \
     SHELLCHECK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" \
     -o /tmp/shellcheck.tar.xz && \
@@ -190,7 +190,7 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.164.0 \
     checkov==3.2.530 \
-    ruff==0.15.2 \
+    ruff==0.15.15 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -57,14 +57,14 @@ RUN HADOLINT_VERSION="2.14.0" && \
     chmod +x /usr/local/bin/hadolint
 
 # Download shfmt (Shell formatting)
-RUN SHFMT_VERSION="3.12.0" && \
+RUN SHFMT_VERSION="3.13.1" && \
     SHFMT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${SHFMT_ARCH}" \
     -o /usr/local/bin/shfmt && \
     chmod +x /usr/local/bin/shfmt
 
 # Download Falcoctl (Runtime Security)
-RUN FALCOCTL_VERSION="0.12.2" && \
+RUN FALCOCTL_VERSION="0.13.0" && \
     FALCOCTL_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/falcosecurity/falcoctl/releases/download/v${FALCOCTL_VERSION}/falcoctl_${FALCOCTL_VERSION}_linux_${FALCOCTL_ARCH}.tar.gz" \
     -o /tmp/falcoctl.tar.gz && \
@@ -91,7 +91,7 @@ RUN ZAP_VERSION="2.16.1" && \
     mv /opt/ZAP_${ZAP_VERSION} /opt/zaproxy
 
 # Download Nuclei (DAST + API Security)
-RUN NUCLEI_VERSION="3.7.0" && \
+RUN NUCLEI_VERSION="3.8.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -114,7 +114,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Gosec (Go SAST)
-RUN GOSEC_VERSION="2.22.10" && \
+RUN GOSEC_VERSION="2.26.1" && \
     GOSEC_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_${GOSEC_ARCH}.tar.gz" \
     -o /tmp/gosec.tar.gz && \
@@ -123,7 +123,7 @@ RUN GOSEC_VERSION="2.22.10" && \
     chmod +x /usr/local/bin/gosec
 
 # Download Grype (SCA + Vuln - Anchore)
-RUN GRYPE_VERSION="0.104.0" && \
+RUN GRYPE_VERSION="0.112.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \
@@ -170,7 +170,7 @@ RUN OPA_VERSION="1.12.0" && \
     chmod +x /usr/local/bin/opa
 
 # Download ShellCheck (pinned version instead of apt)
-RUN SHELLCHECK_VERSION="0.10.0" && \
+RUN SHELLCHECK_VERSION="0.11.0" && \
     SHELLCHECK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" \
     -o /tmp/shellcheck.tar.xz && \
@@ -258,7 +258,7 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages checkov==3.2.5
     checkov --version && \
     echo "✓ checkov installed"
 
-RUN python3 -m pip install --no-cache-dir --break-system-packages ruff==0.15.2 && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages ruff==0.15.15 && \
     echo "✓ ruff installed"
 
 RUN python3 -m pip install --no-cache-dir --break-system-packages yara-python==4.5.4 && \

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -53,7 +53,7 @@ RUN HADOLINT_VERSION="2.14.0" && \
     chmod +x /usr/local/bin/hadolint
 
 # Download Nuclei (minimal templates for fast scans)
-RUN NUCLEI_VERSION="3.7.0" && \
+RUN NUCLEI_VERSION="3.8.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -72,7 +72,7 @@ RUN OPA_VERSION="1.12.0" && \
     chmod +x /usr/local/bin/opa
 
 # Download ShellCheck (pinned version instead of apt)
-RUN SHELLCHECK_VERSION="0.10.0" && \
+RUN SHELLCHECK_VERSION="0.11.0" && \
     SHELLCHECK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" \
     -o /tmp/shellcheck.tar.xz && \
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.164.0 \
     checkov==3.2.530 \
-    ruff==0.15.2 \
+    ruff==0.15.15 \
     && find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -53,7 +53,7 @@ RUN HADOLINT_VERSION="2.14.0" && \
     chmod +x /usr/local/bin/hadolint
 
 # Download Nuclei (DAST + API)
-RUN NUCLEI_VERSION="3.7.0" && \
+RUN NUCLEI_VERSION="3.8.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -72,7 +72,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Grype (SCA + Vuln)
-RUN GRYPE_VERSION="0.104.0" && \
+RUN GRYPE_VERSION="0.112.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \
@@ -105,7 +105,7 @@ RUN OPA_VERSION="1.12.0" && \
     chmod +x /usr/local/bin/opa
 
 # Download ShellCheck (pinned version instead of apt)
-RUN SHELLCHECK_VERSION="0.10.0" && \
+RUN SHELLCHECK_VERSION="0.11.0" && \
     SHELLCHECK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" \
     -o /tmp/shellcheck.tar.xz && \
@@ -158,7 +158,7 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.164.0 \
     checkov==3.2.530 \
-    ruff==0.15.2 \
+    ruff==0.15.15 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \

--- a/versions.yaml
+++ b/versions.yaml
@@ -19,7 +19,7 @@ python_tools:
     update_check: pip index versions checkov
     critical: true
   ruff:
-    version: 0.15.2
+    version: 0.15.15
     pypi_package: ruff
     description: Python linter and formatter
     update_check: pip index versions ruff
@@ -121,7 +121,7 @@ binary_tools:
     critical: false
     brew_package: hadolint
   falcoctl:
-    version: 0.12.2
+    version: 0.13.0
     github_repo: falcosecurity/falcoctl
     description: Falco CLI for static analysis
     release_pattern: falcoctl_{version}_linux_{arch}.tar.gz
@@ -131,7 +131,7 @@ binary_tools:
     update_check: gh api repos/falcosecurity/falcoctl/releases/latest
     critical: false
   shfmt:
-    version: 3.12.0
+    version: 3.13.1
     github_repo: mvdan/sh
     description: Shell formatter
     release_pattern: shfmt_v{version}_linux_{arch}
@@ -141,7 +141,7 @@ binary_tools:
     update_check: gh api repos/mvdan/sh/releases/latest
     critical: false
   nuclei:
-    version: 3.7.0
+    version: 3.8.0
     github_repo: projectdiscovery/nuclei
     description: Fast vulnerability scanner with 4000+ templates (DAST/API security)
     release_pattern: nuclei_{version}_linux_{arch}.zip
@@ -164,7 +164,7 @@ binary_tools:
     critical: true
     notes: v1.0.0 - K8s hardening and compliance
   gosec:
-    version: 2.22.10
+    version: 2.26.1
     github_repo: securego/gosec
     description: Go security analyzer
     release_pattern: gosec_{version}_linux_{arch}.tar.gz
@@ -175,7 +175,7 @@ binary_tools:
     critical: false
     notes: v1.0.0 - Go-specific SAST
   grype:
-    version: 0.104.0
+    version: 0.112.0
     github_repo: anchore/grype
     description: Vulnerability scanner for containers/filesystems
     release_pattern: grype_{version}_linux_{arch}.tar.gz
@@ -186,7 +186,7 @@ binary_tools:
     critical: false
     notes: v1.0.0 - Dual scanning with Trivy (Anchore DB)
   osv-scanner:
-    version: 2.3.1
+    version: 2.3.8
     github_repo: google/osv-scanner
     description: Google OSV vulnerability scanner
     release_pattern: osv-scanner_linux_{arch}
@@ -246,7 +246,7 @@ special_tools:
       '
     docker_ready: false
   yara:
-    version: 4.5.4
+    version: 4.5.5
     pypi_package: yara-python
     github_repo: VirusTotal/yara
     description: Malware pattern detection
@@ -295,7 +295,7 @@ special_tools:
     critical: true
     notes: 'v1.0.0 - Policy-as-Code feature (Feature #5)'
   shellcheck:
-    version: 0.10.0
+    version: 0.11.0
     github_repo: koalaman/shellcheck
     description: Static analysis for shell scripts
     release_pattern: shellcheck-v{version}.linux.{arch}.tar.xz
@@ -372,6 +372,123 @@ update_policies:
   automated_check_schedule: Weekly (Sunday 00:00 UTC)
   manual_review_schedule: First Monday of each month
 version_history:
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated shellcheck
+  tools_updated:
+  - tool: shellcheck
+    old_version: 0.10.0
+    new_version: 0.11.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated yara
+  tools_updated:
+  - tool: yara
+    old_version: 4.5.4
+    new_version: 4.5.5
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated osv-scanner
+  tools_updated:
+  - tool: osv-scanner
+    old_version: 2.3.1
+    new_version: 2.3.8
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated grype
+  tools_updated:
+  - tool: grype
+    old_version: 0.104.0
+    new_version: 0.112.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated gosec
+  tools_updated:
+  - tool: gosec
+    old_version: 2.22.10
+    new_version: 2.26.1
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated nuclei
+  tools_updated:
+  - tool: nuclei
+    old_version: 3.7.0
+    new_version: 3.8.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated shfmt
+  tools_updated:
+  - tool: shfmt
+    old_version: 3.12.0
+    new_version: 3.13.1
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated falcoctl
+  tools_updated:
+  - tool: falcoctl
+    old_version: 0.12.2
+    new_version: 0.13.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-05-31'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-05-31'
+  action: Updated ruff
+  tools_updated:
+  - tool: ruff
+    old_version: 0.15.2
+    new_version: 0.15.15
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
 - date: '2026-05-31'
   action: Automated version update
   tools_updated: []


### PR DESCRIPTION
## Summary

Manual **fold-in** of the 9 tool-version update issues the weekly `check-versions` cron filed but could **not** auto-apply. The 2026-05-31 cron hit a GitHub API flake at 00:48 UTC and only swept the 3 PyPI tools (semgrep/checkov/prowler — landed separately in #544); these 9 GitHub/PyPI-released tools were filed as issues instead.

Bumped via `update_versions.py --tool <t> --version <v>` (×9) then a single `--sync` to propagate `versions.yaml` → 4 Dockerfiles + `scheduled.yml`. No Dockerfiles edited by hand.

## Bumps

| Tool | From | To | Issue |
|------|------|----|-------|
| ruff | 0.15.2 | 0.15.15 | #545 |
| falcoctl | 0.12.2 | 0.13.0 | #546 |
| shfmt | 3.12.0 | 3.13.1 | #547 |
| nuclei | 3.7.0 | 3.8.0 | #548 |
| gosec | 2.22.10 | 2.26.1 | #549 |
| grype | 0.104.0 | 0.112.0 | #550 |
| osv-scanner | 2.3.1 | 2.3.8 | #551 |
| yara | 4.5.4 | 4.5.5 | #552 |
| shellcheck | 0.10.0 | 0.11.0 | #553 |

> Note on ruff: this bumps the **`versions.yaml`/Dockerfile** pin (`0.15.2 → 0.15.15`). The separate `.pre-commit-config.yaml` ruff hook pin was already moved to `v0.15.15` in #544 — the two pins are now aligned.

## Verification

- ✅ All 9 versions confirmed to exist upstream (`update_versions.py --validate`).
- ✅ Pre-commit clean (incl. `mixed line ending`, `yamllint`, GitHub Actions lint).
- 👀 **Reviewer watch — grype:** largest jump (8 minor releases, `0.104.0 → 0.112.0`). If `tool-contract-tests` goes red, suspect grype SARIF/JSON format drift first.

Closes #545
Closes #546
Closes #547
Closes #548
Closes #549
Closes #550
Closes #551
Closes #552
Closes #553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled security analysis tools (Grype, Gosec, ShellCheck, Nuclei) and development dependencies (ruff, shfmt, falcoctl, osv-scanner, yara) to latest versions across all Docker image variants and workflows for improved functionality and security coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->