### PR TITLE
fix(core): measure tool duration with perf_counter to end the Windows 0.0 flake

### DIFF
--- a/scripts/core/tool_runner.py
+++ b/scripts/core/tool_runner.py
@@ -223,7 +223,7 @@ class ToolRunner:
         Returns:
             ToolResult with execution status and metadata
         """
-        start_time = time.time()
+        start_time = time.perf_counter()
         rc = tool.retry_config
         attempt = 0
         last_error = ""
@@ -248,7 +248,7 @@ class ToolRunner:
 
                 # Check if return code is acceptable
                 if result.returncode in tool.ok_return_codes:
-                    duration = time.time() - start_time
+                    duration = time.perf_counter() - start_time
                     return ToolResult(
                         tool=tool.name,
                         status="success",
@@ -307,7 +307,7 @@ class ToolRunner:
 
             except FileNotFoundError:
                 # Tool not found - never retry
-                duration = time.time() - start_time
+                duration = time.perf_counter() - start_time
                 return ToolResult(
                     tool=tool.name,
                     status="error",
@@ -348,7 +348,7 @@ class ToolRunner:
                 break
 
         # All retries exhausted for the last failure type
-        duration = time.time() - start_time
+        duration = time.perf_counter() - start_time
         return ToolResult(
             tool=tool.name,
             status="retry_exhausted" if attempt > 1 else "error",

--- a/tests/unit/test_tool_runner.py
+++ b/tests/unit/test_tool_runner.py
@@ -19,6 +19,54 @@ from scripts.core.tool_runner import (
     run_tools,
 )
 
+TOOL_RUNNER_SOURCE = (
+    Path(__file__).resolve().parents[2] / "scripts" / "core" / "tool_runner.py"
+)
+
+
+def test_duration_is_measured_with_perf_counter() -> None:
+    """Elapsed time must come from perf_counter -- not time() and NOT monotonic.
+
+    `test_run_tool_success` asserts `duration > 0` and flaked on Windows with
+    `assert 0.0 > 0`: a fast subprocess finished inside one clock tick.
+
+    The intuitive fix -- "use the monotonic clock for elapsed time" -- makes it
+    strictly worse here. On CPython/Windows `time.monotonic()` is GetTickCount64,
+    fixed at ~15.6ms granularity, while `time.time()` follows the *global* system
+    timer, which any process can raise to ~1ms via timeBeginPeriod. Measured on a
+    dev box with 60 runs of the `echo hello` tool used by that test:
+
+        time.time()          0/60 zero, 59 distinct values
+        time.monotonic()    16/60 zero (26.7%), 5 distinct values
+        time.perf_counter()  0/60 zero, 60 distinct values
+
+    So monotonic would have converted an intermittent flake into a frequent one,
+    and time() only avoids it by luck -- whichever unrelated process happens to
+    have raised the timer resolution. `time.perf_counter()` is QueryPerformance-
+    Counter (100ns, monotonic, unaffected by wall-clock adjustment), which is
+    what the stdlib documents for measuring short durations.
+
+    Guarded at the source level because the whole measurement is one unit: the
+    `start_time` assignment and every `duration =` subtraction must use the same
+    clock. Mixing them subtracts a wall-clock epoch from a since-boot counter.
+    """
+    text = TOOL_RUNNER_SOURCE.read_text(encoding="utf-8")
+
+    for forbidden, why in (
+        ("time.monotonic()", "~15.6ms granularity on Windows -- coarser than time()"),
+        ("time.time()", "wall-clock; adjustable, and granularity varies by host"),
+    ):
+        assert forbidden not in text, (
+            f"tool_runner.py measures elapsed time with {forbidden} ({why}). "
+            "Use time.perf_counter() -- see this test's docstring for measurements."
+        )
+
+    assert text.count("time.perf_counter()") == 4, (
+        "Expected 4 perf_counter() calls (1 start_time + 3 duration subtractions). "
+        "If a return path was added or removed, update this count -- but every "
+        "elapsed-time measurement in the file must use the same clock."
+    )
+
 
 class TestToolDefinition:
     """Test ToolDefinition dataclass"""


### PR DESCRIPTION
## Summary

`tests/unit/test_tool_runner.py::test_run_tool_success` asserts `result.duration > 0` and
intermittently failed on Windows with `assert 0.0 > 0` — a fast subprocess (`echo hello`)
completed inside a single clock tick, so the elapsed measurement rounded to exactly zero.

Confirmed **flaky, not a regression**: the same test passed on #688's run and failed on #689's
against identical code.

## Why not `time.monotonic()`

The intuitive fix — "use the monotonic clock for elapsed time" — is wrong here, and measurably so.
On CPython/Windows `time.monotonic()` is `GetTickCount64`, fixed at ~15.6ms granularity, whereas
`time.time()` follows the *global* system timer, which any process on the box can raise to ~1ms via
`timeBeginPeriod`. Switching to monotonic therefore makes the tick **coarser**, not finer.

Measured over 60 runs of the same tool the test uses:

| clock | zero readings | distinct values |
|---|---|---|
| `time.time()` | 0/60 | 59 |
| `time.monotonic()` | **16/60 (26.7%)** | 5 |
| `time.perf_counter()` | 0/60 | 60 |

Monotonic would have promoted an intermittent flake into a frequent one. And `time()` only escapes
it by luck — it depends on whichever unrelated process happens to have raised the host's timer
resolution, which is exactly why a CI runner (nothing raising it, ~15.6ms) flakes where a dev box
does not.

`time.perf_counter()` is `QueryPerformanceCounter`: 100ns resolution, monotonic, and immune to
wall-clock adjustment. It is what the stdlib documents for measuring short durations, so this is a
correctness fix independent of the flake.

## Changes

- `scripts/core/tool_runner.py` — all **four** call sites move together: the `start_time` assignment
  plus the three `duration =` subtractions are one measurement. Converting only the subtractions
  would subtract a wall-clock epoch from a since-boot counter.
- `tests/unit/test_tool_runner.py` — adds a source-level drift guard carrying the measurements above,
  because the correct clock here is counter-intuitive and a future reader would plausibly "fix"
  `perf_counter` back to `monotonic`.

## Test plan

- [x] `pytest tests/unit/test_tool_runner.py` — 43 passed, 3 skipped
- [x] Drift guard verified non-vacuous: fails on **both** reversions (`→ time.monotonic()` and
      `→ time.time()`), passes on `perf_counter`
- [x] `black --check`, `ruff check`, `mypy scripts/core/tool_runner.py` — all clean
- [x] `update_versions.py --sync --dry-run` — no version drift
- [ ] CI sharded tests pass (incl. the `windows-2022` shard this targets)
