### PR TITLE
fix(deps): bump pydantic-settings to 2.14.2 (GHSA-4xgf-cpjx-pc3j) — unblocks CI audit gate

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -146,7 +146,7 @@ pydantic==2.12.5
     #   sigstore-rekor-types
 pydantic-core==2.41.5
     # via pydantic
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
     # via mcp
 pygments==2.20.0
     # via


### PR DESCRIPTION
## Why (blocking, security)

`ci.yml` → `quick-checks` → **Audit Python dependencies for vulnerabilities** (pip-audit) hard-fails on **every** PR because `pydantic-settings 2.13.1` carries **GHSA-4xgf-cpjx-pc3j** (fixed in **2.14.2**). The existing `--ignore-vuln` list (PYSEC-2025-183 pyjwt-disputed, GHSA-qp9x-wp8f-qgjj tuf-unadoptable) correctly does **not** cover this one, because a fix is available.

This is a **main-level gate break**, not a per-PR issue — confirmed red even on the npm-only PR #600. It currently blocks the entire open backlog: **#591, #596, #597, #598, #599, #600**.

## What

Single-line lockfile bump: `pydantic-settings 2.13.1 → 2.14.2`.

- `pydantic-settings` is a **transitive, dev-only** dep (`# via mcp`).
- `mcp 1.27.2` already permits `2.14.2`, so **mcp is unchanged** — this is an isolated, minimal bump with **no overlap/conflict** with the in-flight `mcp 1.28.0` bump in #597.
- Lockfile regenerated with **pinned uv 0.11.15** via `uv pip compile --upgrade-package pydantic-settings --universal --python-version 3.12`.

## Verification (local, exact CI commands)

- **Freshness gate:** a plain `uv pip compile` (pinned uv 0.11.15) reproduces this committed file **byte-for-byte** → `git diff --exit-code` clean.
- **Audit gate:** `pip-audit -r requirements-dev.txt --ignore-vuln PYSEC-2025-183 --ignore-vuln GHSA-qp9x-wp8f-qgjj` → `No known vulnerabilities found` (**exit 0**).
- `pre-commit` `pip-audit` hook also **Passed**.

## After merge

Rebase the open Dependabot PRs (`@dependabot rebase` on #597/#599/#600, and #596) to clear their now-stale red CI. This PR does not touch them directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `pydantic-settings` dependency to version 2.14.2 for development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->