### PR TITLE
docs: credit contributors @xzlknr (#571) and @iclectic (#572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to JMo Security will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **"Choosing a Profile" decision guide** in `docs/PROFILES_AND_TOOLS.md` — a scenario-to-profile table (fast/slim/balanced/deep) with time-cost tradeoffs so new users can pick a scan profile at a glance. Thanks @xzlknr! ([#571](https://github.com/jimmy058910/jmo-security-repo/pull/571), closes [#531](https://github.com/jimmy058910/jmo-security-repo/issues/531))
+
+### Fixed
+
+- **Dev-dependency CVEs failing the `quick-checks` pip-audit gate** — bumped `cryptography` 46.0.7→48.0.1 (GHSA-537c-gmf6-5ccf), `starlette` 1.0.1→1.3.1 (CVE-2026-48817/48818/54282/54283), and `python-multipart` 0.0.27→0.0.32 (CVE-2026-53538/53539/53540), with a `sigstore` 4.2.0→4.3.0 / `pyopenssl` 26.0.0→26.2.0 cascade. These transitive deps of the optional `mcp`/`attestation` extras were failing `pip-audit` on every open PR; regenerated `requirements-dev.txt` via pinned `uv==0.11.15`. ([#580](https://github.com/jimmy058910/jmo-security-repo/pull/580))
+
+### Internal
+
+- **Hadolint Dockerfile linting in CI** — the `quick-checks` job now lints all 4 Dockerfiles (fast/slim/balanced/deep) via `hadolint/hadolint-action@v3.1.0` (`failure-threshold: warning`), with a `.hadolint.yaml` suppression config (DL3008/DL3059/DL4006/SC1091, documented) and DL3003 fixes across all Dockerfiles. Thanks @iclectic! ([#572](https://github.com/jimmy058910/jmo-security-repo/pull/572), closes [#85](https://github.com/jimmy058910/jmo-security-repo/issues/85))
+
 ## [1.0.5] - 2026-04-27
 
 ### Summary

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,9 +8,9 @@ Listed in chronological order of first contribution:
 
 ### @iclectic
 
-- **Hadolint Dockerfile Linting Integration** ([#2](https://github.com/jimmy058910/jmo-security-repo/pull/2))
-  - Added Hadolint to CI for Dockerfile best practices validation
-  - Integrated linting checks for all 3 Docker variants (full/slim/alpine)
+- **Hadolint Dockerfile Linting Integration** ([#2](https://github.com/jimmy058910/jmo-security-repo/pull/2), [#572](https://github.com/jimmy058910/jmo-security-repo/pull/572), closes [#85](https://github.com/jimmy058910/jmo-security-repo/issues/85))
+  - Added Hadolint linting to the `quick-checks` CI gate for all 4 Docker variants (fast/slim/balanced/deep)
+  - Authored `.hadolint.yaml` with documented rule suppressions and fixed DL3003 across all Dockerfiles
   - Impact: Improved container security and build quality
 
 ### @ADITYABHURAN
@@ -20,6 +20,12 @@ Listed in chronological order of first contribution:
   - Python-based validation using Microsoft SARIF SDK schema
   - Optimized CI by moving validation to quick-checks job (6x efficiency gain)
   - Impact: Ensures SARIF output compliance with industry standards
+
+### @xzlknr
+
+- **"Choosing a Profile" Decision Guide** ([#571](https://github.com/jimmy058910/jmo-security-repo/pull/571), closes [#531](https://github.com/jimmy058910/jmo-security-repo/issues/531))
+  - Added a scenario-to-profile decision table to `docs/PROFILES_AND_TOOLS.md` (fast/slim/balanced/deep) with time-cost tradeoffs
+  - Impact: Helps new users pick the right scan profile quickly
 
 ## How to Contribute
 


### PR DESCRIPTION
Records the two recently merged community contributions per the process in `CONTRIBUTORS.md` ("Recognition").

## CONTRIBUTORS.md
- **@xzlknr** — new entry for the "Choosing a Profile" decision guide (#571, closes #531).
- **@iclectic** — refreshed the existing hadolint entry to reflect the current 4-variant integration (#572, closes #85). The prior entry referenced PR #2's "3 variants (full/slim/alpine)", which predates the `deep` rename.

## CHANGELOG.md (`[Unreleased]`)
- **Added**: profile decision guide (#571) — *Thanks @xzlknr!*
- **Internal**: hadolint Dockerfile linting in CI (#572) — *Thanks @iclectic!*
- **Fixed**: #580 dev-dependency CVE bumps (cryptography/starlette/python-multipart + cascade) — included because that security fix landed in the same window and the section was otherwise empty.

Docs-only; no code or workflow changes.