### PR TITLE
chore(release): v1.0.6 — version bump + mypy 2.3.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to JMo Security will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.6] - 2026-07-15
+
 ### Added
 
 - **"Choosing a Profile" decision guide** in `docs/PROFILES_AND_TOOLS.md` — a scenario-to-profile table (fast/slim/balanced/deep) with time-cost tradeoffs so new users can pick a scan profile at a glance. Thanks @xzlknr! ([#571](https://github.com/jimmy058910/jmo-security-repo/pull/571), closes [#531](https://github.com/jimmy058910/jmo-security-repo/issues/531))
@@ -11,10 +13,13 @@ All notable changes to JMo Security will be documented in this file.
 ### Fixed
 
 - **Dev-dependency CVEs failing the `quick-checks` pip-audit gate** — bumped `cryptography` 46.0.7→48.0.1 (GHSA-537c-gmf6-5ccf), `starlette` 1.0.1→1.3.1 (CVE-2026-48817/48818/54282/54283), and `python-multipart` 0.0.27→0.0.32 (CVE-2026-53538/53539/53540), with a `sigstore` 4.2.0→4.3.0 / `pyopenssl` 26.0.0→26.2.0 cascade. These transitive deps of the optional `mcp`/`attestation` extras were failing `pip-audit` on every open PR; regenerated `requirements-dev.txt` via pinned `uv==0.11.15`. ([#580](https://github.com/jimmy058910/jmo-security-repo/pull/580))
+- **Fresh `click` transitive CVE blocking all CI** — bumped `click` 8.3.1→8.4.2 (**PYSEC-2026-2132**, fixed in 8.3.3) via a documented `click>=8.3.3` floor in `requirements-dev.in`. Because `pip-audit` scans the entire lockfile (not the PR delta), this advisory was failing `quick-checks` on every open PR and would have reddened `main` on its next push. ([#640](https://github.com/jimmy058910/jmo-security-repo/pull/640))
 
 ### Internal
 
 - **Hadolint Dockerfile linting in CI** — the `quick-checks` job now lints all 4 Dockerfiles (fast/slim/balanced/deep) via `hadolint/hadolint-action@v3.1.0` (`failure-threshold: warning`), with a `.hadolint.yaml` suppression config (DL3008/DL3059/DL4006/SC1091, documented) and DL3003 fixes across all Dockerfiles. Thanks @iclectic! ([#572](https://github.com/jimmy058910/jmo-security-repo/pull/572), closes [#85](https://github.com/jimmy058910/jmo-security-repo/issues/85))
+- **`mypy` upgraded 1.20.2 → 2.3.0** — sandbox-validated as a clean no-op (0 type errors on `scripts/`, 182 files; verified clean at 2.1.0, 2.2.0, and 2.3.0). Landed via a `mypy>=2.2.0` floor + `uv` recompile rather than the raw Dependabot lockfile edit, which avoids reintroducing format drift. (supersedes [#634](https://github.com/jimmy058910/jmo-security-repo/pull/634), resolves [#487](https://github.com/jimmy058910/jmo-security-repo/issues/487))
+- **Routine dependency bumps** — `resend` 6.17.1→6.17.2 ([#638](https://github.com/jimmy058910/jmo-security-repo/pull/638)), the dashboard-deps group ([#636](https://github.com/jimmy058910/jmo-security-repo/pull/636)), `types-requests` ([#635](https://github.com/jimmy058910/jmo-security-repo/pull/635)), the python-minor-patch group (`croniter`/`hypothesis`/`ruff`/`sigstore`/`types-croniter`, [#633](https://github.com/jimmy058910/jmo-security-repo/pull/633)), and `actions/labeler` 6.1.0→6.2.0 ([#632](https://github.com/jimmy058910/jmo-security-repo/pull/632)).
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jmo-security"
-version = "1.0.5"
+version = "1.0.6"
 description = "JMo Security Audit Suite (terminal-first, multi-tool, unified outputs, multi-target scanning)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -23,7 +23,7 @@ black
 pyyaml
 jsonschema
 pre-commit
-mypy
+mypy>=2.2.0  # adopt mypy 2.x — sandbox-verified 0 errors on scripts/ (supersedes #634, #487)
 types-PyYAML
 types-tabulate
 types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,8 @@ anyio==4.13.0
     #   mcp
     #   sse-starlette
     #   starlette
+ast-serialize==0.6.0
+    # via mypy
 attrs==26.1.0
     # via
     #   jsonschema
@@ -94,7 +96,7 @@ jsonschema==4.26.0
     #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
-librt==0.8.1 ; platform_python_implementation != 'PyPy'
+librt==0.13.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 markdown-it-py==4.0.0
     # via rich
@@ -102,7 +104,7 @@ mcp==1.28.1
     # via -r requirements-dev.in
 mdurl==0.1.2
     # via markdown-it-py
-mypy==1.20.2
+mypy==2.3.0
     # via -r requirements-dev.in
 mypy-extensions==1.1.0
     # via

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -37,7 +37,7 @@ from scripts.core.unicode_utils import (
 logger = logging.getLogger(__name__)
 
 # Version (from pyproject.toml)
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 
 def _merge_dict(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/dev/verify_badges.sh
+++ b/scripts/dev/verify_badges.sh
@@ -97,9 +97,9 @@ main() {
   elif [[ $current_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     is_release_commit=true
     echo -e "${YELLOW}ℹ️  Detected release tag: $current_tag${NC}"
-  elif [[ $current_branch == "dev" ]] || [[ $current_branch =~ ^(feature|refactor|hotfix|dependabot|chore|release)/ ]]; then
+  elif [[ $current_branch == "dev" ]] || [[ $current_branch =~ ^(feature|refactor|hotfix|dependabot|chore|release|release-prep)/ ]]; then
     is_release_commit=true
-    echo -e "${YELLOW}ℹ️  Detected dev/feature/refactor/hotfix/dependabot/chore/release branch: $current_branch (skipping version check)${NC}"
+    echo -e "${YELLOW}ℹ️  Detected dev/feature/refactor/hotfix/dependabot/chore/release/release-prep branch: $current_branch (skipping version check)${NC}"
   fi
 
   # Check if PyPI matches local

--- a/scripts/jmo_mcp/__init__.py
+++ b/scripts/jmo_mcp/__init__.py
@@ -18,5 +18,5 @@ Architecture:
 - Transport: stdio, HTTP, SSE
 """
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 __all__ = ["jmo_server"]


### PR DESCRIPTION
## v1.0.6 release-prep

Final assembly PR for the **v1.0.6** tag. After this merges, tagging `v1.0.6` triggers `release.yml` (PyPI + Docker).

### Version bump 1.0.5 → 1.0.6
- `pyproject.toml`, `scripts/cli/jmo.py` (`__version__`), `scripts/jmo_mcp/__init__.py` (`__version__`).

### mypy 2.x adoption (supersedes #634, resolves #487)
- Added a `mypy>=2.2.0` floor to `requirements-dev.in` and recompiled `requirements-dev.txt` with pinned `uv==0.11.15` → resolves to **mypy 2.3.0** (+ its `librt`/`ast-serialize` internal deps).
- **Sandbox-validated:** `mypy scripts/ --config-file=pyproject.toml` → **0 errors, 182 files** at 2.1.0, 2.2.0, *and* 2.3.0.
- Landed via the `.in` floor rather than Dependabot's raw lockfile edit (#634), which avoids reintroducing uv-vs-Dependabot format drift. #634 will be closed as superseded.

### CHANGELOG
- `[Unreleased]` → `[1.0.6] - 2026-07-15`, with the click CVE fix (#640), the mypy bump, and this cycle's routine dependency bumps (#632/#633/#635/#636/#638). Telemetry retirement already recorded under Removed.

### What's already on main (this cycle)
- Telemetry retirement + click CVE fix (#640), and the 5 Dependabot minor/patch merges.

### Deferred (not in this release)
- **TypeScript 7** (#637) — TS7 code is compatible, but `ts-jest` (latest) still caps `typescript <7`, breaking the dashboard build. Held until ts-jest ships TS7 support.

Resolves #487.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application and CLI version to **1.0.6**.
  - Added a profile-selection decision guide to the documentation.

- **Bug Fixes**
  - Resolved development dependency security issues and restored CI checks.
  - Improved version verification for release-preparation branches.

- **Maintenance**
  - Updated development tooling and dependency versions.
  - Added broader Dockerfile linting coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->