### PR TITLE
chore(ci): correct stale actions/labeler version comments + clear deps-compile drift

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-# Configuration for actions/labeler@v6
+# Configuration for actions/labeler@v7
 # https://github.com/actions/labeler
 #
 # Auto-applies labels to PRs based on file paths changed. The label set

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Apply labels
-        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13  # v6.0.0
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13  # v7.0.0
         with:
           configuration-path: .github/labeler.yml
           # Don't remove labels that no longer match — maintainers may have

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ certifi==2026.2.25
     #   httpcore
     #   httpx
     #   requests
-cffi==2.0.0
+cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
 cfgv==3.5.0
     # via pre-commit
@@ -38,8 +38,12 @@ click==8.4.2
     #   typer
     #   uvicorn
 colorama==0.4.6
-    # via -r requirements-dev.in
-coverage[toml]==7.13.5
+    # via
+    #   -r requirements-dev.in
+    #   bandit
+    #   click
+    #   pytest
+coverage==7.13.5
     # via pytest-cov
 croniter==6.2.4
     # via -r requirements-dev.in
@@ -92,11 +96,11 @@ jsonschema==4.26.0
     #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
-librt==0.13.0
+librt==0.13.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 markdown-it-py==4.0.0
     # via rich
-mcp[cli]==1.28.1
+mcp==1.28.1
     # via -r requirements-dev.in
 mdurl==0.1.2
     # via markdown-it-py
@@ -134,9 +138,9 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 pyasn1==0.6.4
     # via sigstore
-pycparser==3.0
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
-pydantic[email]==2.12.5
+pydantic==2.12.5
     # via
     #   mcp
     #   pydantic-settings
@@ -151,7 +155,7 @@ pygments==2.20.0
     # via
     #   pytest
     #   rich
-pyjwt[crypto]==2.13.0
+pyjwt==2.13.0
     # via
     #   mcp
     #   sigstore
@@ -200,6 +204,8 @@ pytokens==0.4.1
     # via black
 pytz==2026.3.post1
     # via -r requirements-dev.in
+pywin32==312 ; sys_platform == 'win32'
+    # via mcp
 pyyaml==6.0.3
     # via
     #   -r requirements-dev.in
@@ -284,7 +290,7 @@ urllib3==2.7.0
     #   requests
     #   tuf
     #   types-requests
-uvicorn==0.42.0
+uvicorn==0.42.0 ; sys_platform != 'emscripten'
     # via mcp
 virtualenv==21.2.0
     # via pre-commit


### PR DESCRIPTION
Two changes: the intended comment fix, plus a lockfile recompile that turned out to be required to unblock it.

## 1. Stale `actions/labeler` version comments (the point of this PR)

The SHA-pinned step carried a trailing `# v6.0.0` comment that was **already wrong before #670** (it labelled a v6.2.0 SHA) and became off by a *major* once #670 bumped the pin to v7.0.0. The config header had the same drift.

Verified against the tags API:

| SHA | Actual tag |
|---|---|
| `bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13` (current) | **v7.0.0** |
| `b8dd2d9be0f68b860e7dae5dae7d772984eacd6d` (previous) | v6.2.0 |

**Comments only — the pinned SHA is byte-identical on both sides of the diff.** Zero functional change; purely so the pin doesn't mislead the next reader.

## 2. deps-compile drift (why this PR needed a second commit)

`quick-checks` failed on a two-comment-line change. The tell: the **same commit passed on the `push` event and failed on the `pull_request` event**.

That's the deps-compile freshness gate, which is deliberately scoped to `pull_request` events from non-Dependabot authors. Dependabot pip PRs are exempt — so merging #680 rewrote `requirements-dev.txt` in pip's format and **silently reintroduced the drift #677 cleared this morning**. The next human PR eats it; today that was #676 in the morning and this PR tonight.

Recompiled with pinned `uv==0.11.15`. Verified **pure canonicalization**:

- **version changes: NONE** — all 97 pins identical
- only delta: **`pywin32` restored**, which `--universal` correctly includes and Dependabot's Linux-only resolve had dropped
- remaining diff is marker/extras/comment formatting (`; platform_python_implementation != 'PyPy'`, `coverage[toml]` → `coverage`, expanded `# via` blocks)

> **Recurrence note:** this is the second occurrence today and will repeat after every Dependabot pip merge. Durable fixes would be either a scheduled recompile-and-PR after Dependabot merges, or relaxing the gate to compare resolved versions rather than byte-exact formatting. Neither is in scope here.
