### PR TITLE
chore(deps): bump grype 0.114.0, gosec 2.27.1, nuclei 3.9.0, ruff 0.15.17

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -388,7 +388,7 @@ jobs:
           # Avoids upstream install.sh GitHub-API "latest" lookups that have
           # flaked in CI (see PR #350 + release.rules.md).
           TRIVY_VERSION: "0.70.0"
-          GRYPE_VERSION: "0.112.0"
+          GRYPE_VERSION: "0.114.0"
           SYFT_VERSION: "1.42.4"
           TRUFFLEHOG_VERSION: "3.94.3"
           HADOLINT_VERSION: "2.14.0"

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -61,7 +61,7 @@ RUN ZAP_VERSION="2.16.1" && \
     mv /opt/ZAP_${ZAP_VERSION} /opt/zaproxy
 
 # Download Nuclei (DAST + API Security)
-RUN NUCLEI_VERSION="3.8.0" && \
+RUN NUCLEI_VERSION="3.9.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -84,7 +84,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Gosec (Go SAST)
-RUN GOSEC_VERSION="2.26.1" && \
+RUN GOSEC_VERSION="2.27.1" && \
     GOSEC_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_${GOSEC_ARCH}.tar.gz" \
     -o /tmp/gosec.tar.gz && \
@@ -93,7 +93,7 @@ RUN GOSEC_VERSION="2.26.1" && \
     chmod +x /usr/local/bin/gosec
 
 # Download Grype (SCA + Vuln - Anchore)
-RUN GRYPE_VERSION="0.112.0" && \
+RUN GRYPE_VERSION="0.114.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \
@@ -190,7 +190,7 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.166.0 \
     checkov==3.3.1 \
-    ruff==0.15.15 \
+    ruff==0.15.17 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -91,7 +91,7 @@ RUN ZAP_VERSION="2.16.1" && \
     mv /opt/ZAP_${ZAP_VERSION} /opt/zaproxy
 
 # Download Nuclei (DAST + API Security)
-RUN NUCLEI_VERSION="3.8.0" && \
+RUN NUCLEI_VERSION="3.9.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -114,7 +114,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Gosec (Go SAST)
-RUN GOSEC_VERSION="2.26.1" && \
+RUN GOSEC_VERSION="2.27.1" && \
     GOSEC_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_${GOSEC_ARCH}.tar.gz" \
     -o /tmp/gosec.tar.gz && \
@@ -123,7 +123,7 @@ RUN GOSEC_VERSION="2.26.1" && \
     chmod +x /usr/local/bin/gosec
 
 # Download Grype (SCA + Vuln - Anchore)
-RUN GRYPE_VERSION="0.112.0" && \
+RUN GRYPE_VERSION="0.114.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \
@@ -258,7 +258,7 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages checkov==3.3.1
     checkov --version && \
     echo "✓ checkov installed"
 
-RUN python3 -m pip install --no-cache-dir --break-system-packages ruff==0.15.15 && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages ruff==0.15.17 && \
     echo "✓ ruff installed"
 
 RUN python3 -m pip install --no-cache-dir --break-system-packages yara-python==4.5.4 && \

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -53,7 +53,7 @@ RUN HADOLINT_VERSION="2.14.0" && \
     chmod +x /usr/local/bin/hadolint
 
 # Download Nuclei (minimal templates for fast scans)
-RUN NUCLEI_VERSION="3.8.0" && \
+RUN NUCLEI_VERSION="3.9.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.166.0 \
     checkov==3.3.1 \
-    ruff==0.15.15 \
+    ruff==0.15.17 \
     && find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -53,7 +53,7 @@ RUN HADOLINT_VERSION="2.14.0" && \
     chmod +x /usr/local/bin/hadolint
 
 # Download Nuclei (DAST + API)
-RUN NUCLEI_VERSION="3.8.0" && \
+RUN NUCLEI_VERSION="3.9.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -72,7 +72,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Grype (SCA + Vuln)
-RUN GRYPE_VERSION="0.112.0" && \
+RUN GRYPE_VERSION="0.114.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \
@@ -158,7 +158,7 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.166.0 \
     checkov==3.3.1 \
-    ruff==0.15.15 \
+    ruff==0.15.17 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \

--- a/versions.yaml
+++ b/versions.yaml
@@ -19,7 +19,7 @@ python_tools:
     update_check: pip index versions checkov
     critical: true
   ruff:
-    version: 0.15.15
+    version: 0.15.17
     pypi_package: ruff
     description: Python linter and formatter
     update_check: pip index versions ruff
@@ -141,7 +141,7 @@ binary_tools:
     update_check: gh api repos/mvdan/sh/releases/latest
     critical: false
   nuclei:
-    version: 3.8.0
+    version: 3.9.0
     github_repo: projectdiscovery/nuclei
     description: Fast vulnerability scanner with 4000+ templates (DAST/API security)
     release_pattern: nuclei_{version}_linux_{arch}.zip
@@ -164,7 +164,7 @@ binary_tools:
     critical: true
     notes: v1.0.0 - K8s hardening and compliance
   gosec:
-    version: 2.26.1
+    version: 2.27.1
     github_repo: securego/gosec
     description: Go security analyzer
     release_pattern: gosec_{version}_linux_{arch}.tar.gz
@@ -175,7 +175,7 @@ binary_tools:
     critical: false
     notes: v1.0.0 - Go-specific SAST
   grype:
-    version: 0.112.0
+    version: 0.114.0
     github_repo: anchore/grype
     description: Vulnerability scanner for containers/filesystems
     release_pattern: grype_{version}_linux_{arch}.tar.gz
@@ -372,6 +372,58 @@ update_policies:
   automated_check_schedule: Weekly (Sunday 00:00 UTC)
   manual_review_schedule: First Monday of each month
 version_history:
+- date: '2026-06-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-06-16'
+  action: Updated grype
+  tools_updated:
+  - tool: grype
+    old_version: 0.112.0
+    new_version: 0.114.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-06-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-06-16'
+  action: Updated gosec
+  tools_updated:
+  - tool: gosec
+    old_version: 2.26.1
+    new_version: 2.27.1
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-06-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-06-16'
+  action: Updated nuclei
+  tools_updated:
+  - tool: nuclei
+    old_version: 3.8.0
+    new_version: 3.9.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-06-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-06-16'
+  action: Updated ruff
+  tools_updated:
+  - tool: ruff
+    old_version: 0.15.15
+    new_version: 0.15.17
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
 - date: '2026-06-14'
   action: Automated version update
   tools_updated: []


### PR DESCRIPTION
## Summary

Weekly tool-version fold-in (from the `check-versions` cron issues). Bumps four security tools in `versions.yaml` and syncs Dockerfiles + the `scheduled.yml` `GRYPE_VERSION` env pin via `update_versions.py --tool/--sync`.

| Tool | old -> new | Issue |
|------|-----------|-------|
| grype | 0.112.0 -> 0.114.0 | #578 |
| gosec | 2.26.1 -> 2.27.1 | #577 |
| nuclei | 3.8.0 -> 3.9.0 | #576 |
| ruff | 0.15.15 -> 0.15.17 | #575 |

All same-major bumps. The ruff `versions.yaml` pin now matches the ruff pre-commit hook already bumped to 0.15.17 in #574. LF endings preserved; deps-compile clean (rebased past #586).

Closes #575, #576, #577, #578.