### PR TITLE
chore(deps): recompile requirements-dev.txt to clear deps-compile drift

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ certifi==2026.2.25
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
@@ -38,8 +38,12 @@ click==8.4.2
     #   typer
     #   uvicorn
 colorama==0.4.6
-    # via -r requirements-dev.in
-coverage[toml]==7.13.5
+    # via
+    #   -r requirements-dev.in
+    #   bandit
+    #   click
+    #   pytest
+coverage==7.13.5
     # via pytest-cov
 croniter==6.2.4
     # via -r requirements-dev.in
@@ -92,11 +96,11 @@ jsonschema==4.26.0
     #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
-librt==0.13.0
+librt==0.13.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 markdown-it-py==4.0.0
     # via rich
-mcp[cli]==1.28.1
+mcp==1.28.1
     # via -r requirements-dev.in
 mdurl==0.1.2
     # via markdown-it-py
@@ -134,9 +138,9 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 pyasn1==0.6.4
     # via sigstore
-pycparser==3.0
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
-pydantic[email]==2.12.5
+pydantic==2.12.5
     # via
     #   mcp
     #   pydantic-settings
@@ -151,7 +155,7 @@ pygments==2.20.0
     # via
     #   pytest
     #   rich
-pyjwt[crypto]==2.13.0
+pyjwt==2.13.0
     # via
     #   mcp
     #   sigstore
@@ -200,6 +204,8 @@ pytokens==0.4.1
     # via black
 pytz==2026.2
     # via -r requirements-dev.in
+pywin32==312 ; sys_platform == 'win32'
+    # via mcp
 pyyaml==6.0.3
     # via
     #   -r requirements-dev.in
@@ -284,7 +290,7 @@ urllib3==2.7.0
     #   requests
     #   tuf
     #   types-requests
-uvicorn==0.42.0
+uvicorn==0.42.0 ; sys_platform != 'emscripten'
     # via mcp
 virtualenv==21.2.0
     # via pre-commit


### PR DESCRIPTION
`quick-checks` was failing on **every human PR** with:

```
requirements-dev.txt is out of date. Run: make deps-compile
```

Dependabot pip PRs bypass the `deps-compile` gate, so drift accumulated on `main` and ambushed the next human PR (#676, which only touches dashboard JSON).

Regenerated with the pinned `uv==0.11.15` (consistent across all 5 pin sites):
```
uv pip compile --universal --python-version 3.12 -o requirements-dev.txt requirements-dev.in
```

**Zero version changes.** The diff is purely uv canonicalization:
- extras resolved out of compiled output (`coverage[toml]`→`coverage`, `mcp[cli]`→`mcp`, `pydantic[email]`→`pydantic`, `pyjwt[crypto]`→`pyjwt`)
- environment markers made explicit (`sys_platform`, `platform_python_implementation`)
- one new transitive: `pywin32==312 ; sys_platform == 'win32'` (via mcp)

Merge this first — it unblocks #676 and any other open human PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency specifications for improved platform and Python implementation compatibility.
  * Added Windows-specific support for development environments.
  * Simplified several dependency extras and refined package installation markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->