### PR TITLE
chore(deps): bump ruff 0.15.17→0.15.20 in versions.yaml + Dockerfiles (closes #604)

### DIFF
--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -190,7 +190,7 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.168.0 \
     checkov==3.3.2 \
-    ruff==0.15.17 \
+    ruff==0.15.20 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -258,7 +258,7 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages checkov==3.3.2
     checkov --version && \
     echo "✓ checkov installed"
 
-RUN python3 -m pip install --no-cache-dir --break-system-packages ruff==0.15.17 && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages ruff==0.15.20 && \
     echo "✓ ruff installed"
 
 RUN python3 -m pip install --no-cache-dir --break-system-packages yara-python==4.5.4 && \

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.168.0 \
     checkov==3.3.2 \
-    ruff==0.15.17 \
+    ruff==0.15.20 \
     && find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -158,7 +158,7 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
     semgrep==1.168.0 \
     checkov==3.3.2 \
-    ruff==0.15.17 \
+    ruff==0.15.20 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \
     find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \

--- a/versions.yaml
+++ b/versions.yaml
@@ -19,7 +19,7 @@ python_tools:
     update_check: pip index versions checkov
     critical: true
   ruff:
-    version: 0.15.17
+    version: 0.15.20
     pypi_package: ruff
     description: Python linter and formatter
     update_check: pip index versions ruff
@@ -372,6 +372,19 @@ update_policies:
   automated_check_schedule: Weekly (Sunday 00:00 UTC)
   manual_review_schedule: First Monday of each month
 version_history:
+- date: '2026-06-29'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-06-29'
+  action: Updated ruff
+  tools_updated:
+  - tool: ruff
+    old_version: 0.15.17
+    new_version: 0.15.20
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
 - date: '2026-06-29'
   action: Automated version update
   tools_updated: []


### PR DESCRIPTION
Bumps ruff `0.15.17` → `0.15.20` in `versions.yaml` + all 4 Dockerfiles, via `update_versions.py --tool ruff --version 0.15.20 --sync`.

This **aligns all three ruff pins** (they had drifted apart this cycle):
- pre-commit hook → 0.15.20 (#603)
- requirements-dev.txt → 0.15.20 (#618)
- versions.yaml / Dockerfiles → 0.15.20 (**this PR**)

Same-major patch bump. Surfaced by the weekly maintenance routine (tool-update issue #604; the #603 auto-update only bumped the ruff *hook*, not the versions.yaml pin).

Closes #604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Python formatting/linting tool to a newer version across available build images.
  * Refreshed the pinned tool version used for runtime setup and recorded the version change history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->