### PR TITLE
fix(security): drop the tuf ignore now that the fix is reachable (closes #539)

### DIFF
--- a/docs/internal/DEPENDENCY_MANAGEMENT.md
+++ b/docs/internal/DEPENDENCY_MANAGEMENT.md
@@ -105,14 +105,23 @@ uv export --frozen --quiet --format requirements.txt --no-emit-project --no-hash
 
 The export is universal, so the audited set includes platform-conditional entries such as `pywin32==312 ; sys_platform == 'win32'` no matter which OS runs the audit. A Linux-only audit would silently skip Windows-only dependencies.
 
-Two advisories are ignored, both documented with full reasoning in the script's header:
+### The ignore policy
+
+**An `--ignore-vuln` is only justified while there is nothing to adopt.** The moment a fix becomes reachable, the ignore stops protecting you and starts hiding a regression — so it must be removed, not kept "just in case".
+
+One advisory is currently ignored, documented with full reasoning in the script's header:
 
 | Advisory | Why it is ignored |
 |----------|-------------------|
-| `PYSEC-2025-183` | Disputed pyjwt "weak encryption" advisory. No fix version exists; the maintainer's position is that key length is the calling application's choice. Transitive dev-only via `mcp`. |
-| `GHSA-qp9x-wp8f-qgjj` | tuf delegation path matching, fixed in tuf 7.0.0. Adopted when every sigstore release capped `tuf<7`, making the fix unreachable. Tracking: [#539](https://github.com/jimmy058910/jmo-security-repo/issues/539). |
+| `PYSEC-2025-183` | Disputed pyjwt "weak encryption" advisory. **No fix version exists**, so the ignore is the only available lever. The maintainer's position is that key length is the calling application's choice. Transitive dev-only via `mcp`. Not firing at pyjwt 2.13.0, but retained in case a future resolve lands on a covered version. |
 
-Do not remove either ignore without first confirming the advisory is genuinely absent from the current lock. `tests/unit/test_dep_audit_drift.py` asserts both survive refactoring.
+**Retired — do not re-add:**
+
+| Advisory | Why it was dropped |
+|----------|--------------------|
+| `GHSA-qp9x-wp8f-qgjj` | tuf delegation path matching. Adopted when every sigstore release capped `tuf<7`, making the fix unreachable. sigstore 4.5.0 lifted that cap and the lock now resolves **tuf 7.0.0** — the fixed version — so the ignore was masking regressions rather than papering over an unfixable finding. Removed 2026-07-29, closing [#539](https://github.com/jimmy058910/jmo-security-repo/issues/539). Verified: forcing `tuf<7` back into the lock makes pip-audit report it with fix version 7.0.0 available. |
+
+`tests/unit/test_dep_audit_drift.py` enforces both directions — the unfixable ignore must survive refactors, and the retired one must not come back.
 
 ---
 

--- a/scripts/dev/audit_deps.sh
+++ b/scripts/dev/audit_deps.sh
@@ -11,22 +11,26 @@
 # any tracked requirements*.txt is a file Dependabot would try to manage, which
 # is the exact second-writer problem this migration removed.
 #
-# Ignored advisories -- verify before removing either:
+# Ignored advisories -- an ignore is only justified when there is nothing to
+# adopt. Verify that is still true before adding one, and drop it the moment a
+# fix becomes reachable (see the tuf note below for why that matters).
 #
 #   PYSEC-2025-183 (CVE-2025-45768) "pyjwt weak encryption" -- DISPUTED by the
 #     maintainer ("key length is chosen by the application that uses the
-#     library"). No fix version exists. pyjwt is a transitive dev-only dep via
-#     `mcp`, not used in production paths.
+#     library"). No fix version exists, so there is nothing to upgrade to.
+#     pyjwt is a transitive dev-only dep via `mcp`, not used in production
+#     paths. Not currently firing at pyjwt 2.13.0, but kept because the ignore
+#     remains the only available lever if a future resolve lands on a version
+#     the advisory covers.
 #     https://api.osv.dev/v1/vulns/PYSEC-2025-183
 #
-#   GHSA-qp9x-wp8f-qgjj "tuf platform-dependent delegation path matching"
-#     (CVSS 4.0 medium) -- fixed in tuf 7.0.0. Adopted when every sigstore
-#     release capped tuf<7.0.0, making the fix unreachable. As of the uv.lock
-#     migration the lock resolves tuf 7.0.0 (sigstore 4.5.0 lifted the cap), so
-#     this ignore is likely inert and #539 may be closeable. Kept for now
-#     because dropping it is a security-posture change that deserves its own
-#     review, not a rider on a dependency migration.
-#     https://github.com/advisories/GHSA-qp9x-wp8f-qgjj
+# Removed 2026-07-29 (issue #539): GHSA-qp9x-wp8f-qgjj (tuf delegation path
+# matching). It was adopted when every sigstore release capped tuf<7.0.0,
+# making the fix unreachable. sigstore 4.5.0 lifted that cap and the lock now
+# resolves tuf 7.0.0 -- the fixed version -- so the ignore had stopped
+# protecting anything and started masking regressions instead. Verified: with
+# `tuf<7` forced back into the lock, pip-audit reports the advisory with fix
+# version 7.0.0 available. Do NOT re-add it; if it fires, upgrade tuf.
 #
 # Usage: scripts/dev/audit_deps.sh
 set -euo pipefail
@@ -56,5 +60,4 @@ uv export \
   --output-file "$REQ_FILE"
 
 pip-audit -r "$REQ_FILE" --progress-spinner=off \
-  --ignore-vuln PYSEC-2025-183 \
-  --ignore-vuln GHSA-qp9x-wp8f-qgjj
+  --ignore-vuln PYSEC-2025-183

--- a/tests/unit/test_dep_audit_drift.py
+++ b/tests/unit/test_dep_audit_drift.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
 """Drift guards for the dependency-audit path and the pinned-uv convention.
 
-Two invariants that have each been broken before and are invisible until CI
-goes red for an unrelated-looking reason:
+Invariants that have each been broken before and are invisible until CI goes
+red for an unrelated-looking reason:
 
-1. The two pip-audit `--ignore-vuln` advisories must survive refactors. Both
-   were adopted because no remediation existed: PYSEC-2025-183 is a disputed
-   pyjwt advisory with no fix version, and GHSA-qp9x-wp8f-qgjj could not be
-   resolved while sigstore capped tuf<7 (tracked in #539). Dropping an ignore
-   whose advisory is still live turns every CI run red with nothing to do
-   about it.
+1. A pip-audit `--ignore-vuln` is only justified while there is nothing to
+   adopt. PYSEC-2025-183 is a disputed pyjwt advisory with no fix version, so
+   the ignore is the only available lever and must survive refactors.
 
-2. Exactly one uv version is pinned across every site (the PR #488 convention).
+2. The converse also needs guarding: an ignore whose fix has become reachable
+   must NOT come back. GHSA-qp9x-wp8f-qgjj (tuf) was dropped in #539 once
+   sigstore 4.5.0 lifted the `tuf<7` cap and the lock moved to the fixed
+   7.0.0. Re-adding it would silently mask a regression rather than paper over
+   an unfixable finding -- verified: forcing `tuf<7` back into the lock makes
+   pip-audit report it with fix version 7.0.0 available.
+
+3. Exactly one uv version is pinned across every site (the PR #488 convention).
    The uv.lock migration multiplied the number of pinned sites from ~4 to ~16;
    a single stale pin means one job resolves differently from the rest, which
    is precisely the class of bug this migration removed.
@@ -28,7 +32,14 @@ AUDIT_SCRIPT = REPO_ROOT / "scripts" / "dev" / "audit_deps.sh"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 PRE_COMMIT = REPO_ROOT / ".pre-commit-config.yaml"
 
-REQUIRED_IGNORES = ("PYSEC-2025-183", "GHSA-qp9x-wp8f-qgjj")
+# Advisories with no reachable fix -- the ignore is the only lever, keep it.
+REQUIRED_IGNORES = ("PYSEC-2025-183",)
+
+# Advisories whose fix IS reachable -- an ignore here masks a regression.
+# Maps advisory -> the fix that made it retired, for the failure message.
+RETIRED_IGNORES = {
+    "GHSA-qp9x-wp8f-qgjj": "tuf 7.0.0 (sigstore 4.5.0 lifted the tuf<7 cap) -- issue #539",
+}
 
 # The single pinned uv version. Bump here and at every site in one commit.
 PINNED_UV_VERSION = "0.11.15"
@@ -54,13 +65,33 @@ def test_audit_script_exists_and_is_bash() -> None:
     assert AUDIT_SCRIPT.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash")
 
 
-def test_audit_script_preserves_both_ignores() -> None:
+def test_audit_script_preserves_unfixable_ignores() -> None:
+    """Ignores with no reachable fix must survive refactors."""
     text = AUDIT_SCRIPT.read_text(encoding="utf-8")
     for advisory in REQUIRED_IGNORES:
         assert advisory in text, (
-            f"{advisory} is no longer ignored in audit_deps.sh. Confirm the "
-            "advisory is genuinely resolved in the current lock before "
-            "removing the ignore -- see the script's header comment and #539."
+            f"{advisory} is no longer ignored in audit_deps.sh. It has no fix "
+            "version, so the ignore is the only available lever -- removing it "
+            "turns CI red with nothing to upgrade to. See the script header."
+        )
+
+
+def test_audit_script_does_not_readd_retired_ignores() -> None:
+    """An ignore whose fix is reachable must not come back -- it masks regressions."""
+    # Only the executable invocation matters; the header comment documents the
+    # removal by name and must stay readable.
+    invocation = [
+        ln
+        for ln in AUDIT_SCRIPT.read_text(encoding="utf-8").splitlines()
+        if "--ignore-vuln" in ln and not ln.lstrip().startswith("#")
+    ]
+    joined = "\n".join(invocation)
+    for advisory, fix in RETIRED_IGNORES.items():
+        assert advisory not in joined, (
+            f"{advisory} was re-added to audit_deps.sh, but its fix is "
+            f"reachable: {fix}. Suppressing it now hides a regression instead "
+            "of papering over an unfixable finding. Upgrade the dependency "
+            "rather than restoring the ignore."
         )
 
 


### PR DESCRIPTION
Closes #539.

## Why now

`GHSA-qp9x-wp8f-qgjj` (tuf delegation path matching) was ignored because **every sigstore release capped `tuf<7.0.0`**, putting the fix out of reach. sigstore 4.5.0 lifted that cap, and since the uv.lock migration the lock resolves **tuf 7.0.0** — the fixed version.

## Why this is not just cleanup

An inert ignore would be harmless. This one is not, because **tuf can still resolve below 7** — sigstore does not force `>=7`. So the ignore was no longer papering over an unfixable finding; it was standing by to suppress a *regression*.

Verified by forcing it:

```console
$ uv add --group dev 'tuf<7'
 - tuf==7.0.0
 + tuf==6.0.0

$ pip-audit -r <export> --ignore-vuln PYSEC-2025-183
Found 1 known vulnerability in 1 package
Name Version ID                  Fix Versions
---- ------- ------------------- ------------
tuf  6.0.0   GHSA-qp9x-wp8f-qgjj 7.0.0
```

Removing the ignore turns a permanently-suppressed advisory back into a live guard. Reverted after testing; the lock is unchanged in this PR.

## What is kept, and why

`PYSEC-2025-183` stays. It is **disputed with no fix version at all**, so there is nothing to upgrade to — the ignore is the only available lever if a future resolve lands on a version the advisory covers. It is not currently firing at pyjwt 2.13.0.

That is the policy this PR writes down: *an ignore is justified only while there is nothing to adopt.* The two advisories look similar and needed opposite treatment, so I documented the rule rather than the outcome.

## Guard works in both directions now

`tests/unit/test_dep_audit_drift.py` previously asserted both ignores survive refactors. It now enforces:

- `test_audit_script_preserves_unfixable_ignores` — `PYSEC-2025-183` must stay
- `test_audit_script_does_not_readd_retired_ignores` — `GHSA-qp9x-wp8f-qgjj` must not come back

The negative guard inspects only the executable invocation, so the header comment can keep explaining the removal by name. Verified it fails (exit 1) when the ignore is re-added, then passes again after restore — a guard that cannot fail is worth nothing.

## Verification

- `bash scripts/dev/audit_deps.sh` → `No known vulnerabilities found`, exit 0
- 6/6 drift tests pass
- Full pre-commit suite green (22 hooks, exit 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated dependency security auditing to stop ignoring an advisory whose fix is now available.
  - Continued handling the disputed advisory without an available fix according to the documented policy.

- **Documentation**
  - Clarified vulnerability-ignore rules, retirement criteria, and audit expectations.

- **Tests**
  - Added safeguards to prevent retired vulnerability exceptions from being reintroduced.
  - Verified that required exceptions remain in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->