### PR TITLE
chore(deps): adopt mcp 2.0 and make its silent test-skip loud in CI

### DIFF
--- a/docs/integrations/GITHUB_COPILOT.md
+++ b/docs/integrations/GITHUB_COPILOT.md
@@ -39,7 +39,7 @@ security scan results, enabling:
 ```text
 ┌─────────────────┐      MCP Protocol      ┌──────────────────┐
 │ GitHub Copilot  │ ←─────────────────────→ │  JMo MCP Server  │
-│   (VS Code)     │      (stdio/JSON-RPC)   │  (FastMCP)       │
+│   (VS Code)     │      (stdio/JSON-RPC)   │  (MCPServer)     │
 └─────────────────┘                         └──────────────────┘
                                                       │
                                                       ↓

--- a/docs/internal/DEPENDENCY_MANAGEMENT.md
+++ b/docs/internal/DEPENDENCY_MANAGEMENT.md
@@ -86,7 +86,17 @@ git add pyproject.toml uv.lock
 
 ### Upper bounds: only to hold back a known-breaking major
 
-Constraints are floors by default. The one deliberate cap today is `mcp[cli]>=1.0.0,<2`: mcp 2.0 replaces `httpx` with `httpx2` and drops `pydantic-settings` and `httpx-sse`, which changes what roughly a hundred tests collect and breaks `tests/integration/test_cli_scan_ci.py`. The cap holds the project on the 1.x line until that upgrade is done deliberately, with the test work attached. Dependabot will keep proposing it as an ungrouped major bump.
+Constraints are floors by default. **There is no upper bound in the tree today.** The one that existed, `mcp[cli]>=1.0.0,<2`, was retired when mcp 2.0 was adopted — which is precisely what a cap is for: hold the line until the upgrade is done deliberately, then remove it.
+
+That cap is worth keeping as the worked example, because a cap is not free and its stated reasons did not survive contact evenly:
+
+| Reason the cap gave | What was actually true |
+|---|---|
+| mcp 2.0 swaps `httpx`→`httpx2`, drops `pydantic-settings` + `httpx-sse` | Correct — but no first-party code imports any of the three, so the blast radius was one renamed symbol |
+| "changes what roughly a hundred tests collect" | Correct **and the real hazard**: `mcp.server.fastmcp.FastMCP` became `mcp.server.MCPServer` with no shim, and `tests/jmo_mcp/conftest.py` turned that ImportError into a silent collection drop. Green CI over 235 missing tests |
+| "breaks `tests/integration/test_cli_scan_ci.py`" | **Wrong.** That was an unrelated `GITHUB_PATH` POSIX-path bug on Windows, fixed in `f605ac2` |
+
+Two lessons. First, write down *how you will verify the upgrade*, not just why you are deferring it — the acceptance check here was a collection count, and no status check would ever have produced it. Second, a cap is a claim about the future that decays; re-verify its reasons before renewing it. Dependabot proposed `<2`→`<3` (#686); that was closed rather than merged, because no mcp 3.0 exists and a cap against an unknown major is not a known-breaking one.
 
 This matters generally, because **an unbounded declaration means the next from-scratch `uv lock` is an upgrade, not a translation.** The migration's first resolve moved 30 of 94 packages this way. If you ever regenerate the lock from nothing, diff the resulting package set against the previous one before assuming they are equivalent:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,12 +92,18 @@ dev = [
     "croniter",
     "types-croniter",
     # MCP Server dependencies (Feature #2: AI Remediation)
-    # Capped below 2.0 to match what the pre-migration lockfile actually resolved
-    # (mcp 1.28.1). mcp 2.0 replaces httpx with httpx2 and drops pydantic-settings
-    # and httpx-sse, which changes ~100 tests' collection/skip status and breaks
-    # tests/integration/test_cli_scan_ci.py. Adopting it is a real upgrade that
-    # deserves its own PR; Dependabot will propose it as an ungrouped major bump.
-    "mcp[cli]>=1.0.0,<2",           # Official Anthropic MCP SDK with FastMCP framework
+    # The `<2` cap is GONE — mcp 2.0 was adopted deliberately, which is exactly
+    # what that cap was waiting for. Do not re-add a cap for 3.x: per the
+    # upper-bounds policy a cap exists only to hold back a *known-breaking*
+    # major, and no mcp 3.0 exists. Dependabot proposed `<3` (#686); that would
+    # re-arm the same trap on no evidence, so it was closed rather than merged.
+    #
+    # For the record, the cap's stated reasons resolved as follows: mcp 2.0 does
+    # swap httpx -> httpx2 and drop pydantic-settings + httpx-sse, but no
+    # first-party code imports any of the three. The `tests/integration/
+    # test_cli_scan_ci.py` breakage attributed to it was a misdiagnosis — that
+    # was a GITHUB_PATH POSIX-path bug on Windows, fixed in f605ac2.
+    "mcp[cli]>=1.0.0",              # Official Anthropic MCP SDK with FastMCP framework
     # Security floors for mcp's transitive web deps (pip-audit fixable CVEs, 2026-06):
     #   starlette>=1.3.1: CVE-2026-48817/48818/54282/54283
     #   python-multipart>=0.0.31: CVE-2026-53538/53539/53540

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -3345,8 +3345,11 @@ def _check_mcp_dependencies() -> tuple[bool, str | None]:
         return False, "pydantic_v1"
 
     # Check 2: Is MCP SDK installed?
+    # Probe the same symbol jmo_server.py imports. mcp 2.0 renamed FastMCP ->
+    # MCPServer with no compatibility shim, so probing the old path would report
+    # "mcp_missing" for an SDK that is in fact installed and working.
     try:
-        from mcp.server.fastmcp import FastMCP  # noqa: F401
+        from mcp.server import MCPServer  # noqa: F401
     except ImportError:
         return False, "mcp_missing"
 

--- a/scripts/jmo_mcp/__init__.py
+++ b/scripts/jmo_mcp/__init__.py
@@ -12,7 +12,7 @@ Supported AI Tools:
 - Custom MCP clients
 
 Architecture:
-- FastMCP framework (Official Anthropic SDK)
+- MCPServer framework (Official Anthropic SDK; named FastMCP before mcp 2.0)
 - Tools: get_security_findings, apply_fix, mark_resolved
 - Resources: finding://{id} for full context
 - Transport: stdio, HTTP, SSE

--- a/scripts/jmo_mcp/jmo_server.py
+++ b/scripts/jmo_mcp/jmo_server.py
@@ -6,7 +6,7 @@ Provides standardized interface for AI tools (GitHub Copilot, Claude Code, OpenA
 to query security findings and suggest fixes.
 
 Architecture:
-- Framework: FastMCP (Official Anthropic SDK)
+- Framework: MCPServer (Official Anthropic SDK; named FastMCP before mcp 2.0)
 - Tools: get_security_findings, apply_fix, mark_resolved
 - Resources: finding://{id} for full context
 - Transport: stdio, HTTP, SSE
@@ -38,8 +38,12 @@ from pathlib import Path
 
 # NOTE: This import will fail until mcp[cli] is installed
 # To install: pip install "mcp[cli]" or uv add "mcp[cli]"
+#
+# mcp 2.0 renamed the server framework: `mcp.server.fastmcp.FastMCP` became
+# `mcp.server.mcpserver.MCPServer` (re-exported from `mcp.server`). There is no
+# compatibility shim, so the old path raises ModuleNotFoundError on 2.x.
 try:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server import MCPServer
 except ImportError:
     raise ImportError(
         "MCP SDK not installed. Install with:\n"
@@ -87,7 +91,7 @@ logger.info(
 )
 
 # Initialize MCP server
-mcp = FastMCP("JMo Security")
+mcp = MCPServer("JMo Security")
 
 # Initialize utilities (lazy-loaded on first use to handle missing files gracefully)
 _findings_loader: FindingsLoader | None = None

--- a/tests/jmo_mcp/conftest.py
+++ b/tests/jmo_mcp/conftest.py
@@ -11,6 +11,7 @@ Install with: pip install "jmo-security[mcp]"
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -22,8 +23,13 @@ _MCP_SKIP_REASON = "MCP SDK unavailable"
 
 try:
     # MCP requires pydantic v2+ (which has TypeAdapter)
-    # Try importing the actual MCP module
-    from mcp.server.fastmcp import FastMCP  # noqa: F401
+    # Try importing the actual MCP module.
+    #
+    # This MUST probe the same symbol jmo_server.py imports. mcp 2.0 renamed
+    # FastMCP -> MCPServer with no shim; probing a stale path makes
+    # pytest_ignore_collect below drop this entire tree, and uncollected tests
+    # cannot fail -- CI stays green over the hole. See the CI guard below.
+    from mcp.server import MCPServer  # noqa: F401
     from pydantic import TypeAdapter  # noqa: F401
 
     _MCP_AVAILABLE = True
@@ -32,6 +38,26 @@ except ImportError as e:
         f"MCP SDK not properly installed: {e}. "
         "Install with: pip install 'jmo-security[mcp]' "
         "or ensure pydantic>=2.11.0 is installed."
+    )
+
+# The silent skip below is correct for local dev -- a contributor without the
+# optional mcp extra should not be blocked. It is NEVER correct in CI, where
+# mcp[cli] is a declared member of `[dependency-groups] dev` and so cannot be
+# legitimately absent. Left ungated, an SDK rename degrades to "235 tests stop
+# running" with every check still green, because uncollected tests cannot fail.
+#
+# That is not hypothetical: mcp 2.0 renamed FastMCP -> MCPServer with no shim,
+# and this file's availability probe is what would have swallowed it.
+#
+# Raised at import time so it surfaces as a hard collection error rather than a
+# skip. The equivalent guard cannot live in a test file under tests/jmo_mcp/ --
+# it would be dropped by the very failure it exists to detect.
+if not _MCP_AVAILABLE and os.environ.get("CI") == "true":
+    raise RuntimeError(
+        f"MCP SDK unavailable in CI: {_MCP_SKIP_REASON}\n"
+        "mcp[cli] is a declared dev dependency, so this means the environment "
+        "is broken or an SDK import path changed -- not that MCP is optional "
+        "here. Skipping tests/jmo_mcp/ would report green over a real hole."
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -577,40 +577,32 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore2" },
     { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -795,7 +787,7 @@ dev = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "hypothesis" },
     { name = "jsonschema" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=2.2.0" },
     { name = "packaging" },
     { name = "pre-commit" },
@@ -922,15 +914,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -940,15 +932,28 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1021,6 +1026,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1214,20 +1231,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -1981,6 +1984,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Retires the `mcp[cli]>=1.0.0,<2` cap from #683. That cap existed to hold the 1.x line until the upgrade could be done deliberately — this is that upgrade. **Supersedes #686.**

## The code change is small

mcp 2.0 renamed the server framework: `mcp.server.fastmcp.FastMCP` → `mcp.server.MCPServer` (implemented in `mcp.server.mcpserver`), with **no compatibility shim** — the old path raises `ModuleNotFoundError`. `MCPServer` is otherwise drop-in for our usage (positional `name`, `.tool()`, `.resource()`, `.run()`), so this is four import/instantiation sites.

Dependency churn stayed in transitives exactly as predicted: `httpx`→`httpx2`, `httpcore`→`httpcore2`, drops `httpx-sse` + `pydantic-settings`, adds `mcp-types`, `opentelemetry-api`, `truststore`. No first-party code imports any of them. Locked with `uv lock --upgrade-package mcp` so this is a targeted move, not a mass re-resolve — 109 packages resolved, only those ten changed.

## Why a green CI proves nothing here

`tests/jmo_mcp/conftest.py` probes SDK availability and, on `ImportError`, uses `pytest_ignore_collect` to drop the tree. Under this rename that probe fails — so the real failure mode of this upgrade is **not a red check**, it is 235 tests quietly ceasing to exist. Uncollected tests cannot fail.

Measured with the probe deliberately broken, collection falls **235 → 120** (115 files dropped outright, the remaining 120 skip-marked). That is the ~120-test swing observed on the migration's first resolve.

So the acceptance criterion was the collection count:

| Check | Before | After |
|---|---|---|
| `pytest tests/jmo_mcp/ --collect-only -q` | 235 | **235** |
| `pytest tests/jmo_mcp/` | — | 233 passed, 1 skipped |

The one remaining failure (`test_context_with_unicode_characters`) is a pre-existing **local** cp1252 console artifact — it fails identically on mcp 1.29.0, and does not reproduce in CI's UTF-8 environment.

## Hardening: the silent skip becomes loud in CI

The silent skip is correct for local dev, where a contributor may not have the optional extra. It is never correct in CI, where `mcp[cli]` is a declared member of `[dependency-groups] dev` and cannot be legitimately absent. `conftest.py` now raises at import time when the SDK is missing **and** `CI=true`, converting a silent hole into a hard collection error.

All three paths verified:

| Condition | Result |
|---|---|
| `CI=true`, SDK present | 235 collected, exit 0 |
| `CI=true`, import broken | exit 4, loud `RuntimeError` |
| `CI` unset, import broken | exit 0 — quiet degradation preserved for local dev |

The guard has to live in `conftest.py`: a test placed under `tests/jmo_mcp/` would be dropped by the very failure it exists to detect.

## Docs corrected

`docs/internal/DEPENDENCY_MANAGEMENT.md` described the cap as current. Its third stated reason — that mcp 2.0 "breaks `tests/integration/test_cli_scan_ci.py`" — was a **misdiagnosis**; that was a `GITHUB_PATH` POSIX-path bug on Windows, fixed in `f605ac2`. The section now carries the cap as a worked example of what a deferral note should record: *how the upgrade will be verified*, not just why it is deferred.

**No cap is re-added.** #686 proposed `<2`→`<3`; per the upper-bounds policy a cap exists only to hold back a *known-breaking* major, and no mcp 3.0 exists.

Closes #686


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated MCP server integration to use the MCP 2.x `MCPServer` framework.
  * Improved CI validation so MCP-related tests cannot silently be skipped when the SDK is unavailable.

* **Bug Fixes**
  * Updated dependency detection to recognize the current MCP server interface.

* **Documentation**
  * Refreshed architecture diagrams, framework references, and dependency guidance.
  * Documented the removal of the previous MCP version cap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->