### PR TITLE
chore(deps): bump grype 0.115.0 + osv-scanner 2.4.0 (closes #605, #606)

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -403,7 +403,7 @@ jobs:
           # Avoids upstream install.sh GitHub-API "latest" lookups that have
           # flaked in CI (see PR #350 + release.rules.md).
           TRIVY_VERSION: "0.70.0"
-          GRYPE_VERSION: "0.114.0"
+          GRYPE_VERSION: "0.115.0"
           SYFT_VERSION: "1.42.4"
           TRUFFLEHOG_VERSION: "3.94.3"
           HADOLINT_VERSION: "2.14.0"

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -93,7 +93,7 @@ RUN GOSEC_VERSION="2.27.1" && \
     chmod +x /usr/local/bin/gosec
 
 # Download Grype (SCA + Vuln - Anchore)
-RUN GRYPE_VERSION="0.114.0" && \
+RUN GRYPE_VERSION="0.115.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -123,7 +123,7 @@ RUN GOSEC_VERSION="2.27.1" && \
     chmod +x /usr/local/bin/gosec
 
 # Download Grype (SCA + Vuln - Anchore)
-RUN GRYPE_VERSION="0.114.0" && \
+RUN GRYPE_VERSION="0.115.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -72,7 +72,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Grype (SCA + Vuln)
-RUN GRYPE_VERSION="0.114.0" && \
+RUN GRYPE_VERSION="0.115.0" && \
     GRYPE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_${GRYPE_ARCH}.tar.gz" \
     -o /tmp/grype.tar.gz && \

--- a/versions.yaml
+++ b/versions.yaml
@@ -175,7 +175,7 @@ binary_tools:
     critical: false
     notes: v1.0.0 - Go-specific SAST
   grype:
-    version: 0.114.0
+    version: 0.115.0
     github_repo: anchore/grype
     description: Vulnerability scanner for containers/filesystems
     release_pattern: grype_{version}_linux_{arch}.tar.gz
@@ -186,7 +186,7 @@ binary_tools:
     critical: false
     notes: v1.0.0 - Dual scanning with Trivy (Anchore DB)
   osv-scanner:
-    version: 2.3.8
+    version: 2.4.0
     github_repo: google/osv-scanner
     description: Google OSV vulnerability scanner
     release_pattern: osv-scanner_linux_{arch}
@@ -372,6 +372,32 @@ update_policies:
   automated_check_schedule: Weekly (Sunday 00:00 UTC)
   manual_review_schedule: First Monday of each month
 version_history:
+- date: '2026-06-29'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-06-29'
+  action: Updated osv-scanner
+  tools_updated:
+  - tool: osv-scanner
+    old_version: 2.3.8
+    new_version: 2.4.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-06-29'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-06-29'
+  action: Updated grype
+  tools_updated:
+  - tool: grype
+    old_version: 0.114.0
+    new_version: 0.115.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
 - date: '2026-06-28'
   action: Automated version update
   tools_updated: []


### PR DESCRIPTION
Minor tool-version bumps flagged by the weekly `check-versions` cron:

- grype `0.114.0` → `0.115.0` (#605)
- osv-scanner `2.3.8` → `2.4.0` (#606)

Applied via `update_versions.py --tool … --sync` (versions.yaml + Dockerfiles + scheduled.yml env block). Both are same-major minor bumps.

### Why a manual bump (not the auto-update cron)

The Sunday `auto-update-tools` lane (PR #603) **did not pick these up** — its binary-tool version fetch failed for *all* GitHub-release tools (`Failed to check latest version` in the `--classify` log), so only the pip tools (semgrep/checkov/ruff) were bumped there. The `check-versions` job ran separately and filed #605/#606. Net: the minor auto-update lane currently covers pip tools but **not GitHub-release binaries**.

> **Follow-up (separate):** investigate why the `auto-update-tools` binary version-check fails (GitHub API auth/rate-limit during the cron run vs a logic bug). Also, `update_versions.py --tool` crashes on Windows with `UnicodeEncodeError` printing the `→` summary arrow (cp1252 console) — the file write succeeds first, so the bump still applies, but the non-zero exit is ugly.

Closes #605
Closes #606

Surfaced + applied by the weekly maintenance routine.