### PR TITLE
fix(ci): recompile requirements-dev.txt with uv 0.11.15 (deps-compile drift)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ certifi==2026.2.25
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
@@ -35,8 +35,12 @@ click==8.3.1
     #   typer
     #   uvicorn
 colorama==0.4.6
-    # via -r requirements-dev.in
-coverage[toml]==7.13.5
+    # via
+    #   -r requirements-dev.in
+    #   bandit
+    #   click
+    #   pytest
+coverage==7.13.5
     # via pytest-cov
 croniter==6.2.2
     # via -r requirements-dev.in
@@ -89,11 +93,11 @@ jsonschema==4.26.0
     #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
-librt==0.8.1
+librt==0.8.1 ; platform_python_implementation != 'PyPy'
     # via mypy
 markdown-it-py==4.0.0
     # via rich
-mcp[cli]==1.27.2
+mcp==1.27.2
     # via -r requirements-dev.in
 mdurl==0.1.2
     # via markdown-it-py
@@ -131,9 +135,9 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 pyasn1==0.6.3
     # via sigstore
-pycparser==3.0
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
-pydantic[email]==2.12.5
+pydantic==2.12.5
     # via
     #   mcp
     #   pydantic-settings
@@ -148,7 +152,7 @@ pygments==2.20.0
     # via
     #   pytest
     #   rich
-pyjwt[crypto]==2.13.0
+pyjwt==2.13.0
     # via
     #   mcp
     #   sigstore
@@ -197,6 +201,8 @@ pytokens==0.4.1
     # via black
 pytz==2026.2
     # via -r requirements-dev.in
+pywin32==312 ; sys_platform == 'win32'
+    # via mcp
 pyyaml==6.0.3
     # via
     #   -r requirements-dev.in
@@ -281,7 +287,7 @@ urllib3==2.7.0
     #   requests
     #   tuf
     #   types-requests
-uvicorn==0.42.0
+uvicorn==0.42.0 ; sys_platform != 'emscripten'
     # via mcp
 virtualenv==21.2.0
     # via pre-commit


### PR DESCRIPTION
## Summary

Recompiles `requirements-dev.txt` with the CI-pinned **uv 0.11.15** to clear a `deps-compile` freshness drift on `main`.

### Root cause
#583 (Dependabot, python-minor-patch group) regenerated `requirements-dev.txt` with a uv whose `--universal` output differs from CI's pinned `uv 0.11.15`. The committed file kept extras annotations (`coverage[toml]`, `mcp[cli]`, `pydantic[email]`, `pyjwt[crypto]`) and omitted the environment markers + win32-only `pywin32` entry that 0.11.15 emits. Dependabot PRs skip the strict `deps-compile` gate (the PR #326 event-context tradeoff), so the drift merged silently and broke the `Check deps-compile freshness` step for the next human PR — first caught on #585.

### Change
Format-only normalization, **no dependency version changes**. Regenerated with `uv pip compile --universal --python-version 3.12 -o requirements-dev.txt requirements-dev.in` (uv 0.11.15).

Unblocks #585 and any subsequent human PR (including the upcoming tool-version fold-in). LF endings preserved; pip-audit clean.