### PR TITLE
docs: add a worked example for scanning a single Python package

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -157,7 +157,7 @@ jmo scan --repos-dir ~/repos --allow-missing-tools
 
 Tip: You can also run `jmo tools install` to install the security scanners for your profile, and `jmo tools check` to verify your setup.
 
-### Worked example: scanning a single Python package
+## Worked example: scanning a single Python package
 
 This walkthrough scans a single local Python project end-to-end using the `fast` profile, then generates a report and opens the HTML dashboard. It assumes you already have JMo installed (see [Quick start](#quick-start-2-minutes)).
 
@@ -191,11 +191,11 @@ Not all 9 fast-profile tools produce findings for every project. JMo uses conten
 | **Semgrep** | Static analysis for Python security issues (SQL injection, insecure deserialization, etc.) |
 | **Syft** | Generates a Software Bill of Materials (SBOM) from `requirements.txt` / `pyproject.toml` |
 | **Trivy** | Checks Python dependencies for known CVEs |
-| **Checkov** | Scans any IaC files if present (Terraform, CloudFormation, Dockerfiles) |
+| **Checkov** | Scans any IaC files if present (Terraform, CloudFormation) |
 | **Hadolint** | Lints Dockerfiles — only fires if a `Dockerfile` exists in the repo |
 | **ShellCheck** | Analyses shell scripts — only fires if `.sh` files exist |
-| **Nuclei** | Skipped for local repos (targets live URLs) |
-| **OPA** | Policy engine — evaluates any `.rego` policy files |
+| **Nuclei** | Skipped for local repos (targets live URLs and APIs) |
+| **`opa`** | Policy engine — evaluates any `.rego` policy files, if present |
 
 Tools that find no applicable files write an empty stub so reporting still works. See [Content-Triggered Tool Execution](PROFILES_AND_TOOLS.md#content-triggered-tool-execution) for the full matrix.
 
@@ -211,28 +211,7 @@ The `--profile` flag writes a `timings.json` file showing how long each tool too
 
 **4. Inspect the results**
 
-After the report step, your `results/` directory looks like this:
-
-```text
-results/
-├── individual-repos/
-│   └── my-python-app/
-│       ├── trufflehog.json      # Raw secrets scan output
-│       ├── semgrep.json         # Raw SAST output
-│       ├── syft.json            # SBOM
-│       ├── trivy.json           # Dependency vulnerabilities
-│       ├── checkov.json         # IaC findings (or empty stub)
-│       ├── hadolint.json        # Dockerfile lint (or empty stub)
-│       └── shellcheck.json      # Shell analysis (or empty stub)
-└── summaries/
-    ├── findings.json            # All findings, normalised and deduplicated
-    ├── SUMMARY.md               # Human-readable severity breakdown
-    ├── dashboard.html           # Interactive HTML dashboard
-    ├── findings.sarif           # SARIF 2.1.0 for IDE/GitHub integration
-    ├── findings.yaml            # YAML output (if PyYAML installed)
-    ├── findings.csv             # Spreadsheet-friendly export
-    └── timings.json             # Per-tool timing data (from --profile)
-```
+Raw tool output lands in `results/individual-repos/<repo>/` and unified summaries in `results/summaries/`. See [Output overview](#output-overview) for the full file list and format details.
 
 **5. Open the dashboard**
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -157,6 +157,105 @@ jmo scan --repos-dir ~/repos --allow-missing-tools
 
 Tip: You can also run `jmo tools install` to install the security scanners for your profile, and `jmo tools check` to verify your setup.
 
+### Worked example: scanning a single Python package
+
+This walkthrough scans a single local Python project end-to-end using the `fast` profile, then generates a report and opens the HTML dashboard. It assumes you already have JMo installed (see [Quick start](#quick-start-2-minutes)).
+
+**1. Check that the required tools are installed**
+
+```bash
+jmo tools check --profile fast
+```
+
+If any tools are missing, install them:
+
+```bash
+jmo tools install --profile fast
+```
+
+**2. Scan the project**
+
+Point `jmo scan` at your Python package directory. The `--profile-name fast` flag selects 9 lightweight tools and sets a 300-second timeout per tool:
+
+```bash
+jmo scan --repo ~/projects/my-python-app --profile-name fast --human-logs
+```
+
+**Which tools actually run on a Python project?**
+
+Not all 9 fast-profile tools produce findings for every project. JMo uses content-triggered execution — some tools only fire when specific file types are present. For a typical Python package you can expect:
+
+| Tool | Why it runs |
+|------|-------------|
+| **TruffleHog** | Scans git history for leaked secrets (API keys, tokens) |
+| **Semgrep** | Static analysis for Python security issues (SQL injection, insecure deserialization, etc.) |
+| **Syft** | Generates a Software Bill of Materials (SBOM) from `requirements.txt` / `pyproject.toml` |
+| **Trivy** | Checks Python dependencies for known CVEs |
+| **Checkov** | Scans any IaC files if present (Terraform, CloudFormation, Dockerfiles) |
+| **Hadolint** | Lints Dockerfiles — only fires if a `Dockerfile` exists in the repo |
+| **ShellCheck** | Analyses shell scripts — only fires if `.sh` files exist |
+| **Nuclei** | Skipped for local repos (targets live URLs) |
+| **OPA** | Policy engine — evaluates any `.rego` policy files |
+
+Tools that find no applicable files write an empty stub so reporting still works. See [Content-Triggered Tool Execution](PROFILES_AND_TOOLS.md#content-triggered-tool-execution) for the full matrix.
+
+**3. Generate the report**
+
+Once the scan finishes, aggregate the raw tool outputs into unified summaries:
+
+```bash
+jmo report results/ --profile --human-logs
+```
+
+The `--profile` flag writes a `timings.json` file showing how long each tool took, which is useful for spotting bottlenecks.
+
+**4. Inspect the results**
+
+After the report step, your `results/` directory looks like this:
+
+```text
+results/
+├── individual-repos/
+│   └── my-python-app/
+│       ├── trufflehog.json      # Raw secrets scan output
+│       ├── semgrep.json         # Raw SAST output
+│       ├── syft.json            # SBOM
+│       ├── trivy.json           # Dependency vulnerabilities
+│       ├── checkov.json         # IaC findings (or empty stub)
+│       ├── hadolint.json        # Dockerfile lint (or empty stub)
+│       └── shellcheck.json      # Shell analysis (or empty stub)
+└── summaries/
+    ├── findings.json            # All findings, normalised and deduplicated
+    ├── SUMMARY.md               # Human-readable severity breakdown
+    ├── dashboard.html           # Interactive HTML dashboard
+    ├── findings.sarif           # SARIF 2.1.0 for IDE/GitHub integration
+    ├── findings.yaml            # YAML output (if PyYAML installed)
+    ├── findings.csv             # Spreadsheet-friendly export
+    └── timings.json             # Per-tool timing data (from --profile)
+```
+
+**5. Open the dashboard**
+
+```bash
+# macOS
+open results/summaries/dashboard.html
+
+# Linux
+xdg-open results/summaries/dashboard.html
+```
+
+The dashboard is a self-contained HTML file with sorting, filtering, severity badges, and expandable code context — no web server needed. See [HTML Dashboard v2](#html-dashboard-v2-enhanced-ux) for the full feature list.
+
+**Putting it all together (copy-paste version):**
+
+```bash
+# Install tools, scan, report, and open dashboard — four commands
+jmo tools install --profile fast
+jmo scan --repo ~/projects/my-python-app --profile-name fast --human-logs
+jmo report results/ --profile --human-logs
+open results/summaries/dashboard.html   # macOS (use xdg-open on Linux)
+```
+
 ## Tool Management
 
 JMo Security orchestrates 28+ security scanners. For native installations (non-Docker), use the `jmo tools` command to manage these tools.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -45,3 +45,8 @@ cat results/summaries/timings.json
 ```
 
 <!-- Removed ai-search private examples to keep public docs neutral. -->
+
+## 6) Worked example: scanning a single Python package
+
+Step-by-step walkthrough using the `fast` profile — install tools, scan, report, and open the dashboard.
+See [Worked example: scanning a single Python package](../USER_GUIDE.md#worked-example-scanning-a-single-python-package) in the User Guide.


### PR DESCRIPTION
The user guide had plenty of individual command snippets, but nothing that walked you through a full scan from beginning to end. If you were new to JMo and just wanted to scan a Python project, you had to piece it together yourself from several different sections. Not ideal.

This adds a single, clear walkthrough to the Everyday basics section of USER_GUIDE.md. It covers checking your tools are installed, running the scan, understanding which tools actually fire for a Python project, generating the report, and opening the HTML dashboard afterwards.

There is also a short table explaining content-triggered execution, so readers understand why some tools run and others do not, as well as a copy-paste four-command block at the end for quick reference.

Docs-only change. No code was modified.

## Summary

Adds a worked example to USER_GUIDE.md showing how to scan a single local Python project end-to-end using the fast profile.

## Linked issues

Closes #532 

## Changes

- [ ] Code
- [ ] Tests
- [ ✔ ] Docs
- [ ] Breaking change (CLI flag, output format, public API, schema)

## Motivation / Context

The guide would benefit from a simple, joined-up example for the most common use case: scanning one Python project. This gives new users one clear place to follow the process from the first command to the final report.

## How to test

Open docs/USER_GUIDE.md and find the "Worked example: scanning a single Python package" subsection under Everyday basics. Read through the five steps and confirm the commands, table, results layout, and dashboard instructions are present and accurate.

## Checklist

- [ ] Ran `make fmt && make lint && make test`
- [ ✔] Updated docs (README/QUICKSTART/USER_GUIDE) if behavior changed
- [ ] Considered backward compatibility for CLI flags/outputs
- [ ] Added a `CHANGELOG.md` entry if this is user-facing
