### PR TITLE
chore(deps): update security tools to latest minor versions (2026-07-15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -809,7 +809,7 @@ jobs:
         env:
           # Pinned to versions.yaml. Update both files together when bumping.
           TRIVY_VERSION: "0.70.0"
-          TRUFFLEHOG_VERSION: "3.94.3"
+          TRUFFLEHOG_VERSION: "3.95.9"
           HADOLINT_VERSION: "2.14.0"
         run: |
           # Same install block as scheduled.yml:tool-contract-tests — kept in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,7 +329,7 @@ jobs:
 
       - name: Install security tools (for pre-release checks)
         env:
-          TRUFFLEHOG_VERSION: "3.94.3"  # Pin per versions.yaml — see release.rules.md
+          TRUFFLEHOG_VERSION: "3.95.9"  # Pin per versions.yaml — see release.rules.md
         run: |
           # Install TruffleHog for secrets scanning
           v="$TRUFFLEHOG_VERSION"  # short alias to keep URL line under 140 chars

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install security tools
         env:
-          TRUFFLEHOG_VERSION: "3.94.3"  # Pin per versions.yaml — see release.rules.md
+          TRUFFLEHOG_VERSION: "3.95.9"  # Pin per versions.yaml — see release.rules.md
         run: |
           v="$TRUFFLEHOG_VERSION"  # short alias to keep URL line under 140 chars
           curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 \
@@ -404,8 +404,8 @@ jobs:
           # flaked in CI (see PR #350 + release.rules.md).
           TRIVY_VERSION: "0.70.0"
           GRYPE_VERSION: "0.115.0"
-          SYFT_VERSION: "1.42.4"
-          TRUFFLEHOG_VERSION: "3.94.3"
+          SYFT_VERSION: "1.46.0"
+          TRUFFLEHOG_VERSION: "3.95.9"
           HADOLINT_VERSION: "2.14.0"
         run: |
           # Install tools needed for smoke tests
@@ -580,7 +580,7 @@ jobs:
 
       - name: Install minimal security tools
         env:
-          TRUFFLEHOG_VERSION: "3.94.3"  # Pin per versions.yaml — see release.rules.md
+          TRUFFLEHOG_VERSION: "3.95.9"  # Pin per versions.yaml — see release.rules.md
         run: |
           # Install semgrep for SAST testing
           pip install semgrep
@@ -856,7 +856,7 @@ jobs:
       - name: Install security tools for integration tests
         env:
           TRIVY_VERSION: "0.70.0"  # Pin per versions.yaml
-          TRUFFLEHOG_VERSION: "3.94.3"
+          TRUFFLEHOG_VERSION: "3.95.9"
         run: |
           # Semgrep - for SQL injection detection tests
           pip install semgrep
@@ -943,7 +943,7 @@ jobs:
           # tool-contract-tests block. Any drift means the weekly and
           # PR gates disagree.
           TRIVY_VERSION: "0.70.0"
-          TRUFFLEHOG_VERSION: "3.94.3"
+          TRUFFLEHOG_VERSION: "3.95.9"
           HADOLINT_VERSION: "2.14.0"
         run: |
           # Install tools needed for contract validation

--- a/Dockerfile.balanced
+++ b/Dockerfile.balanced
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Download TruffleHog (Secrets - Verified)
-RUN TRUFFLEHOG_VERSION="3.94.3" && \
+RUN TRUFFLEHOG_VERSION="3.95.9" && \
     TRUFFLEHOG_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_${TRUFFLEHOG_ARCH}.tar.gz" \
     -o /tmp/trufflehog.tar.gz && \
@@ -30,7 +30,7 @@ RUN TRUFFLEHOG_VERSION="3.94.3" && \
     chmod +x /usr/local/bin/trufflehog
 
 # Download Syft (SBOM)
-RUN SYFT_VERSION="1.42.4" && \
+RUN SYFT_VERSION="1.46.0" && \
     SYFT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${SYFT_ARCH}.tar.gz" \
     -o /tmp/syft.tar.gz && \
@@ -53,7 +53,7 @@ RUN HADOLINT_VERSION="2.14.0" && \
     chmod +x /usr/local/bin/hadolint
 
 # Download OWASP ZAP (DAST)
-RUN ZAP_VERSION="2.16.1" && \
+RUN ZAP_VERSION="2.17.0" && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/zaproxy/zaproxy/releases/download/v${ZAP_VERSION}/ZAP_${ZAP_VERSION}_Linux.tar.gz" \
     -o /tmp/zap.tar.gz && \
     gzip -t /tmp/zap.tar.gz && \
@@ -61,7 +61,7 @@ RUN ZAP_VERSION="2.16.1" && \
     mv /opt/ZAP_${ZAP_VERSION} /opt/zaproxy
 
 # Download Nuclei (DAST + API Security)
-RUN NUCLEI_VERSION="3.9.0" && \
+RUN NUCLEI_VERSION="3.11.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -84,7 +84,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Gosec (Go SAST)
-RUN GOSEC_VERSION="2.27.1" && \
+RUN GOSEC_VERSION="2.28.0" && \
     GOSEC_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_${GOSEC_ARCH}.tar.gz" \
     -o /tmp/gosec.tar.gz && \
@@ -119,7 +119,7 @@ RUN HORUSEC_VERSION="2.8.0" && \
     chmod +x /usr/local/bin/horusec
 
 # Download OPA (Policy-as-Code engine)
-RUN OPA_VERSION="1.12.0" && \
+RUN OPA_VERSION="1.18.2" && \
     OPA_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_${OPA_ARCH}_static" \
     -o /usr/local/bin/opa && \
@@ -188,8 +188,8 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 # Note: checkov and prowler have conflicting dependencies - install separately
 # Note: Ubuntu 24.04 ships pip 24.0/setuptools 68.1/wheel 0.42 (sufficient, skip upgrade)
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
-    semgrep==1.168.0 \
-    checkov==3.3.6 \
+    semgrep==1.170.0 \
+    checkov==3.3.8 \
     ruff==0.15.20 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \

--- a/Dockerfile.deep
+++ b/Dockerfile.deep
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Download TruffleHog (Secrets - Verified)
-RUN TRUFFLEHOG_VERSION="3.94.3" && \
+RUN TRUFFLEHOG_VERSION="3.95.9" && \
     TRUFFLEHOG_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_${TRUFFLEHOG_ARCH}.tar.gz" \
     -o /tmp/trufflehog.tar.gz && \
@@ -34,7 +34,7 @@ RUN TRUFFLEHOG_VERSION="3.94.3" && \
     chmod +x /usr/local/bin/trufflehog
 
 # Download Syft (SBOM)
-RUN SYFT_VERSION="1.42.4" && \
+RUN SYFT_VERSION="1.46.0" && \
     SYFT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${SYFT_ARCH}.tar.gz" \
     -o /tmp/syft.tar.gz && \
@@ -83,7 +83,7 @@ RUN NP_VERSION="0.24.0" && \
     chmod +x /usr/local/bin/noseyparker
 
 # Download OWASP ZAP (DAST)
-RUN ZAP_VERSION="2.16.1" && \
+RUN ZAP_VERSION="2.17.0" && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/zaproxy/zaproxy/releases/download/v${ZAP_VERSION}/ZAP_${ZAP_VERSION}_Linux.tar.gz" \
     -o /tmp/zap.tar.gz && \
     gzip -t /tmp/zap.tar.gz && \
@@ -91,7 +91,7 @@ RUN ZAP_VERSION="2.16.1" && \
     mv /opt/ZAP_${ZAP_VERSION} /opt/zaproxy
 
 # Download Nuclei (DAST + API Security)
-RUN NUCLEI_VERSION="3.9.0" && \
+RUN NUCLEI_VERSION="3.11.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -114,7 +114,7 @@ RUN KUBESCAPE_VERSION="3.0.47" && \
     chmod +x /usr/local/bin/kubescape
 
 # Download Gosec (Go SAST)
-RUN GOSEC_VERSION="2.27.1" && \
+RUN GOSEC_VERSION="2.28.0" && \
     GOSEC_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_${GOSEC_ARCH}.tar.gz" \
     -o /tmp/gosec.tar.gz && \
@@ -163,7 +163,7 @@ RUN HORUSEC_VERSION="2.8.0" && \
     chmod +x /usr/local/bin/horusec
 
 # Download OPA (Policy-as-Code engine)
-RUN OPA_VERSION="1.12.0" && \
+RUN OPA_VERSION="1.18.2" && \
     OPA_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_${OPA_ARCH}_static" \
     -o /usr/local/bin/opa && \
@@ -250,11 +250,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python3 -m pip install --no-cache-dir --break-system-packages bandit==1.9.4 && \
     echo "✓ bandit installed"
 
-RUN python3 -m pip install --no-cache-dir --break-system-packages semgrep==1.168.0 && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages semgrep==1.170.0 && \
     semgrep --version && \
     echo "✓ semgrep installed"
 
-RUN python3 -m pip install --no-cache-dir --break-system-packages checkov==3.3.6 && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages checkov==3.3.8 && \
     checkov --version && \
     echo "✓ checkov installed"
 

--- a/Dockerfile.fast
+++ b/Dockerfile.fast
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Download TruffleHog
-RUN TRUFFLEHOG_VERSION="3.94.3" && \
+RUN TRUFFLEHOG_VERSION="3.95.9" && \
     TRUFFLEHOG_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_${TRUFFLEHOG_ARCH}.tar.gz" \
     -o /tmp/trufflehog.tar.gz && \
@@ -30,7 +30,7 @@ RUN TRUFFLEHOG_VERSION="3.94.3" && \
     chmod +x /usr/local/bin/trufflehog
 
 # Download Syft
-RUN SYFT_VERSION="1.42.4" && \
+RUN SYFT_VERSION="1.46.0" && \
     SYFT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${SYFT_ARCH}.tar.gz" \
     -o /tmp/syft.tar.gz && \
@@ -53,7 +53,7 @@ RUN HADOLINT_VERSION="2.14.0" && \
     chmod +x /usr/local/bin/hadolint
 
 # Download Nuclei (minimal templates for fast scans)
-RUN NUCLEI_VERSION="3.9.0" && \
+RUN NUCLEI_VERSION="3.11.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -65,7 +65,7 @@ RUN NUCLEI_VERSION="3.9.0" && \
     nuclei -update-templates -tl cves,exposures -silent
 
 # Download OPA (Policy-as-Code engine)
-RUN OPA_VERSION="1.12.0" && \
+RUN OPA_VERSION="1.18.2" && \
     OPA_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_${OPA_ARCH}_static" \
     -o /usr/local/bin/opa && \
@@ -114,8 +114,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Python tools (minimal for fast variant)
 # Note: Ubuntu 24.04 ships pip 24.0/setuptools 68.1/wheel 0.42 (sufficient, skip upgrade)
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
-    semgrep==1.168.0 \
-    checkov==3.3.6 \
+    semgrep==1.170.0 \
+    checkov==3.3.8 \
     ruff==0.15.20 \
     && find /usr/local/lib/python3* -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
     find /usr/local/lib/python3* -type f -name '*.pyc' -delete 2>/dev/null || true

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Download TruffleHog (Secrets)
-RUN TRUFFLEHOG_VERSION="3.94.3" && \
+RUN TRUFFLEHOG_VERSION="3.95.9" && \
     TRUFFLEHOG_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_${TRUFFLEHOG_ARCH}.tar.gz" \
     -o /tmp/trufflehog.tar.gz && \
@@ -30,7 +30,7 @@ RUN TRUFFLEHOG_VERSION="3.94.3" && \
     chmod +x /usr/local/bin/trufflehog
 
 # Download Syft (SBOM)
-RUN SYFT_VERSION="1.42.4" && \
+RUN SYFT_VERSION="1.46.0" && \
     SYFT_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_${SYFT_ARCH}.tar.gz" \
     -o /tmp/syft.tar.gz && \
@@ -53,7 +53,7 @@ RUN HADOLINT_VERSION="2.14.0" && \
     chmod +x /usr/local/bin/hadolint
 
 # Download Nuclei (DAST + API)
-RUN NUCLEI_VERSION="3.9.0" && \
+RUN NUCLEI_VERSION="3.11.0" && \
     TARGETARCH=$(dpkg --print-architecture) && \
     NUCLEI_ARCH=$(case ${TARGETARCH} in amd64) echo "amd64";; arm64) echo "arm64";; *) echo "amd64";; esac) && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${NUCLEI_ARCH}.zip" \
@@ -98,7 +98,7 @@ RUN HORUSEC_VERSION="2.8.0" && \
     chmod +x /usr/local/bin/horusec
 
 # Download OPA (Policy-as-Code engine)
-RUN OPA_VERSION="1.12.0" && \
+RUN OPA_VERSION="1.18.2" && \
     OPA_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
     curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 600 "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_${OPA_ARCH}_static" \
     -o /usr/local/bin/opa && \
@@ -156,8 +156,8 @@ RUN rm -rf /usr/lib/jvm/java-17-openjdk-*/man \
 # Note: checkov and prowler have conflicting dependencies - install separately
 # Note: Ubuntu 24.04 ships pip 24.0/setuptools 68.1/wheel 0.42 (sufficient, skip upgrade)
 RUN python3 -m pip install --no-cache-dir --break-system-packages \
-    semgrep==1.168.0 \
-    checkov==3.3.6 \
+    semgrep==1.170.0 \
+    checkov==3.3.8 \
     ruff==0.15.20 \
     yara-python==4.5.4 && \
     python3 -m pip install --no-cache-dir --break-system-packages prowler==5.18.2 && \

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,13 +7,13 @@ python_tools:
     update_check: pip index versions bandit
     critical: false
   semgrep:
-    version: 1.168.0
+    version: 1.170.0
     pypi_package: semgrep
     description: Multi-language SAST scanner
     update_check: pip index versions semgrep
     critical: true
   checkov:
-    version: 3.3.6
+    version: 3.3.8
     pypi_package: checkov
     description: IaC security scanner
     update_check: pip index versions checkov
@@ -57,7 +57,7 @@ python_tools:
       '
     installation: git clone (pinned version) or apt-get install lynis
   prowler:
-    version: 5.32.0
+    version: 5.34.0
     pypi_package: prowler
     description: Multi-cloud CSPM (AWS/Azure/GCP/K8s)
     update_check: pip index versions prowler
@@ -66,7 +66,7 @@ python_tools:
       since v4.x)
 binary_tools:
   trufflehog:
-    version: 3.94.3
+    version: 3.95.9
     github_repo: trufflesecurity/trufflehog
     description: Verified secrets scanner (primary)
     release_pattern: trufflehog_{version}_linux_{arch}.tar.gz
@@ -87,7 +87,7 @@ binary_tools:
     update_check: gh api repos/praetorian-inc/noseyparker/releases/latest
     critical: false
   syft:
-    version: 1.42.4
+    version: 1.46.0
     github_repo: anchore/syft
     description: SBOM generator
     release_pattern: syft_{version}_linux_{arch}.tar.gz
@@ -141,7 +141,7 @@ binary_tools:
     update_check: gh api repos/mvdan/sh/releases/latest
     critical: false
   nuclei:
-    version: 3.9.0
+    version: 3.11.0
     github_repo: projectdiscovery/nuclei
     description: Fast vulnerability scanner with 4000+ templates (DAST/API security)
     release_pattern: nuclei_{version}_linux_{arch}.zip
@@ -164,7 +164,7 @@ binary_tools:
     critical: true
     notes: v1.0.0 - K8s hardening and compliance
   gosec:
-    version: 2.27.1
+    version: 2.28.0
     github_repo: securego/gosec
     description: Go security analyzer
     release_pattern: gosec_{version}_linux_{arch}.tar.gz
@@ -198,7 +198,7 @@ binary_tools:
     notes: v1.0.0 - Uses Google OSV database for comprehensive vulnerability data
 special_tools:
   zap:
-    version: 2.16.1
+    version: 2.17.0
     github_repo: zaproxy/zaproxy
     description: OWASP ZAP - Dynamic Application Security Testing
     release_pattern: ZAP_{version}_Linux.tar.gz
@@ -219,7 +219,7 @@ special_tools:
 
       '
   mobsf:
-    version: 4.4.2
+    version: 4.5.1
     github_repo: MobSF/Mobile-Security-Framework-MobSF
     description: Mobile Security Framework (Android/iOS SAST/DAST)
     release_pattern: v{version}.tar.gz
@@ -284,7 +284,7 @@ special_tools:
     critical: false
     notes: v1.0.0 - Alternative SAST for broad language coverage
   opa:
-    version: 1.12.0
+    version: 1.18.2
     github_repo: open-policy-agent/opa
     description: Open Policy Agent (policy-as-code engine)
     release_pattern: opa_linux_{arch}_static
@@ -372,6 +372,136 @@ update_policies:
   automated_check_schedule: Weekly (Sunday 00:00 UTC)
   manual_review_schedule: First Monday of each month
 version_history:
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated opa
+  tools_updated:
+  - tool: opa
+    old_version: 1.12.0
+    new_version: 1.18.2
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated mobsf
+  tools_updated:
+  - tool: mobsf
+    old_version: 4.4.2
+    new_version: 4.5.1
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated zap
+  tools_updated:
+  - tool: zap
+    old_version: 2.16.1
+    new_version: 2.17.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated gosec
+  tools_updated:
+  - tool: gosec
+    old_version: 2.27.1
+    new_version: 2.28.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated nuclei
+  tools_updated:
+  - tool: nuclei
+    old_version: 3.9.0
+    new_version: 3.11.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated syft
+  tools_updated:
+  - tool: syft
+    old_version: 1.42.4
+    new_version: 1.46.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated trufflehog
+  tools_updated:
+  - tool: trufflehog
+    old_version: 3.94.3
+    new_version: 3.95.9
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated prowler
+  tools_updated:
+  - tool: prowler
+    old_version: 5.32.0
+    new_version: 5.34.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated checkov
+  tools_updated:
+  - tool: checkov
+    old_version: 3.3.6
+    new_version: 3.3.8
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
+- date: '2026-07-16'
+  action: Automated version update
+  tools_updated: []
+  updated_by: update_versions.py
+  notes: ''
+- date: '2026-07-16'
+  action: Updated semgrep
+  tools_updated:
+  - tool: semgrep
+    old_version: 1.168.0
+    new_version: 1.170.0
+  updated_by: update_versions.py
+  notes: Manual update via --tool flag
 - date: '2026-07-05'
   action: Automated version update
   tools_updated: []


### PR DESCRIPTION
Fresh minor-level tool update against current main, for the v1.0.6 release. Supersedes stale bot-PR #629 (which predated the click fix + all this cycle's merges and would conflict).

## Bumped (10 tools — versions.yaml + 4 Dockerfiles + ci/release/scheduled workflow pins)
`semgrep` 1.168.0→1.170.0 · `checkov` 3.3.6→3.3.8 · `prowler` 5.32.0→5.34.0 · `trufflehog` 3.94.3→3.95.9 · `syft` 1.42.4→1.46.0 · `nuclei` 3.9.0→3.11.0 · `gosec` 2.27.1→2.28.0 · `zap` 2.16.1→2.17.0 · `mobsf` 4.4.2→4.5.1 · `opa` 1.12.0→1.18.2

## Skipped (need migration review / conservative)
Majors: `kubescape` 3→4, `afl++` 4→5, `akto` (rename), `falco` placeholder. 0.x tools classified major under 0.x semver: `ruff` 0.15.21 (already on main via #633), `trivy` 0.72.0 (next cycle).

## Release safety
`update_versions.py --validate` → **all 10 bumped tools' download URLs verified reachable**. The 2 validation failures (`cdxgen` npm-vs-PyPI checker quirk, `falco` 0.0.0 placeholder) are pre-existing on main, unchanged here. Generated via the repo's `update_versions.py` (never hand-edited Dockerfiles).

Closes #629.