### PR TITLE
fix(ci): make .trufflehog-exclude.txt valid regex so secret scan runs

### DIFF
--- a/.trufflehog-exclude.txt
+++ b/.trufflehog-exclude.txt
@@ -1,5 +1,13 @@
 # TruffleHog Exclusion Patterns
-# Paths to exclude from secret scanning
+# Paths to exclude from secret scanning.
+#
+# IMPORTANT: `trufflehog --exclude-paths` expects Go (RE2) REGEX patterns,
+# one per line, matched (unanchored) against each file path -- NOT shell
+# globs. A leading "*" (e.g. "*.md") is an invalid regex; trufflehog then
+# fails to build the filter ("could not create exclude rules"), aborts the
+# ENTIRE scan, and -- because the CI step swallows the exit code -- silently
+# disables secret scanning. Use "\.md$" instead of "*.md", "name.*" instead
+# of "name*", and escape literal dots in directory names ("\.venv/").
 
 # Test fixtures and example data (may contain intentional test secrets)
 tests/
@@ -10,60 +18,60 @@ examples/
 # Documentation and archives
 docs/
 dev-only/
-*.md
-*.txt
+\.md$
+\.txt$
 
 # Build artifacts and dependencies
 node_modules/
-.venv/
+\.venv/
 venv/
-venv-*/
-.eggs/
+venv-.*/
+\.eggs/
 dist/
 build/
-*.egg-info/
+\.egg-info/
 __pycache__/
-*.pyc
-*.pyo
+\.pyc$
+\.pyo$
 
 # IDE and editor files
-.vscode/
-.idea/
-*.swp
-*.swo
-*~
+\.vscode/
+\.idea/
+\.swp$
+\.swo$
+~$
 
 # Git and version control
-.git/
-.gitignore
-.gitattributes
+\.git/
+\.gitignore$
+\.gitattributes$
 
 # Package lock files (may contain registry URLs that trigger false positives)
-package-lock.json
-poetry.lock
-Pipfile.lock
-requirements*.txt
+package-lock\.json$
+poetry\.lock$
+Pipfile\.lock$
+requirements.*\.txt$
 
 # Docker and CI/CD configs (may contain example credentials)
-Dockerfile*
-docker-compose*.yml
-.github/
-.gitlab-ci.yml
+Dockerfile.*
+docker-compose.*\.yml$
+\.github/
+\.gitlab-ci\.yml$
 
 # Coverage and test reports
 htmlcov/
-.coverage
+\.coverage$
 coverage/
-.pytest_cache/
+\.pytest_cache/
 
 # Results and logs
 results/
-.jmo/
-*.log
+\.jmo/
+\.log$
 
 # Binary and compiled files
-*.so
-*.dylib
-*.dll
-*.exe
-*.bin
+\.so$
+\.dylib$
+\.dll$
+\.exe$
+\.bin$


### PR DESCRIPTION
## Problem (silent security gap)

`trufflehog --exclude-paths` expects **Go (RE2) regex** patterns, but `.trufflehog-exclude.txt` was written as **shell globs**. Leading-`*` patterns (`*.md`, `*.txt`, `*.pyc`, `*.so`, `*~`, …) are invalid regex, so trufflehog fails on the first one and **aborts the entire scan**:

```
error running scan: failed to scan filesystem: unable to create filter:
could not create exclude rules: can not compile regular expression: *.md
```

Both `ci.yml:136` and `scheduled.yml:197` run trufflehog with `|| true` and only gate on a verified-secret *count*, so the crash is **silent** — the secret-scanning gate on this public security repo has effectively been a **no-op**.

## Fix

Convert every pattern to valid RE2 regex: `*.md` → `\.md$`, `name*` → `name.*`, escape literal dots in dir names (`\.venv/`). Added a header note so it doesn't regress to globs.

## Verification (real trufflehog 3.94.3, the pinned version)

```
# OLD file:
error running scan ... could not create exclude rules: can not compile regular expression: *.md
# NEW file:
finished scanning {"chunks": 1, "verified_secrets": 0, ...}   # .md excluded, .py scanned
```
Also validated all 47 patterns compile via Python `re`. (CI can't catch a wrong fix here because of `|| true` — hence the local binary test.)

## Recommended follow-up (not in this PR, to keep it focused)

The `|| true` + verified-count design masks trufflehog *runtime* errors. Consider failing the step when trufflehog itself errors (e.g. detect a non-empty error log) so a future broken filter is visible instead of silently disabling scanning.

Surfaced by the weekly maintenance routine.