### PR TITLE
feat(ci): add Dockerfile linting with Hadolint to the CI workflow Thi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,30 @@ jobs:
           pip install yamllint
           yamllint -c .yamllint.yaml .
 
+      - name: Lint Dockerfile.fast
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile.fast
+          failure-threshold: warning
+
+      - name: Lint Dockerfile.slim
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile.slim
+          failure-threshold: warning
+
+      - name: Lint Dockerfile.balanced
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile.balanced
+          failure-threshold: warning
+
+      - name: Lint Dockerfile.deep
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile.deep
+          failure-threshold: warning
+
       - name: Validate requirements-dev.txt Python version
         run: |
           python -m pip install uv==0.11.15  # pinned: matches lockfile regen version (companion to PR #488)

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,23 @@
+---
+# Hadolint configuration for JMo Security Dockerfiles
+# See https://github.com/hadolint/hadolint#configure
+
+ignored:
+  # DL3008: Pin versions in apt-get install.
+  # Intentionally unpinned — Ubuntu 24.04 base images receive security
+  # updates via apt; pinning would freeze vulnerable package versions.
+  - DL3008
+
+  # DL3059: Multiple consecutive RUN instructions.
+  # Intentional for build clarity, caching granularity, and per-tool
+  # error isolation across multi-stage Dockerfiles.
+  - DL3059
+
+  # DL4006: Set the SHELL option -o pipefail before RUN with a pipe.
+  # NodeSource install script (curl | bash) is a vendor-recommended
+  # pattern used in Dockerfile.balanced and Dockerfile.deep.
+  - DL4006
+
+  # SC1091: Not following sourced file (ShellCheck via hadolint).
+  # ShellCheck cannot resolve dynamic/external sources inside Docker.
+  - SC1091

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -261,8 +261,7 @@ COPY . /opt/jmo-security/
 RUN cp /opt/jmo-security/jmo.yml /scan/jmo.yml
 
 # Install JMo with reporting dependencies
-RUN cd /opt/jmo-security && \
-    python3 -m pip install --no-cache-dir --break-system-packages -e ".[reporting]" && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages -e "/opt/jmo-security[reporting]" && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true
 

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -365,8 +365,7 @@ RUN cp /opt/jmo-security/jmo.yml /scan/jmo.yml
 
 # Install JMo Security Suite with optional reporting dependencies
 # Clean up pip cache and bytecode immediately after install (Phase 1: 40 MB savings)
-RUN cd /opt/jmo-security && \
-    python3 -m pip install --no-cache-dir --break-system-packages -e ".[reporting]" && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages -e "/opt/jmo-security[reporting]" && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true
 

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -157,8 +157,7 @@ COPY . /opt/jmo-security/
 RUN cp /opt/jmo-security/jmo.yml /scan/jmo.yml
 
 # Install JMo (minimal, no reporting extras)
-RUN cd /opt/jmo-security && \
-    python3 -m pip install --no-cache-dir --break-system-packages -e . && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages -e /opt/jmo-security && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -211,8 +211,7 @@ COPY . /opt/jmo-security/
 RUN cp /opt/jmo-security/jmo.yml /scan/jmo.yml
 
 # Install JMo (minimal, no reporting extras for slim variant)
-RUN cd /opt/jmo-security && \
-    python3 -m pip install --no-cache-dir --break-system-packages -e . && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages -e /opt/jmo-security && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true
 


### PR DESCRIPTION


## Summary

Adds automated Dockerfile linting with Hadolint to the `quick-checks` CI job, so best practice violations and security issues in our Dockerfiles are caught early in pull requests.
 

## Linked issues

Closes #85 

## Changes

- [✓] Code
- [ ] Tests
- [ ] Docs
- [ ] Breaking change (CLI flag, output format, public API, schema)

**Details:**
 
- Added four Hadolint checks to the quick-checks job in the CI workflow, with one check for each Dockerfile: Dockerfile.fast, Dockerfile.slim, Dockerfile.balanced, and Dockerfile.deep.
- Created a .hadolint.yaml configuration file to suppress rules that conflict with intentional design choices, including rules around unpinned apt packages, multiple RUN layers, the NodeSource install pattern, and SC1091.
- Fixed the DL3003 warnings in all four Dockerfiles by replacing the command that changed directory before running pip install with an absolute path. This avoids changing the working directory in the middle of the command.
 
 
## Motivation / Context

JMo ships four production Dockerfiles but had no automated linting to catch issues like missing version pins, unnecessary layers, or security problems. Hadolint is already used as a scanner within JMo itself, so this brings the same standard to our own Dockerfiles. Requested in #85.
 
## How to test

```bash
# Install hadolint locally (macOS)
brew install hadolint
 
# Lint all four Dockerfiles with the repo config
hadolint --config .hadolint.yaml Dockerfile.fast Dockerfile.slim Dockerfile.balanced Dockerfile.deep
# Expected: no output, exit code 0

## Checklist

- [ ] Ran `make fmt && make lint && make test`
- [ ] Updated docs (README/QUICKSTART/USER_GUIDE) if behavior changed
- [ ] Considered backward compatibility for CLI flags/outputs
- [ ] Added a `CHANGELOG.md` entry if this is user-facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added container linting to CI workflow to improve Dockerfile quality assurance.
  * Updated Dockerfile installation configurations for consistency across build variants.
  * Added Hadolint configuration to manage linting rules and suppressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->