### PR TITLE
chore(deps): refresh requirements-dev.txt — mcp 1.28.1, rich 15.0.0, ruff 0.15.20 (supersedes #608, #598)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -97,7 +97,7 @@ librt==0.8.1 ; platform_python_implementation != 'PyPy'
     # via mypy
 markdown-it-py==4.0.0
     # via rich
-mcp==1.28.0
+mcp==1.28.1
     # via -r requirements-dev.in
 mdurl==0.1.2
     # via markdown-it-py
@@ -218,7 +218,7 @@ rfc3161-client==1.0.6
     # via sigstore
 rfc8785==0.1.4
     # via sigstore
-rich==14.3.3
+rich==15.0.0
     # via
     #   bandit
     #   sigstore
@@ -227,7 +227,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.18
+ruff==0.15.20
     # via -r requirements-dev.in
 securesystemslib==1.3.1
     # via tuf


### PR DESCRIPTION
Applies the dev-dependency bumps from Dependabot #608 (mcp 1.28.0→1.28.1, ruff 0.15.18→0.15.20) and #598 (rich 14.3.3→15.0.0) via a targeted `uv pip compile --upgrade-package mcp --upgrade-package rich --upgrade-package ruff` (uv 0.11.15, matching the deps-compile gate).

### Why not just merge #608/#598?

Those PRs were computed in **Dependabot's resolver format** and their diffs **revert the uv-format normalization from #603** (re-adding `coverage[toml]`, `mcp[cli]`, `pydantic[email]`, dropping `platform_python_implementation` markers). Merging them would re-introduce the exact deps-compile drift #603 just healed, ambushing the next human PR.

This refresh applies the **same version bumps in uv-format**, so the `deps-compile` freshness gate stays green (verified: pre-commit `deps-compile` + `pip-audit` pass locally; `uv pip compile` prefers existing pins, so the gate keeps these versions).

### Notes

- **rich 15.0.0** is a major; its only breaking change is dropping Python 3.8 — moot at `requires-python>=3.12`. CI test shards exercise rich usage.
- 3-line diff (the three version pins); everything else preserved.
- **Supersedes #608 and #598** (will close them once this is green).

Surfaced + resolved by the weekly maintenance routine (the Dependabot-vs-uv-format tension).