### PR TITLE
fix(deps): bump pyjwt 2.12.1 -> 2.13.0 (PYSEC-2026-175/177/178/179)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -152,7 +152,7 @@ pygments==2.20.0
     # via
     #   pytest
     #   rich
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via
     #   mcp
     #   sigstore


### PR DESCRIPTION
## Summary

`pip-audit` (the required `quick-checks` gate) started failing on `main` with **no code change** — 4 new pyjwt CVEs were published against the pinned `2.12.1` *after* PR #557's CI run. `pip-audit` queries a live advisory DB, so the same pinned `main` now fails. All 4 are fixed in `2.13.0`:

| ID | Fix |
|----|-----|
| PYSEC-2026-175 | 2.13.0 |
| PYSEC-2026-177 | 2.13.0 |
| PYSEC-2026-178 | 2.13.0 |
| PYSEC-2026-179 | 2.13.0 |

pyjwt is a **transitive** dependency (via `mcp` + `sigstore`); pinning it in the compiled `requirements-dev.txt` lockfile is the correct surface. One-line edit — pyjwt has no required runtime deps, so the rest of the resolution is unchanged.

Precedent: `eb0b404 fix(deps): bump starlette 1.0.0 -> 1.0.1 (PYSEC-2026-161)`.

## Verification

Ran the exact CI gate command (`ci.yml:87-89`) locally:

```
pip-audit -r requirements-dev.txt --progress-spinner=off \
  --ignore-vuln PYSEC-2025-183 --ignore-vuln GHSA-qp9x-wp8f-qgjj
# -> "No known vulnerabilities found, 1 ignored", exit 0
```

The pre-commit `pip-audit` hook also passed on commit.

## Test plan

- [ ] CI `quick-checks` (pip-audit) passes
- [ ] Sharded tests pass (no behavior change expected — patch bump of a JWT lib)