### PR TITLE
fix(deps): bump cryptography/starlette/python-multipart for pip-audit CVEs

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -32,6 +32,11 @@ types-croniter
 
 # MCP Server dependencies (Feature #2: AI Remediation)
 mcp[cli]>=1.0.0  # Official Anthropic MCP SDK with FastMCP framework
+# Security floors for mcp's transitive web deps (pip-audit fixable CVEs, 2026-06):
+#   starlette>=1.3.1: CVE-2026-48817/48818/54282/54283
+#   python-multipart>=0.0.31: CVE-2026-53538/53539/53540
+starlette>=1.3.1
+python-multipart>=0.0.31
 
 # Policy-as-Code dependencies (Feature #5: Policy-as-Code)
 # Note: OPA binary installed separately via scripts/dev/install_tools.sh
@@ -40,7 +45,7 @@ packaging  # For version comparison in OPA version checks
 
 # SLSA Attestation dependencies (Feature #6: Supply Chain Attestation - v1.0.0)
 sigstore>=2.0.0  # Sigstore Python SDK for keyless signing (Fulcio + Rekor)
-cryptography>=41.0.0  # Cryptographic primitives for hashing and signing
+cryptography>=48.0.1  # Cryptographic primitives for hashing and signing (>=48.0.1: GHSA-537c-gmf6-5ccf)
 
 # Platform-specific transitive deps pinned as top-level to ensure they appear in the
 # lockfile. uv pip compile --universal preserves all platform markers natively,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,7 +44,7 @@ coverage==7.13.5
     # via pytest-cov
 croniter==6.2.2
     # via -r requirements-dev.in
-cryptography==46.0.7
+cryptography==48.0.1
     # via
     #   -r requirements-dev.in
     #   pyjwt
@@ -156,7 +156,7 @@ pyjwt==2.13.0
     # via
     #   mcp
     #   sigstore
-pyopenssl==26.0.0
+pyopenssl==26.2.0
     # via sigstore
 pytest==9.0.3
     # via
@@ -193,8 +193,10 @@ python-dotenv==1.2.2
     # via
     #   mcp
     #   pydantic-settings
-python-multipart==0.0.27
-    # via mcp
+python-multipart==0.0.32
+    # via
+    #   -r requirements-dev.in
+    #   mcp
 pytokens==0.4.1
     # via black
 pytz==2026.2
@@ -231,7 +233,7 @@ securesystemslib==1.3.1
     # via tuf
 shellingham==1.5.4
     # via typer
-sigstore==4.2.0
+sigstore==4.3.0
     # via -r requirements-dev.in
 sigstore-models==0.0.6
     # via sigstore
@@ -243,8 +245,9 @@ sortedcontainers==2.4.0
     # via hypothesis
 sse-starlette==3.3.4
     # via mcp
-starlette==1.0.1
+starlette==1.3.1
     # via
+    #   -r requirements-dev.in
     #   mcp
     #   sse-starlette
 stevedore==5.7.0


### PR DESCRIPTION
## Summary

`pip-audit` in the required `quick-checks` gate began failing on **8 fixable CVEs** in dev/optional-extra dependencies. Because the audit runs against `requirements-dev.txt` on the merge base, it fails on **every open PR** regardless of that PR's diff — e.g. it blocked the docs-only #571.

This bumps the affected packages to their fixed versions:

| Package | Before | After | Advisory |
|---------|--------|-------|----------|
| cryptography | 46.0.7 | **48.0.1** | GHSA-537c-gmf6-5ccf |
| starlette | 1.0.1 | **1.3.1** | CVE-2026-48817 / 48818 / 54282 / 54283 |
| python-multipart | 0.0.27 | **0.0.32** | CVE-2026-53538 / 53539 / 53540 |

Transitive cascade required to accept `cryptography>=48`: **sigstore** 4.2.0 → 4.3.0 (old release capped `cryptography<48`), **pyopenssl** 26.0.0 → 26.2.0.

## Risk

Low — all are dev / optional-extra deps, not core runtime:
- `starlette` / `python-multipart` enter only via `mcp[cli]` and are used solely through `mcp`'s high-level `FastMCP` API (no direct repo imports).
- `cryptography` is used only for `Fernet` in `history_db.py` (stable API across 46→48).

## Validation

- Regenerated `requirements-dev.txt` via pinned `uv==0.11.15` (matches CI's deps-compile check).
- `pip-audit -r requirements-dev.txt --ignore-vuln PYSEC-2025-183 --ignore-vuln GHSA-qp9x-wp8f-qgjj` → **No known vulnerabilities found** (exit 0).
- deps-compile freshness idempotent (plain compile reproduces the lockfile byte-for-byte).

Unblocks #571 and the other open PRs (re-run their CI after this merges).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies including cryptography (46.0.7 → 48.0.1), starlette (1.0.1 → 1.3.1), python-multipart (0.0.27 → 0.0.32), pyopenssl (26.0.0 → 26.2.0), and sigstore (4.2.0 → 4.3.0). Added explicit version constraints for transitive web dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->