### PR TITLE
chore: gitignore hygiene — drop retired nightshift entry, ignore .impeccable/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ skill_seekers/
 graphify-out/
 .graphifyignore
 
+# Impeccable design-skill local working artifacts (maintainer's personal tooling)
+.impeccable/
+
 # Paperclip local artifacts
 paperclip/
 
@@ -179,9 +182,6 @@ e2e-screenshots/
 
 # Serena MCP auto-generated project config
 .serena/
-
-# Nightshift automation config (symlink to dev-only/infrastructure/nightshift.yaml)
-nightshift.yaml
 
 # Conductor orchestration files (local development artifacts)
 /conductor/


### PR DESCRIPTION
## Summary

`.gitignore` hygiene — no code or tooling behavior changes.

- **Drop the dead `nightshift.yaml` rule.** The Nightshift automation (Paperclip-era) was retired and its dev-only symlink target archived, so the ignore entry no longer points at anything real.
- **Ignore `.impeccable/`** (impeccable design-skill local cache, e.g. `hook.cache.json`) so maintainer tooling state can't accidentally land in this public repo — matching the `graphify-out/` treatment added in #645.

## Commits

- `chore: gitignore hygiene — drop retired nightshift entry, ignore .impeccable/`

Net diff: `.gitignore` only, +3 / -3.

## Test plan

- [ ] CI sharded tests pass (no code touched — expect green)
- [ ] yamllint / actionlint clean
- [ ] No coverage regression (no source changed)
