### PR TITLE
fix(attestation): use sigstore 4.x Issuer(base_url) for local OIDC

### DIFF
--- a/scripts/core/attestation/constants.py
+++ b/scripts/core/attestation/constants.py
@@ -31,6 +31,11 @@ REKOR_URL_PRODUCTION = "https://rekor.sigstore.dev"
 FULCIO_URL_STAGING = "https://fulcio.sigstage.dev"
 REKOR_URL_STAGING = "https://rekor.sigstage.dev"
 
+# OIDC OAuth issuer for interactive/local keyless signing.
+# sigstore-python 4.x removed the Issuer.production() classmethod, so the
+# production issuer URL must be passed to Issuer(base_url) explicitly.
+OIDC_ISSUER_URL_PRODUCTION = "https://oauth2.sigstore.dev/auth"
+
 # Default URLs (production)
 FULCIO_URL = FULCIO_URL_PRODUCTION
 REKOR_URL = REKOR_URL_PRODUCTION

--- a/scripts/core/attestation/signer.py
+++ b/scripts/core/attestation/signer.py
@@ -23,6 +23,7 @@ from .constants import (
     FULCIO_URL_STAGING,
     REKOR_URL_PRODUCTION,
     REKOR_URL_STAGING,
+    OIDC_ISSUER_URL_PRODUCTION,
     ATTESTATION_TIMEOUT,
     REKOR_TIMEOUT,
 )
@@ -163,9 +164,11 @@ class SigstoreSigner:
             # Use sigstore-python's built-in OAuth flow
             from sigstore.oidc import Issuer
 
-            issuer = Issuer.production()
+            issuer = Issuer(OIDC_ISSUER_URL_PRODUCTION)
             token = issuer.identity_token()
-            return str(token.value)
+            # sigstore 4.x: IdentityToken dropped .value; the raw token is
+            # exposed via __str__.
+            return str(token)
         except (
             Exception
         ) as e:  # Acceptable: re-raises after logging — OIDC failure is fatal for signing

--- a/tests/attestation/test_signer.py
+++ b/tests/attestation/test_signer.py
@@ -177,12 +177,17 @@ class TestOIDCTokenAcquisition:
         """Test local OIDC token acquisition via OAuth flow."""
         signer = SigstoreSigner()
 
-        # Mock sigstore-python OAuth flow
+        # Mock sigstore-python OAuth flow. sigstore 4.x changed this API in
+        # two ways: Issuer.production() was removed (signer now calls
+        # Issuer(base_url)), and IdentityToken dropped .value in favor of
+        # __str__() for the raw token. Mock the constructor (return_value) and
+        # the token's str(), so this test fails if the code regresses to
+        # Issuer.production() or token.value.
         mock_issuer = MagicMock()
         mock_token = MagicMock()
-        mock_token.value = "local_oauth_token_xyz"
+        mock_token.__str__.return_value = "local_oauth_token_xyz"
         mock_issuer.identity_token.return_value = mock_token
-        mock_issuer_class.production.return_value = mock_issuer
+        mock_issuer_class.return_value = mock_issuer
 
         token = signer._get_local_oidc_token()
 
@@ -194,8 +199,8 @@ class TestOIDCTokenAcquisition:
         """Test local OIDC token acquisition failure."""
         signer = SigstoreSigner()
 
-        # Mock OAuth flow failure
-        mock_issuer_class.production.side_effect = Exception("OAuth failed")
+        # Mock OAuth flow failure (Issuer constructor raises)
+        mock_issuer_class.side_effect = Exception("OAuth failed")
 
         with pytest.raises(Exception, match="OAuth failed"):
             signer._get_local_oidc_token()


### PR DESCRIPTION
## Problem

mypy (continue-on-error in `quick-checks`) flags:
```
scripts/core/attestation/signer.py:166: error: "type[Issuer]" has no attribute "production"  [attr-defined]
```
sigstore-python **4.x removed the `Issuer.production()` classmethod** (pinned: `sigstore==4.3.0`). `_get_local_oidc_token()` is therefore a **latent runtime break** — it raises `AttributeError` whenever local browser-based keyless signing runs. CI signing uses *ambient* OIDC (GitHub Actions / GitLab), so this path is rarely hit, which is why the suite stayed green.

## Fix

- Use the public `Issuer(base_url)` constructor (the only public constructor in 4.x — verified against the [v4.3.0 source](https://github.com/sigstore/sigstore-python/blob/v4.3.0/sigstore/oidc.py)).
- Add `OIDC_ISSUER_URL_PRODUCTION = "https://oauth2.sigstore.dev/auth"` to `constants.py`, alongside the existing Fulcio/Rekor production constants. **Behavior preserved** (production issuer, same as the old `Issuer.production()`).

## Test-quality fix (the reason this wasn't caught)

The two existing tests did `@patch("sigstore.oidc.Issuer")` then `mock_issuer_class.production.return_value = ...`. A `MagicMock` auto-fabricates `.production`, so the tests passed **regardless of whether the real API existed** — they couldn't catch the regression. Updated them to mock the **constructor** (`return_value` / `side_effect`), so they now fail if the code reverts to `Issuer.production()`.

## Verification

- pre-commit: black/ruff/**mypy**/bandit all pass.
- The two `@requires_sigstore` tests run in CI (sigstore installed there) and skip locally.
- Watching this PR's `quick-checks` mypy step to confirm the original error is gone.

Surfaced by the weekly maintenance routine (was a non-blocking, masked mypy warning).