### PR TITLE
docs(claude): record the uv.lock workflow in CLAUDE.md's quick-reference tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ make test-fast                         # Fast parallel tests (recommended for de
 | `jmo history list` | View scan history |
 | `jmo validate` | Pre-release validation scorecard (quick tier) |
 | `jmo validate --tier full` | Full validation with real tools |
+| `make deps-sync` | Install/refresh the dev env from `uv.lock` |
+| `make deps-lock` | Regenerate `uv.lock` after changing deps in `pyproject.toml` |
 | `make fmt` | Format code (Black + Ruff) |
 | `make lint` | Lint checks |
 | `make test-fast` | Parallel tests, no coverage (fastest dev loop) |
@@ -257,6 +259,8 @@ Detailed guidelines for specific parts of the codebase. These load automatically
 |------|---------|
 | `jmo.yml` | Main JMo config (referenced throughout codebase) |
 | `jmo.suppress.yml` | Suppression rules |
+| `pyproject.toml` | Single declaration of all deps — runtime, extras, and `[dependency-groups] dev` (PEP 735) |
+| `uv.lock` | The only lockfile. Universal, tracked, generated (NEVER hand-edit; use `make deps-lock`) |
 | `versions.yaml` | Tool versions (NEVER edit manually; use `update_versions.py`) |
 | `.pre-commit-config.yaml` | Pre-commit hooks (Black before Ruff) |
 
@@ -283,6 +287,7 @@ See [docs/USER_GUIDE.md](docs/USER_GUIDE.md) for complete configuration referenc
 | Tool not found | `jmo tools check`, then `jmo tools install` |
 | Tool startup crash | `jmo tools clean --force && jmo tools install <tool>` |
 | Pre-commit fails | `make fmt`, `make lint` |
+| `uv.lock needs to be updated, but --check was provided` | Deps changed in `pyproject.toml` without relocking. `make deps-lock && git add uv.lock`. Local `uv sync` refreshes a stale lock silently; CI and pre-commit hard-fail — that asymmetry is deliberate |
 | CI failures | Check matrix tests, coverage, pre-commit |
 | SQLite locked | `jmo history vacuum` |
 | Docker persistence | Mount `.jmo/` volume |


### PR DESCRIPTION
Closes three gaps the uv.lock migration (#683/#687) left in `CLAUDE.md` itself. Found while auditing the migration's documentation for completeness.

| Table | Gap |
|---|---|
| Essential Commands | No deps rows at all. `make deps-sync` / `make deps-lock` are the daily commands now and were undiscoverable from the quick reference. |
| Core Files | Listed `versions.yaml` and `.pre-commit-config.yaml` but not `pyproject.toml` or `uv.lock` — which are now the single source of truth for every dependency. |
| Troubleshooting | No entry for the most common new failure: a stale lock. |

The troubleshooting row also records *why* local `uv sync` refreshes a stale lock silently while CI and pre-commit hard-fail. That asymmetry is deliberate (a local hard-fail would add a manual step protecting nothing the CI gate already covers), but it reads as a bug if you hit it without the context.

These are pointers only — the detail stays in `docs/internal/DEPENDENCY_MANAGEMENT.md`.

Verified: pre-commit clean on the file, `check_doc_links.py` passes.