### PR TITLE
ci(scheduled): pre-pull BuildKit image with retry to de-flake nightly buildx

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -324,6 +324,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Pre-pull BuildKit image (best-effort retry; mitigates Docker Hub timeouts)
+        continue-on-error: true
+        run: |
+          # setup-buildx-action bootstraps a docker-container driver by pulling
+          # moby/buildkit from Docker Hub, which intermittently times out on the
+          # anonymous token/manifest endpoints and reds the nightly. Pre-pull with
+          # retries so the bootstrap finds the image locally. continue-on-error
+          # keeps this strictly best-effort: a total failure falls back to the
+          # original setup-buildx behaviour (no worse than today).
+          for attempt in 1 2 3; do
+            docker pull moby/buildkit:buildx-stable-1 && break
+            echo "::warning::buildkit image pull attempt $attempt failed; retrying in 15s"
+            sleep 15
+          done
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -685,6 +700,21 @@ jobs:
       - name: Install external security tools
         run: |
           make tools || echo "Some tools failed to install, continuing..."
+
+      - name: Pre-pull BuildKit image (best-effort retry; mitigates Docker Hub timeouts)
+        continue-on-error: true
+        run: |
+          # setup-buildx-action bootstraps a docker-container driver by pulling
+          # moby/buildkit from Docker Hub, which intermittently times out on the
+          # anonymous token/manifest endpoints and reds the nightly. Pre-pull with
+          # retries so the bootstrap finds the image locally. continue-on-error
+          # keeps this strictly best-effort: a total failure falls back to the
+          # original setup-buildx behaviour (no worse than today).
+          for attempt in 1 2 3; do
+            docker pull moby/buildkit:buildx-stable-1 && break
+            echo "::warning::buildkit image pull attempt $attempt failed; retrying in 15s"
+            sleep 15
+          done
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Why

The nightly **Scheduled Tests** intermittently red on **Set up Docker Buildx**. `docker/setup-buildx-action` bootstraps its `docker-container` driver by pulling `moby/buildkit:buildx-stable-1` from Docker Hub, and the anonymous token/manifest endpoints time out under rate limiting:

```
#1 ERROR: ...moby/buildkit/manifests/buildx-stable-1": ...auth.docker.io/token...:
net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

Pattern confirms transient infra, not a regression: **06-19 green · 06-20 red · 06-21 mixed · 06-22 red**.

## What

Add a **best-effort pre-pull** step (3 attempts, 15s backoff, `continue-on-error: true`) before **both** `setup-buildx` steps — `nightly-docker-smoke` and `e2e-ubuntu`. The bootstrap then finds the image locally instead of racing Docker Hub.

- **Strictly an improvement:** if all 3 attempts fail, `continue-on-error` lets the job fall through to the original `setup-buildx` behaviour — never worse than today.
- No new action dependency (plain `docker pull` loop).
- Validated locally: `actionlint` + `yamllint` pass.

## Sequencing (per Jimmy)

This is the **retry-first** mitigation. If flakiness persists, the stronger fix is Docker Hub **auth** before buildx — the secrets already exist (`DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`), so that fallback is a small follow-up.