### PR TITLE
ci: fix SARIF schema validation 404 by using SchemaStore URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
 
           # Create minimal valid SARIF 2.1.0 test file
           sarif_data = {
-              '\$schema': 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/Schemata/sarif-schema-2.1.0.json',
+              '\$schema': 'https://json.schemastore.org/sarif-2.1.0.json',
               'version': '2.1.0',
               'runs': [
                   {
@@ -203,11 +203,14 @@ jobs:
           }
 
           try:
-              # Download SARIF 2.1.0 schema from Microsoft SARIF SDK repository
-              microsoft_sarif_url = 'https://raw.githubusercontent.com/microsoft/sarif-sdk/main/src/Sarif/Schemata/sarif-2.1.0-rtm.6.json'
-              print(f'Downloading SARIF 2.1.0 schema from Microsoft SDK: {microsoft_sarif_url}')
+              # Download SARIF 2.1.0 schema from SchemaStore (stable mirror of the
+              # canonical OASIS sarif-spec schema). The old microsoft/sarif-sdk raw
+              # URL was removed upstream and now 404s, which broke this gate on
+              # every PR and on push to main.
+              sarif_schema_url = 'https://json.schemastore.org/sarif-2.1.0.json'
+              print(f'Downloading SARIF 2.1.0 schema from SchemaStore: {sarif_schema_url}')
 
-              response = requests.get(microsoft_sarif_url)
+              response = requests.get(sarif_schema_url, timeout=30)
               response.raise_for_status()
 
               schema = response.json()


### PR DESCRIPTION
## Problem

`quick-checks` (the only required status check on `main`) is currently **failing on every open PR** and would fail on the next push to main. The failing step is **Validate SARIF schema** in `.github/workflows/ci.yml`.

The failure is uniform across all open PRs *and across ecosystems* (a vite/npm bump fails this Python schema check), which is the signature of an environmental dependency unrelated to any PR's diff.

## Root cause

The step downloads the SARIF 2.1.0 schema from a hardcoded `microsoft/sarif-sdk` raw URL:

```
https://raw.githubusercontent.com/microsoft/sarif-sdk/main/src/Sarif/Schemata/sarif-2.1.0-rtm.6.json
```

That file was removed upstream and now returns **404**. `response.raise_for_status()` raises `RequestException` → `sys.exit(1)`. main's last CI run (HEAD `463d242`, 2026-06-23) was green because the URL was still live then; it rotted afterward.

## Fix

Switch to the **SchemaStore**-hosted copy — the canonical OASIS `sarif-spec` 2.1.0 schema served from a stable, purpose-built mirror:

```
https://json.schemastore.org/sarif-2.1.0.json   # returns 200
```

Also repoint the test document's `$schema` metadata field (which used another now-404 `oasis-tcs/sarif-spec/main` URL) to the same stable source, and add a 30s request timeout.

## Verification

- Confirmed dead URL = 404, SchemaStore = 200.
- Ran the step's exact validation logic locally with the new URL: the minimal SARIF 2.1.0 test document validates cleanly (jsonschema 4.26.0). The SchemaStore copy carries `$id = oasis-tcs/sarif-spec/.../sarif-schema-2.1.0.json` (draft-07) — same schema, stable host.
- pre-commit passed (actionlint, yamllint, yaml-env-tilde).
- **This PR is self-unblocking:** it is PAT-authored, so `pull_request` runs the *edited* ci.yml with the corrected URL — CI on this PR is the real verification.

---

⚙️ Opened as a **draft** by the weekly maintenance routine (propose-only). Not auto-merged. Two co-occurring *non-blocking* CI warnings were noted separately for follow-up (trufflehog `*.md` regex; mypy `signer.py:166` sigstore API) and are intentionally **not** in this PR to keep it focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation to use a more reliable SARIF schema source.
  * Improved schema download handling with a timeout to reduce the chance of CI hangs or slowdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->