### PR TITLE
fix(dev): specify encoding="utf-8" in update_versions.py file ops

### DIFF
--- a/scripts/dev/update_versions.py
+++ b/scripts/dev/update_versions.py
@@ -245,7 +245,7 @@ def load_versions() -> dict:
         err(f"versions.yaml not found at {VERSIONS_YAML}")
         sys.exit(1)
 
-    with open(VERSIONS_YAML) as f:
+    with open(VERSIONS_YAML, encoding="utf-8") as f:
         data: dict[Any, Any] = yaml.safe_load(f) or {}
         return data
 
@@ -269,7 +269,7 @@ def save_versions(data: dict) -> None:
 
     # newline="\n" forces LF on all platforms; without it Windows text-mode
     # writes emit CRLF for every line, producing a full-file false diff (#555).
-    with open(VERSIONS_YAML, "w", newline="\n") as f:
+    with open(VERSIONS_YAML, "w", encoding="utf-8", newline="\n") as f:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
 
@@ -662,7 +662,7 @@ def sync_dockerfiles(dry_run: bool = False) -> bool:
             warn(f"{dockerfile_path.name} not found, skipping")
             continue
 
-        content = dockerfile_path.read_text()
+        content = dockerfile_path.read_text(encoding="utf-8")
         original_content = content
 
         # Replace version variables
@@ -684,7 +684,7 @@ def sync_dockerfiles(dry_run: bool = False) -> bool:
                 warn(f"{dockerfile_path.name} needs updates (dry-run, not writing)")
             else:
                 # newline="\n": keep LF on Windows (see #555).
-                dockerfile_path.write_text(content, newline="\n")
+                dockerfile_path.write_text(content, encoding="utf-8", newline="\n")
                 ok(f"Updated {dockerfile_path.name}")
         else:
             ok(f"{dockerfile_path.name} already in sync")
@@ -694,7 +694,7 @@ def sync_dockerfiles(dry_run: bool = False) -> bool:
         sorted(WORKFLOWS_DIR.glob("*.yml")) if WORKFLOWS_DIR.exists() else []
     )
     for workflow_path in workflow_files:
-        content = workflow_path.read_text()
+        content = workflow_path.read_text(encoding="utf-8")
         original_content = content
 
         for tool, version in version_map.items():
@@ -713,7 +713,7 @@ def sync_dockerfiles(dry_run: bool = False) -> bool:
                 )
             else:
                 # newline="\n": keep LF on Windows (see #555).
-                workflow_path.write_text(content, newline="\n")
+                workflow_path.write_text(content, encoding="utf-8", newline="\n")
                 ok(f"Updated .github/workflows/{workflow_path.name}")
         else:
             ok(f".github/workflows/{workflow_path.name} already in sync")

--- a/tests/unit/test_update_versions_encoding.py
+++ b/tests/unit/test_update_versions_encoding.py
@@ -1,0 +1,141 @@
+"""Regression tests: update_versions.py file ops must specify encoding="utf-8".
+
+`open()`, `Path.read_text()` and `Path.write_text()` without an `encoding=`
+argument fall back to the locale-default codec. On Windows that is the legacy
+ANSI code page (e.g. cp1252), not UTF-8 — so a non-ASCII byte in versions.yaml
+(a tool description, an em-dash, an accented name) would round-trip wrong or
+raise. PEP 597 calls this out; ruff's PLW1514 is the same warning. Follow-up to
+the CRLF fix on these same call sites (#555 / PR #556).
+
+Two complementary checks:
+  * an AST scan that deterministically flags any text file op missing
+    `encoding=` (covers every site on every platform), and
+  * a behavioral check that runs the real functions under
+    `-X warn_default_encoding -W error::EncodingWarning`, which turns the
+    omission itself into an error — so it goes RED regardless of the runner's
+    locale (a byte-compare test would be a tautology on a UTF-8 runner).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "dev" / "update_versions.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("update_versions", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+update_versions = _load_module()
+
+
+def _binary_mode(call: ast.Call) -> bool:
+    """True if an open() call is binary mode (encoding= is invalid there)."""
+    mode = ""
+    if len(call.args) >= 2 and isinstance(call.args[1], ast.Constant):
+        mode = str(call.args[1].value)
+    for kw in call.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+            mode = str(kw.value.value)
+    return "b" in mode
+
+
+def test_all_text_file_ops_specify_encoding():
+    """Every open()/read_text()/write_text() in the script must pass encoding=."""
+    tree = ast.parse(SCRIPT_PATH.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "open":
+            if _binary_mode(node):
+                continue
+            name = "open"
+        elif isinstance(func, ast.Attribute) and func.attr in (
+            "read_text",
+            "write_text",
+        ):
+            name = func.attr
+        else:
+            continue
+        if not any(kw.arg == "encoding" for kw in node.keywords):
+            offenders.append(f"{name}() at line {node.lineno}")
+    assert not offenders, "file ops missing encoding=: " + ", ".join(offenders)
+
+
+def test_file_ops_emit_no_encoding_warning(tmp_path):
+    """save_versions + sync_dockerfiles must raise no EncodingWarning.
+
+    Run in a subprocess under `-X warn_default_encoding -W error::EncodingWarning`
+    so any file op missing `encoding=` raises. GREEN therefore proves every site
+    (the write at save_versions, the read in load_versions, and the two
+    read_text/write_text pairs in sync_dockerfiles) is guarded.
+    """
+    driver = tmp_path / "driver.py"
+    driver.write_text(
+        textwrap.dedent(f"""\
+            import importlib.util, sys, tempfile, pathlib
+            spec = importlib.util.spec_from_file_location(
+                "update_versions", {str(SCRIPT_PATH)!r}
+            )
+            m = importlib.util.module_from_spec(spec)
+            sys.modules["update_versions"] = m
+            spec.loader.exec_module(m)
+
+            d = pathlib.Path(tempfile.mkdtemp())
+            m.VERSIONS_YAML = d / "versions.yaml"
+            # write (save_versions) + later read (load_versions) of versions.yaml
+            m.save_versions({{"binary_tools": {{"trivy": {{"version": "0.70.0"}}}}}})
+
+            # Dockerfile + workflow pinned stale so sync rewrites (exercises both
+            # read_text and write_text). Driver's own writes set encoding to avoid
+            # tripping the warning on the test scaffolding itself.
+            df = d / "Dockerfile.test"
+            df.write_text('ENV TRIVY_VERSION="0.69.0"\\n', encoding="utf-8", newline="\\n")
+            m.DOCKERFILE = df
+            for a in ("DOCKERFILE_BALANCED", "DOCKERFILE_SLIM", "DOCKERFILE_FAST"):
+                setattr(m, a, d / ("absent_" + a))
+            wfd = d / "workflows"
+            wfd.mkdir()
+            (wfd / "t.yml").write_text(
+                '  TRIVY_VERSION: "0.69.0"\\n', encoding="utf-8", newline="\\n"
+            )
+            m.WORKFLOWS_DIR = wfd
+
+            m.sync_dockerfiles(dry_run=False)
+            print("DRIVER_OK")
+            """),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-X",
+            "warn_default_encoding",
+            "-W",
+            "error::EncodingWarning",
+            str(driver),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        "EncodingWarning fired — a file op is missing encoding=:\n" + result.stderr
+    )
+    assert "DRIVER_OK" in result.stdout


### PR DESCRIPTION
## Summary

Follow-up to #556 (the CRLF/`newline` fix). The same `open()` / `read_text()` / `write_text()` sites in `update_versions.py` also omitted an `encoding=` argument, so they used the **locale-default codec** — `cp1252` on a legacy Windows console rather than UTF-8 (PEP 597; ruff's `PLW1514` is the same lint).

For the current file content (versions.yaml, Dockerfiles, workflow `env:` blocks — all ASCII) this is **latent, not active harm** — unlike the CRLF bug's 7,700-line diff. But a non-ASCII byte (a tool description, an em-dash, an accented name) would round-trip wrong or raise. Specifying encoding explicitly is the defensive, correct default.

## Change

`encoding="utf-8"` added to all 6 text file ops:

| Function | Site |
|----------|------|
| `load_versions` | `open(VERSIONS_YAML)` (read) |
| `save_versions` | `open(VERSIONS_YAML, "w", …)` (write) |
| `sync_dockerfiles` | `dockerfile_path.read_text()` / `.write_text()` |
| `sync_dockerfiles` | `workflow_path.read_text()` / `.write_text()` |

## Tests (`tests/unit/test_update_versions_encoding.py`)

Two complementary regression guards, both verified **RED→GREEN**:

1. **AST scan** — deterministically flags any `open`/`read_text`/`write_text` missing `encoding=` (binary-mode `open` excluded). Covers all 6 sites on every platform.
2. **Behavioral** — runs `save_versions` + `sync_dockerfiles` in a subprocess under `-X warn_default_encoding -W error::EncodingWarning`. The omission *itself* raises, so the test goes RED even on a UTF-8 machine (a byte-compare test would be a tautology there). Verified failing pre-fix at `update_versions.py:272`, passing post-fix.

Full `tests/unit/test_update_versions_*.py`: 33 passed.

Context: #555 / #556.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated file I/O operations to explicitly specify UTF-8 encoding across configuration and deployment files.

* **Tests**
  * Added regression tests to verify that all text file operations specify explicit UTF-8 encoding and detect related warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->