### PR TITLE
fix(encoding): specify utf-8 on all 153 ruff-visible file I/O sites

### DIFF
--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -2220,7 +2220,7 @@ def _check_first_run() -> bool:
     try:
         import yaml
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
         return not config.get("onboarding_completed", False)
     except (FileNotFoundError, OSError) as e:
@@ -2284,7 +2284,7 @@ def _collect_email_opt_in(args) -> None:
                     "onboarding_completed": True,
                     "pending_subscription": not subscribed,
                 }
-                with open(config_path, "w") as f:
+                with open(config_path, "w", encoding="utf-8") as f:
                     yaml.dump(config, f)
 
                 if subscribed and welcomed:
@@ -2313,7 +2313,7 @@ def _collect_email_opt_in(args) -> None:
                 import yaml
 
                 config = {"onboarding_completed": True}
-                with open(config_path, "w") as f:
+                with open(config_path, "w", encoding="utf-8") as f:
                     yaml.dump(config, f)
         except ImportError:
             # email_service module not available (resend not installed)
@@ -2325,7 +2325,7 @@ def _collect_email_opt_in(args) -> None:
                 "email_opt_in": True,
                 "onboarding_completed": True,
             }
-            with open(config_path, "w") as f:
+            with open(config_path, "w", encoding="utf-8") as f:
                 yaml.dump(config, f)
             _log(
                 args,
@@ -2343,7 +2343,7 @@ def _collect_email_opt_in(args) -> None:
                 "email_opt_in": True,
                 "onboarding_completed": True,
             }
-            with open(config_path, "w") as f:
+            with open(config_path, "w", encoding="utf-8") as f:
                 yaml.dump(config, f)
             _log(args, "DEBUG", f"Email collection error (non-blocking): {e}")
     else:
@@ -2354,7 +2354,7 @@ def _collect_email_opt_in(args) -> None:
         import yaml
 
         config = {"onboarding_completed": True}
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(config, f)
 
 
@@ -2373,7 +2373,7 @@ def _show_kofi_reminder(args) -> None:
         try:
             import yaml
 
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 config = yaml.safe_load(f) or {}
         except (ImportError, OSError) as e:
             logger.debug(f"Failed to load config file: {e}")
@@ -2389,7 +2389,7 @@ def _show_kofi_reminder(args) -> None:
     try:
         import yaml
 
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             yaml.safe_dump(config, f, default_flow_style=False)
     except (ImportError, OSError, PermissionError, UnicodeEncodeError) as e:
         logger.debug(
@@ -3547,7 +3547,7 @@ def cmd_attest(args) -> int:
     # Load scan arguments if provided
     scan_args = {}
     if hasattr(args, "scan_args") and args.scan_args:
-        with open(args.scan_args) as f:
+        with open(args.scan_args, encoding="utf-8") as f:
             scan_args = json.load(f)
 
     # Get tools list
@@ -3573,7 +3573,7 @@ def cmd_attest(args) -> int:
     # Save attestation
     attestation_path = Path(output_path)
     attestation_path.parent.mkdir(parents=True, exist_ok=True)
-    attestation_path.write_text(json.dumps(statement, indent=2))
+    attestation_path.write_text(json.dumps(statement, indent=2), encoding="utf-8")
 
     _log(args, "INFO", f"Generated attestation: {output_path}")
 

--- a/scripts/cli/schedule_commands.py
+++ b/scripts/cli/schedule_commands.py
@@ -314,7 +314,7 @@ def _cmd_schedule_export(args, manager: ScheduleManager) -> int:
 
     # Output
     if args.output:
-        Path(args.output).write_text(workflow)
+        Path(args.output).write_text(workflow, encoding="utf-8")
         _success(f"Exported to {args.output}")
     else:
         print(workflow, end="")

--- a/scripts/cli/wizard.py
+++ b/scripts/cli/wizard.py
@@ -1003,7 +1003,7 @@ def run_wizard(
         if emit_make:
             command = generate_command(config)
             content = generate_makefile_target(config, command)
-            Path(emit_make).write_text(content)
+            Path(emit_make).write_text(content, encoding="utf-8")
             print(f"\n{_colorize('Generated:', 'green')} {emit_make}")
             return 0
 
@@ -1013,7 +1013,7 @@ def run_wizard(
             script_path = Path(emit_script)
             try:
                 script_path.parent.mkdir(parents=True, exist_ok=True)
-                script_path.write_text(content)
+                script_path.write_text(content, encoding="utf-8")
             except OSError as e:
                 print(f"Error: Could not write to {emit_script}: {e}")
                 return 1
@@ -1029,7 +1029,7 @@ def run_wizard(
             content = generate_github_actions(config, PROFILES)
             gha_path = Path(emit_gha)
             gha_path.parent.mkdir(parents=True, exist_ok=True)
-            gha_path.write_text(content)
+            gha_path.write_text(content, encoding="utf-8")
             print(f"\n{_colorize('Generated:', 'green')} {emit_gha}")
             return 0
 

--- a/scripts/core/attestation/tamper_detector.py
+++ b/scripts/core/attestation/tamper_detector.py
@@ -165,7 +165,9 @@ class TamperDetector:
         indicators: list[TamperIndicator] = []
 
         try:
-            attestation_data = json.loads(Path(attestation_path).read_text())
+            attestation_data = json.loads(
+                Path(attestation_path).read_text(encoding="utf-8")
+            )
         except (
             Exception
         ) as e:  # Acceptable: file scanning safety — skip unreadable attestations
@@ -324,7 +326,9 @@ class TamperDetector:
         indicators: list[TamperIndicator] = []
 
         try:
-            current_data = json.loads(Path(attestation_path).read_text())
+            current_data = json.loads(
+                Path(attestation_path).read_text(encoding="utf-8")
+            )
             current_builder = (
                 current_data.get("predicate", {})
                 .get("runDetails", {})
@@ -352,7 +356,9 @@ class TamperDetector:
         # Compare with historical attestations
         for historical_path in historical_attestations:
             try:
-                historical_data = json.loads(Path(historical_path).read_text())
+                historical_data = json.loads(
+                    Path(historical_path).read_text(encoding="utf-8")
+                )
                 historical_builder = (
                     historical_data.get("predicate", {})
                     .get("runDetails", {})
@@ -425,7 +431,9 @@ class TamperDetector:
         indicators: list[TamperIndicator] = []
 
         try:
-            current_data = json.loads(Path(attestation_path).read_text())
+            current_data = json.loads(
+                Path(attestation_path).read_text(encoding="utf-8")
+            )
             build_def = current_data.get("predicate", {}).get("buildDefinition", {})
 
             # Try externalParameters.tools first (ProvenanceGenerator format)
@@ -456,7 +464,9 @@ class TamperDetector:
         # Compare with historical attestations
         for historical_path in historical_attestations:
             try:
-                historical_data = json.loads(Path(historical_path).read_text())
+                historical_data = json.loads(
+                    Path(historical_path).read_text(encoding="utf-8")
+                )
                 historical_build_def = historical_data.get("predicate", {}).get(
                     "buildDefinition", {}
                 )
@@ -543,7 +553,9 @@ class TamperDetector:
         indicators: list[TamperIndicator] = []
 
         try:
-            attestation_data = json.loads(Path(attestation_path).read_text())
+            attestation_data = json.loads(
+                Path(attestation_path).read_text(encoding="utf-8")
+            )
         except (
             Exception
         ) as e:  # Acceptable: file scanning safety — skip unreadable attestations
@@ -566,7 +578,9 @@ class TamperDetector:
         if len(tools) >= 5:
             try:
                 if Path(subject_path).exists():
-                    subject_data = json.loads(Path(subject_path).read_text())
+                    subject_data = json.loads(
+                        Path(subject_path).read_text(encoding="utf-8")
+                    )
                     findings_count = len(subject_data.get("findings", []))
 
                     if findings_count == 0:

--- a/scripts/core/attestation/verifier.py
+++ b/scripts/core/attestation/verifier.py
@@ -133,7 +133,7 @@ class AttestationVerifier:
 
         # Load attestation
         try:
-            with open(attestation_path) as f:
+            with open(attestation_path, encoding="utf-8") as f:
                 attestation_data = json.load(f)
 
             # Parse as InTotoStatement

--- a/scripts/core/developer_attribution.py
+++ b/scripts/core/developer_attribution.py
@@ -414,7 +414,7 @@ def load_team_mapping(team_file_path: Path) -> dict[str, str]:
     """
     import json
 
-    with open(team_file_path) as f:
+    with open(team_file_path, encoding="utf-8") as f:
         return json.load(f)  # type: ignore[no-any-return]  # JSON parse returns Any, caller validates structure
 
 

--- a/scripts/core/policy_engine.py
+++ b/scripts/core/policy_engine.py
@@ -298,7 +298,7 @@ class PolicyEngine:
         if not test_data_path.exists():
             raise FileNotFoundError(f"Test data not found: {test_data_path}")
 
-        with open(test_data_path) as f:
+        with open(test_data_path, encoding="utf-8") as f:
             test_data = json.load(f)
 
         if not isinstance(test_data, dict):
@@ -319,7 +319,7 @@ class PolicyEngine:
             Package name in data.* format (e.g., "data.jmo.policy.secrets"), or None
         """
         try:
-            content = policy_path.read_text()
+            content = policy_path.read_text(encoding="utf-8")
             import re
 
             # Look for package declaration (e.g., "package jmo.policy.secrets")
@@ -380,7 +380,7 @@ class PolicyEngine:
                             return cast(dict[str, Any], metadata)
 
             # Fallback: parse file manually for metadata
-            content = policy_path.read_text()
+            content = policy_path.read_text(encoding="utf-8")
             import re
 
             # Look for metadata object definition

--- a/scripts/core/reporters/yaml_reporter.py
+++ b/scripts/core/reporters/yaml_reporter.py
@@ -48,7 +48,7 @@ def write_yaml(
         )
         if schema_path.exists():
             try:
-                with open(schema_path) as f:
+                with open(schema_path, encoding="utf-8") as f:
                     schema = json.load(f)
                 for idx, finding in enumerate(findings):
                     try:

--- a/scripts/core/trend_exporters.py
+++ b/scripts/core/trend_exporters.py
@@ -135,7 +135,7 @@ def export_to_prometheus(analysis: dict[str, Any], output_path: Path) -> None:
 
     if not by_severity:
         # Write empty metrics if no data
-        output_path.write_text("# No trend data available\n")
+        output_path.write_text("# No trend data available\n", encoding="utf-8")
         return
 
     # Get latest counts (last value in each severity list)
@@ -210,7 +210,7 @@ jmo_scan_count {scan_count}
             safe_rule = rule_id.replace("-", "_").replace(".", "_")
             metrics += f'jmo_rule_findings{{rule="{safe_rule}"}} {count}\n'
 
-    output_path.write_text(metrics)
+    output_path.write_text(metrics, encoding="utf-8")
 
 
 def export_to_grafana(analysis: dict[str, Any], output_path: Path) -> None:
@@ -387,7 +387,7 @@ def export_to_grafana(analysis: dict[str, Any], output_path: Path) -> None:
         "overwrite": True,
     }
 
-    output_path.write_text(json.dumps(dashboard, indent=2))
+    output_path.write_text(json.dumps(dashboard, indent=2), encoding="utf-8")
 
 
 def export_for_dashboard(analysis: dict[str, Any], output_path: Path) -> None:
@@ -461,4 +461,6 @@ def export_for_dashboard(analysis: dict[str, Any], output_path: Path) -> None:
         "top_rules": analysis.get("top_rules", [])[:10],  # Top 10 rules
     }
 
-    output_path.write_text(json.dumps(dashboard_data, indent=2, default=str))
+    output_path.write_text(
+        json.dumps(dashboard_data, indent=2, default=str), encoding="utf-8"
+    )

--- a/scripts/core/validators/scan_validator.py
+++ b/scripts/core/validators/scan_validator.py
@@ -1377,7 +1377,9 @@ def _check_reporter_json() -> CheckResult:
         from scripts.core.reporters.basic_reporter import write_json
 
         findings = [_make_sample_finding()]
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", suffix=".json", delete=False, mode="w"
+        ) as f:
             tmp_path = Path(f.name)
         try:
             write_json(findings, tmp_path)
@@ -1431,7 +1433,9 @@ def _check_reporter_html() -> CheckResult:
         from scripts.core.reporters.simple_html_reporter import write_simple_html
 
         findings = [_make_sample_finding()]
-        with tempfile.NamedTemporaryFile(suffix=".html", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", suffix=".html", delete=False, mode="w"
+        ) as f:
             tmp_path = Path(f.name)
         try:
             write_simple_html(findings, tmp_path)
@@ -1490,7 +1494,9 @@ def _check_reporter_csv() -> CheckResult:
         from scripts.core.reporters.csv_reporter import write_csv
 
         findings = [_make_sample_finding()]
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", suffix=".csv", delete=False, mode="w"
+        ) as f:
             tmp_path = Path(f.name)
         try:
             write_csv(findings, tmp_path)
@@ -1555,7 +1561,9 @@ def _check_reporter_utf8() -> CheckResult:
         utf8_message = "SQL injection (\u00e9l\u00e8ve) in \u2018query\u2019 \u2014 \u00fc\u00f1\u00ee\u00e7\u00f6d\u00e9"
         finding = _make_sample_finding(message=utf8_message)
 
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", suffix=".json", delete=False, mode="w"
+        ) as f:
             tmp_path = Path(f.name)
         try:
             write_json([finding], tmp_path)
@@ -1662,7 +1670,9 @@ def _check_full_dashboard_html() -> CheckResult:
             _make_sample_finding(id=f"dash_{i}", severity=sev, ruleId=f"RULE-{i}")
             for i, sev in enumerate(["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"])
         ]
-        with tempfile.NamedTemporaryFile(suffix=".html", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", suffix=".html", delete=False, mode="w"
+        ) as f:
             tmp_path = Path(f.name)
         try:
             write_simple_html(findings, tmp_path)
@@ -1735,7 +1745,9 @@ def _check_full_json_roundtrip() -> CheckResult:
         findings = [
             _make_sample_finding(id=f"rt_{i}", ruleId=f"RULE-{i}") for i in range(5)
         ]
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", suffix=".json", delete=False, mode="w"
+        ) as f:
             tmp_path = Path(f.name)
         try:
             write_json(findings, tmp_path)

--- a/scripts/dev/compare_benchmarks.py
+++ b/scripts/dev/compare_benchmarks.py
@@ -58,7 +58,7 @@ def parse_pytest_json(json_path: Path) -> list[BenchmarkResult]:
     if not json_path.exists():
         return []
 
-    with open(json_path) as f:
+    with open(json_path, encoding="utf-8") as f:
         data = json.load(f)
 
     results: list[BenchmarkResult] = []
@@ -296,7 +296,7 @@ def main():
         # Set output for GitHub Actions (using GITHUB_OUTPUT env file)
         github_output = os.environ.get("GITHUB_OUTPUT")
         if github_output:
-            with open(github_output, "a") as f:
+            with open(github_output, "a", encoding="utf-8") as f:
                 f.write("regression_detected=true\n")
         sys.exit(1)
     else:
@@ -304,7 +304,7 @@ def main():
         # Set output for GitHub Actions (using GITHUB_OUTPUT env file)
         github_output = os.environ.get("GITHUB_OUTPUT")
         if github_output:
-            with open(github_output, "a") as f:
+            with open(github_output, "a", encoding="utf-8") as f:
                 f.write("regression_detected=false\n")
 
 

--- a/scripts/dev/generate_baseline.py
+++ b/scripts/dev/generate_baseline.py
@@ -155,7 +155,7 @@ def load_findings(results_dir: Path) -> list[dict[str, Any]]:
         logger.warning(f"No findings.json found in {results_dir}")
         return []
 
-    with open(findings_file) as f:
+    with open(findings_file, encoding="utf-8") as f:
         data = json.load(f)
 
     # Handle both list and dict formats
@@ -292,10 +292,10 @@ def validate_baseline(baseline_path: Path) -> bool:
         logger.error(f"Schema file not found: {SCHEMA_FILE}")
         return False
 
-    with open(SCHEMA_FILE) as f:
+    with open(SCHEMA_FILE, encoding="utf-8") as f:
         schema = json.load(f)
 
-    with open(baseline_path) as f:
+    with open(baseline_path, encoding="utf-8") as f:
         baseline = json.load(f)
 
     try:
@@ -377,7 +377,7 @@ def main() -> int:
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Write baseline
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(baseline, f, indent=2)
             f.write("\n")
 

--- a/scripts/dev/generate_release_notes.py
+++ b/scripts/dev/generate_release_notes.py
@@ -42,7 +42,7 @@ def extract_changelog_section(
     if not changelog_path.exists():
         raise FileNotFoundError(f"CHANGELOG.md not found at {changelog_path}")
 
-    changelog = changelog_path.read_text()
+    changelog = changelog_path.read_text(encoding="utf-8")
 
     # Pattern to match: ## [version] or ## version (both formats supported)
     # Extract everything between this heading and the next ## heading (or end of file)

--- a/scripts/dev/serve_attack_navigator.py
+++ b/scripts/dev/serve_attack_navigator.py
@@ -255,7 +255,7 @@ def serve_and_open(json_file: Path):
 
     # Load layer JSON
     try:
-        with open(json_file) as f:
+        with open(json_file, encoding="utf-8") as f:
             layer_data = json.load(f)
     except Exception as e:
         print(f"❌ Error loading JSON: {e}")

--- a/scripts/dev/validate_readme.py
+++ b/scripts/dev/validate_readme.py
@@ -170,7 +170,7 @@ def check_dockerhub_local_consistency(
         # Get version from pyproject.toml
         pyproject_path = Path("pyproject.toml")
         if pyproject_path.exists():
-            pyproject_content = pyproject_path.read_text()
+            pyproject_content = pyproject_path.read_text(encoding="utf-8")
             current_version_match = re.search(
                 r'version\s*=\s*"(\d+\.\d+\.\d+)"', pyproject_content
             )
@@ -208,7 +208,7 @@ def check_dockerhub_sync_config() -> list[dict[str, str]]:
         )
         return issues
 
-    content = release_yml.read_text()
+    content = release_yml.read_text(encoding="utf-8")
 
     # Check for docker-hub-readme job
     if "docker-hub-readme:" not in content:
@@ -342,7 +342,7 @@ def validate_dockerhub(args) -> tuple[bool, list[dict]]:
         )
         return False, all_issues
 
-    local_dockerhub_readme = dockerhub_readme_path.read_text()
+    local_dockerhub_readme = dockerhub_readme_path.read_text(encoding="utf-8")
     print(f"\n📄 Local Docker Hub README: {len(local_dockerhub_readme)} bytes")
 
     # Check local file consistency

--- a/tests/cli/test_diff_commands.py
+++ b/tests/cli/test_diff_commands.py
@@ -258,7 +258,7 @@ def test_cli_directory_mode_json(sample_scan_directories, tmp_path, monkeypatch)
     assert output_path.exists()
 
     # Verify JSON structure
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         data = json.load(f)
 
     assert "meta" in data
@@ -321,7 +321,7 @@ def test_cli_sqlite_mode(sample_sqlite_db, tmp_path):
     assert result == 0
     assert output_path.exists()
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         data = json.load(f)
 
     assert data["statistics"]["total_new"] == 1
@@ -350,7 +350,7 @@ def test_cli_no_modifications(sample_scan_directories, tmp_path):
 
     assert result == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         data = json.load(f)
 
     # No modified findings when detection disabled
@@ -380,7 +380,7 @@ def test_cli_severity_filter(sample_scan_directories, tmp_path):
 
     assert result == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         data = json.load(f)
 
     # Only HIGH finding should be in new (Semgrep ERROR maps to HIGH)
@@ -414,7 +414,7 @@ def test_cli_tool_filter(sample_scan_directories, tmp_path):
 
     assert result == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         data = json.load(f)
 
     # Only semgrep findings
@@ -444,7 +444,7 @@ def test_cli_only_new(sample_scan_directories, tmp_path):
 
     assert result == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         data = json.load(f)
 
     # Only new findings should be present

--- a/tests/cli/test_wizard_diff.py
+++ b/tests/cli/test_wizard_diff.py
@@ -675,7 +675,7 @@ class TestRunDiffWizardHTMLBrowserOpen:
 
         def mock_cmd_diff(args):
             # Simulate creating the output file
-            Path(args.output).write_text("<html>Report</html>")
+            Path(args.output).write_text("<html>Report</html>", encoding="utf-8")
             return 0
 
         with patch("builtins.input", side_effect=inputs):
@@ -712,7 +712,7 @@ class TestRunDiffWizardHTMLBrowserOpen:
         ]
 
         def mock_cmd_diff(args):
-            Path(args.output).write_text("<html>Report</html>")
+            Path(args.output).write_text("<html>Report</html>", encoding="utf-8")
             return 0
 
         with patch("builtins.input", side_effect=inputs):

--- a/tests/e2e/test_cross_platform.py
+++ b/tests/e2e/test_cross_platform.py
@@ -383,7 +383,7 @@ class TestCrossPlatformCompatibility:
         # Check findings for path consistency
         findings_json = results_dir / "summaries" / "findings.json"
         if findings_json.exists():
-            with open(findings_json) as f:
+            with open(findings_json, encoding="utf-8") as f:
                 data = json.load(f)
 
             # v1.0.0 metadata wrapper

--- a/tests/e2e/test_real_tool_scans.py
+++ b/tests/e2e/test_real_tool_scans.py
@@ -141,7 +141,7 @@ class TestRealToolScans:
         trivy_output = image_results / "trivy.json"
         assert trivy_output.exists(), "Trivy output should exist"
 
-        with open(trivy_output) as f:
+        with open(trivy_output, encoding="utf-8") as f:
             trivy_data = json.load(f)
 
         # Trivy format varies - check both array and Results field
@@ -267,7 +267,7 @@ def safe_process(user_input):
         semgrep_output = repo_results / "semgrep.json"
         assert semgrep_output.exists(), "Semgrep output should exist"
 
-        with open(semgrep_output) as f:
+        with open(semgrep_output, encoding="utf-8") as f:
             semgrep_data = json.load(f)
 
         # Semgrep format: {"results": [...], "errors": [...]}
@@ -380,7 +380,7 @@ def main():
 
         # TruffleHog outputs NDJSON (one JSON object per line)
         secrets_found = []
-        with open(trufflehog_output) as f:
+        with open(trufflehog_output, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if line:
@@ -501,7 +501,7 @@ resource "aws_s3_bucket" "secure_example" {
         checkov_output = iac_results / "checkov.json"
         assert checkov_output.exists(), "Checkov output should exist"
 
-        with open(checkov_output) as f:
+        with open(checkov_output, encoding="utf-8") as f:
             checkov_data = json.load(f)
 
         # Checkov format: {"results": {"failed_checks": [...], "passed_checks": [...]}}

--- a/tests/e2e/test_windows_specific.py
+++ b/tests/e2e/test_windows_specific.py
@@ -225,7 +225,7 @@ class TestWindowsFileOperations:
         test_file.write_text("x = 1", encoding="utf-8")
 
         # Open file to lock it (Windows-specific behavior)
-        with open(test_file) as _locked:
+        with open(test_file, encoding="utf-8") as _locked:
             result = jmo_runner(
                 [
                     "scan",

--- a/tests/edge_cases/test_diff_edge_cases.py
+++ b/tests/edge_cases/test_diff_edge_cases.py
@@ -84,7 +84,7 @@ def test_empty_baseline(temp_workspace, sample_finding):
     assert result.returncode == 0, f"Diff failed: {result.stderr}"
     assert output_path.exists()
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # All current findings are new
@@ -132,7 +132,7 @@ def test_empty_current(temp_workspace, sample_finding):
 
     assert result.returncode == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # All baseline findings resolved
@@ -185,7 +185,7 @@ def test_identical_scans(temp_workspace, sample_finding):
 
     assert result.returncode == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # No changes
@@ -248,7 +248,7 @@ def test_large_diff_10k_findings(temp_workspace, sample_finding):
     assert result.returncode == 0
     assert elapsed < 5.0, f"Diff took {elapsed:.2f}s (expected <5s for 10K findings)"
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     assert diff["statistics"]["total_new"] == 5000
@@ -409,7 +409,7 @@ def test_mixed_schema_versions(temp_workspace, sample_finding):
 
     assert result.returncode == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # Should handle gracefully
@@ -462,7 +462,7 @@ def test_modification_detection_disabled(temp_workspace, sample_finding):
 
     assert result.returncode == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # Should treat as unchanged (no modification detection)
@@ -518,7 +518,7 @@ def test_filter_combinations(temp_workspace, sample_finding):
 
     assert result.returncode == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # Should only see: c1 (HIGH + semgrep + new)
@@ -605,7 +605,7 @@ def test_only_new_filter(temp_workspace, sample_finding):
 
     assert result.returncode == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # Only new findings
@@ -663,7 +663,7 @@ def test_only_resolved_filter(temp_workspace, sample_finding):
 
     assert result.returncode == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # Only resolved findings

--- a/tests/integration/test_baseline_validation.py
+++ b/tests/integration/test_baseline_validation.py
@@ -50,7 +50,7 @@ class BaselineValidationResult:
 
 def load_baseline(baseline_file: Path) -> dict[str, Any]:
     """Load a baseline file."""
-    with open(baseline_file) as f:
+    with open(baseline_file, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -103,7 +103,7 @@ def load_findings(results_dir: Path) -> list[dict[str, Any]]:
     if not findings_file.exists():
         return []
 
-    with open(findings_file) as f:
+    with open(findings_file, encoding="utf-8") as f:
         data = json.load(f)
 
     if isinstance(data, list):
@@ -304,7 +304,7 @@ class TestBaselineSchemaValidation:
     def test_baseline_files_valid_json(self):
         """All baseline files should be valid JSON."""
         for baseline_file in BASELINES_DIR.glob("*.baseline.json"):
-            with open(baseline_file) as f:
+            with open(baseline_file, encoding="utf-8") as f:
                 data = json.load(f)
 
             # Check required top-level keys

--- a/tests/integration/test_cross_tool_dedup_integration.py
+++ b/tests/integration/test_cross_tool_dedup_integration.py
@@ -20,7 +20,7 @@ def fixture_path() -> Path:
 @pytest.fixture
 def sql_injection_cluster(fixture_path):
     """Load SQL injection cluster from fixtures."""
-    with open(fixture_path) as f:
+    with open(fixture_path, encoding="utf-8") as f:
         data = json.load(f)
 
     # Get the SQL injection cluster (first in known_duplicates)

--- a/tests/integration/test_diff_e2e.py
+++ b/tests/integration/test_diff_e2e.py
@@ -108,7 +108,7 @@ def test_e2e_directory_diff_json(temp_workspace, sample_findings):
     assert output_path.exists()
 
     # Validate JSON structure
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     assert "meta" in diff
@@ -201,7 +201,7 @@ def test_e2e_modification_detection(temp_workspace, sample_findings):
     assert result.returncode == 0
 
     # Validate modification detected
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     assert diff["statistics"]["total_modified"] == 1
@@ -272,7 +272,7 @@ def test_e2e_ci_workflow(temp_workspace, sample_findings):
     assert result.returncode == 0
 
     # Validate filtering worked
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # Should only see CRITICAL finding
@@ -337,7 +337,7 @@ def test_e2e_filtering_combinations(temp_workspace, sample_findings):
 
     assert result.returncode == 0
 
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         diff = json.load(f)
 
     # Should only see: c1 (HIGH + semgrep + new)
@@ -414,10 +414,10 @@ def test_e2e_no_modifications_flag(temp_workspace, sample_findings):
     assert result_without.returncode == 0
 
     # Validate difference
-    with open(output_with) as f:
+    with open(output_with, encoding="utf-8") as f:
         diff_with = json.load(f)
 
-    with open(output_without) as f:
+    with open(output_without, encoding="utf-8") as f:
         diff_without = json.load(f)
 
     # With modifications: should detect severity change
@@ -565,7 +565,7 @@ def test_e2e_sarif_output(temp_workspace, sample_findings):
     assert output_path.exists()
 
     # Validate SARIF structure
-    with open(output_path) as f:
+    with open(output_path, encoding="utf-8") as f:
         sarif = json.load(f)
 
     assert sarif["version"] == "2.1.0"

--- a/tests/integration/test_diff_workflows.py
+++ b/tests/integration/test_diff_workflows.py
@@ -111,7 +111,7 @@ class TestDirectoryDiffWorkflows:
         assert output_path.exists(), "JSON output should exist"
 
         # Validate JSON structure
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             diff = json.load(f)
 
         assert "meta" in diff
@@ -293,7 +293,7 @@ class TestDirectoryDiffWorkflows:
         assert result.returncode == 0, f"Diff failed: {result.stderr}"
         assert output_path.exists()
 
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             sarif = json.load(f)
 
         assert sarif["version"] == "2.1.0"
@@ -357,7 +357,7 @@ class TestFilteringCombinations:
         assert result.returncode == 0
         assert output_path.exists()
 
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             diff = json.load(f)
 
         # Should only see HIGH finding
@@ -417,7 +417,7 @@ class TestFilteringCombinations:
         assert result.returncode == 0
         assert output_path.exists()
 
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             diff = json.load(f)
 
         assert diff["statistics"]["total_new"] == 1
@@ -478,7 +478,7 @@ class TestFilteringCombinations:
         assert result.returncode == 0
         assert output_path.exists()
 
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             diff = json.load(f)
 
         # Should only see new findings
@@ -545,7 +545,7 @@ class TestCICDIntegrationPatterns:
         assert result.returncode == 0
         assert output_path.exists()
 
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             diff = json.load(f)
 
         # Security gate check
@@ -610,7 +610,7 @@ class TestCICDIntegrationPatterns:
         assert result.returncode == 0
         assert output_path.exists()
 
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             diff = json.load(f)
 
         # Verify remediation tracking

--- a/tests/integration/test_full_v1_workflow.py
+++ b/tests/integration/test_full_v1_workflow.py
@@ -130,7 +130,7 @@ class TestV1WorkflowIntegration:
         findings_json = results_dir / "summaries" / "findings.json"
         assert findings_json.exists(), "findings.json should exist"
 
-        with open(findings_json) as f:
+        with open(findings_json, encoding="utf-8") as f:
             data = json.load(f)
 
         # v1.0.0 metadata wrapper validation

--- a/tests/integration/test_github_actions_generation.py
+++ b/tests/integration/test_github_actions_generation.py
@@ -115,7 +115,9 @@ def test_actionlint_validation():
     workflow_yaml = generator.generate(schedule)
 
     # Write to temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(
+        encoding="utf-8", mode="w", suffix=".yml", delete=False
+    ) as f:
         f.write(workflow_yaml)
         temp_file = Path(f.name)
 

--- a/tests/integration/test_multi_target_history.py
+++ b/tests/integration/test_multi_target_history.py
@@ -209,7 +209,7 @@ class TestMultiTargetHistoryIntegration:
         assert output_path.exists(), "JSON output should exist"
 
         # Validate diff detected new IaC finding
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             diff = json.load(f)
 
         assert "statistics" in diff

--- a/tests/integration/test_scan_pipeline.py
+++ b/tests/integration/test_scan_pipeline.py
@@ -61,7 +61,7 @@ def load_findings(results_dir: Path) -> list[dict[str, Any]]:
     if not findings_file.exists():
         return []
 
-    with open(findings_file) as f:
+    with open(findings_file, encoding="utf-8") as f:
         data = json.load(f)
 
     if isinstance(data, list):
@@ -79,7 +79,7 @@ def count_raw_findings(results_dir: Path) -> int:
     if individual_dir.exists():
         for json_file in individual_dir.glob("*.json"):
             try:
-                with open(json_file) as f:
+                with open(json_file, encoding="utf-8") as f:
                     data = json.load(f)
                 if isinstance(data, list):
                     total += len(data)
@@ -245,7 +245,7 @@ class TestScanReporting:
         findings_file = results_dir / "findings.json"
         if findings_file.exists():
             # Should be valid JSON
-            with open(findings_file) as f:
+            with open(findings_file, encoding="utf-8") as f:
                 data = json.load(f)
 
             # Should be list or dict with findings

--- a/tests/integration/test_tool_smoke.py
+++ b/tests/integration/test_tool_smoke.py
@@ -479,7 +479,7 @@ def parse_with_adapter(tool_name: str, output_file: Path) -> list[dict[str, Any]
     if hasattr(adapter, "parse"):
         return adapter.parse(output_file)
     elif hasattr(adapter, "parse_output"):
-        with open(output_file) as f:
+        with open(output_file, encoding="utf-8") as f:
             content = f.read()
         return adapter.parse_output(content)
     else:

--- a/tests/jmo_mcp/test_server_apply_fix.py
+++ b/tests/jmo_mcp/test_server_apply_fix.py
@@ -30,11 +30,11 @@ def mock_findings_file(tmp_path):
     results_dir = tmp_path / "results" / "summaries"
     results_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(findings_json) as f:
+    with open(findings_json, encoding="utf-8") as f:
         findings_data = json.load(f)
 
     output_path = results_dir / "findings.json"
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(findings_data, f, indent=2)
 
     return tmp_path

--- a/tests/jmo_mcp/test_server_get_security_findings.py
+++ b/tests/jmo_mcp/test_server_get_security_findings.py
@@ -29,11 +29,11 @@ def mock_findings_file(tmp_path):
     results_dir = tmp_path / "results" / "summaries"
     results_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(findings_json) as f:
+    with open(findings_json, encoding="utf-8") as f:
         findings_data = json.load(f)
 
     output_path = results_dir / "findings.json"
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(findings_data, f, indent=2)
 
     return tmp_path
@@ -266,7 +266,7 @@ def test_get_security_findings_empty_findings_file(tmp_path, monkeypatch):
     results_dir.mkdir(parents=True, exist_ok=True)
 
     findings_path = results_dir / "findings.json"
-    with open(findings_path, "w") as f:
+    with open(findings_path, "w", encoding="utf-8") as f:
         json.dump([], f)  # Empty list, not object
 
     monkeypatch.setenv("MCP_RESULTS_DIR", str(tmp_path / "results"))

--- a/tests/jmo_mcp/test_server_info_and_context.py
+++ b/tests/jmo_mcp/test_server_info_and_context.py
@@ -27,11 +27,11 @@ def mock_findings_file(tmp_path):
     results_dir = tmp_path / "results" / "summaries"
     results_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(findings_json) as f:
+    with open(findings_json, encoding="utf-8") as f:
         findings_data = json.load(f)
 
     output_path = results_dir / "findings.json"
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(findings_data, f, indent=2)
 
     # Copy repo fixtures

--- a/tests/jmo_mcp/test_server_mark_resolved.py
+++ b/tests/jmo_mcp/test_server_mark_resolved.py
@@ -32,11 +32,11 @@ def mock_findings_file(tmp_path):
     results_dir = tmp_path / "results" / "summaries"
     results_dir.mkdir(parents=True, exist_ok=True)
 
-    with open(findings_json) as f:
+    with open(findings_json, encoding="utf-8") as f:
         findings_data = json.load(f)
 
     output_path = results_dir / "findings.json"
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(findings_data, f, indent=2)
 
     return tmp_path

--- a/tests/performance/test_benchmarks.py
+++ b/tests/performance/test_benchmarks.py
@@ -245,7 +245,7 @@ class TestPerformanceBenchmarks:
 
         # Write findings.json (store_scan expects this file)
         findings_json = results_dir / "summaries" / "findings.json"
-        with open(findings_json, "w") as f:
+        with open(findings_json, "w", encoding="utf-8") as f:
             json.dump(scan_data["findings"], f)
 
         # Create dummy target directory to avoid detection errors
@@ -356,7 +356,7 @@ class TestPerformanceBenchmarks:
 
             # Write findings.json
             findings_json = scan_results_dir / "summaries" / "findings.json"
-            with open(findings_json, "w") as f:
+            with open(findings_json, "w", encoding="utf-8") as f:
                 json.dump(scan_data["findings"], f)
 
             # Create dummy target directory

--- a/tests/performance/test_history_db_perf.py
+++ b/tests/performance/test_history_db_perf.py
@@ -53,7 +53,7 @@ def test_store_scan_1000_findings_fast(
     # Write findings to JSON (simulate scan output)
     # Format: {"findings": [...], "metadata": {...}}
     findings_file = summaries_dir / "findings.json"
-    with open(findings_file, "w") as f:
+    with open(findings_file, "w", encoding="utf-8") as f:
         json.dump(
             {
                 "findings": benchmark_findings,
@@ -353,7 +353,7 @@ def test_benchmark_suite(tmp_path: Path, benchmark_findings: list[dict[str, Any]
 
     # Write findings.json
     findings_file = summaries_dir / "findings.json"
-    with open(findings_file, "w") as f:
+    with open(findings_file, "w", encoding="utf-8") as f:
         json.dump(
             {
                 "findings": benchmark_findings,

--- a/tests/performance/test_load.py
+++ b/tests/performance/test_load.py
@@ -174,7 +174,7 @@ class TestLargeRepositoryScanning:
         for tool_file in (results_dir / "individual-repos" / "large-repo").glob(
             "*.json"
         ):
-            with open(tool_file) as f:
+            with open(tool_file, encoding="utf-8") as f:
                 tool_findings = json.load(f)
                 all_findings.extend(
                     tool_findings if isinstance(tool_findings, list) else []
@@ -237,7 +237,7 @@ class TestLargeRepositoryScanning:
         for tool_file in (results_dir / "individual-repos" / "enterprise-repo").glob(
             "*.json"
         ):
-            with open(tool_file) as f:
+            with open(tool_file, encoding="utf-8") as f:
                 tool_findings = json.load(f)
                 all_findings.extend(
                     tool_findings if isinstance(tool_findings, list) else []
@@ -298,7 +298,7 @@ class TestLargeRepositoryScanning:
         combined_findings = []
         for repo_dir in (results_dir / "individual-repos").iterdir():
             for tool_file in repo_dir.glob("*.json"):
-                with open(tool_file) as f:
+                with open(tool_file, encoding="utf-8") as f:
                     tool_findings = json.load(f)
                     combined_findings.extend(
                         tool_findings if isinstance(tool_findings, list) else []

--- a/tests/reporters/test_diff_html_reporter.py
+++ b/tests/reporters/test_diff_html_reporter.py
@@ -256,7 +256,7 @@ def test_html_external_mode(tmp_path):
     json_path = tmp_path / "diff-data.json"
     assert json_path.exists()
 
-    with open(json_path) as f:
+    with open(json_path, encoding="utf-8") as f:
         data = json.load(f)
     assert len(data["new"]) == 1001
 

--- a/tests/reporters/test_diff_json_reporter.py
+++ b/tests/reporters/test_diff_json_reporter.py
@@ -124,7 +124,7 @@ def test_json_schema_structure(tmp_path, sample_diff_result):
 
     assert out_path.exists()
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     # Check top-level keys
@@ -140,7 +140,7 @@ def test_json_metadata_wrapper(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.json"
     write_json_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     meta = data["meta"]
@@ -178,7 +178,7 @@ def test_json_statistics_section(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.json"
     write_json_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     stats = data["statistics"]
@@ -200,7 +200,7 @@ def test_json_new_findings(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.json"
     write_json_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     new = data["new_findings"]
@@ -218,7 +218,7 @@ def test_json_resolved_findings(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.json"
     write_json_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     resolved = data["resolved_findings"]
@@ -233,7 +233,7 @@ def test_json_modified_findings(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.json"
     write_json_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     modified = data["modified_findings"]
@@ -256,7 +256,7 @@ def test_json_valid_format(tmp_path, sample_diff_result):
     write_json_diff(sample_diff_result, out_path)
 
     # Should parse without errors
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     assert isinstance(data, dict)
@@ -268,7 +268,7 @@ def test_json_round_trip(tmp_path, sample_diff_result):
     write_json_diff(sample_diff_result, out_path)
 
     # Read back
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     # Verify all data intact
@@ -320,7 +320,7 @@ def test_json_empty_diff(tmp_path):
     out_path = tmp_path / "empty-diff.json"
     write_json_diff(diff, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     assert data["statistics"]["total_new"] == 0

--- a/tests/reporters/test_diff_sarif_reporter.py
+++ b/tests/reporters/test_diff_sarif_reporter.py
@@ -103,7 +103,7 @@ def test_sarif_schema_compliance(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.sarif"
     write_sarif_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         sarif = json.load(f)
 
     # Check top-level structure
@@ -118,7 +118,7 @@ def test_sarif_tool_metadata(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.sarif"
     write_sarif_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         sarif = json.load(f)
 
     tool = sarif["runs"][0]["tool"]["driver"]
@@ -132,7 +132,7 @@ def test_sarif_diff_metadata(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.sarif"
     write_sarif_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         sarif = json.load(f)
 
     props = sarif["runs"][0]["properties"]
@@ -150,7 +150,7 @@ def test_sarif_new_findings(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.sarif"
     write_sarif_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         sarif = json.load(f)
 
     results = sarif["runs"][0]["results"]
@@ -170,7 +170,7 @@ def test_sarif_resolved_findings(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.sarif"
     write_sarif_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         sarif = json.load(f)
 
     results = sarif["runs"][0]["results"]
@@ -192,7 +192,7 @@ def test_sarif_modified_findings(tmp_path, sample_diff_result):
     out_path = tmp_path / "diff.sarif"
     write_sarif_diff(sample_diff_result, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         sarif = json.load(f)
 
     results = sarif["runs"][0]["results"]
@@ -263,7 +263,7 @@ def test_sarif_valid_json(tmp_path, sample_diff_result):
     write_sarif_diff(sample_diff_result, out_path)
 
     # Should parse without errors
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         data = json.load(f)
 
     assert isinstance(data, dict)
@@ -383,7 +383,7 @@ def test_sarif_empty_diff(tmp_path):
     out_path = tmp_path / "empty-diff.sarif"
     write_sarif_diff(diff, out_path)
 
-    with open(out_path) as f:
+    with open(out_path, encoding="utf-8") as f:
         sarif = json.load(f)
 
     assert len(sarif["runs"][0]["results"]) == 0

--- a/tests/security/test_secrets_management.py
+++ b/tests/security/test_secrets_management.py
@@ -114,7 +114,7 @@ class TestSecretsManagement:
         gitignore_path = Path(".gitignore")
         assert gitignore_path.exists(), ".gitignore must exist"
 
-        gitignore_content = gitignore_path.read_text()
+        gitignore_content = gitignore_path.read_text(encoding="utf-8")
 
         # Critical patterns that MUST be gitignored
         required_patterns = [
@@ -139,7 +139,7 @@ class TestSecretsManagement:
         pre_commit_config = Path(".pre-commit-config.yaml")
         assert pre_commit_config.exists(), ".pre-commit-config.yaml must exist"
 
-        config_content = pre_commit_config.read_text()
+        config_content = pre_commit_config.read_text(encoding="utf-8")
 
         # Should include detect-private-key hook
         assert (

--- a/tests/unit/test_attestation_cicd.py
+++ b/tests/unit/test_attestation_cicd.py
@@ -408,13 +408,15 @@ class TestCIModeIntegration:
         attestation_path_obj = Path(attestation_path_str)
 
         # Save attestation manually
-        attestation_path_obj.write_text(json.dumps(statement, indent=2))
+        attestation_path_obj.write_text(
+            json.dumps(statement, indent=2), encoding="utf-8"
+        )
 
         # Should exist at expected path
         assert attestation_path_obj.exists()
 
         # Should be valid JSON
-        with open(attestation_path_str) as f:
+        with open(attestation_path_str, encoding="utf-8") as f:
             data = json.load(f)
             assert data["_type"] == "https://in-toto.io/Statement/v0.1"
 

--- a/tests/unit/test_attestation_cli.py
+++ b/tests/unit/test_attestation_cli.py
@@ -270,7 +270,7 @@ class TestAttestCommandExecution:
         assert exit_code == 0
         # Verify attestation contains scan args
         attestation_path = Path(str(sample_findings) + ".att.json")
-        attestation = json.loads(attestation_path.read_text())
+        attestation = json.loads(attestation_path.read_text(encoding="utf-8"))
 
         assert (
             attestation["predicate"]["buildDefinition"]["externalParameters"]["profile"]
@@ -302,7 +302,7 @@ class TestAttestCommandExecution:
 
         assert exit_code == 0
         attestation_path = Path(str(sample_findings) + ".att.json")
-        attestation = json.loads(attestation_path.read_text())
+        attestation = json.loads(attestation_path.read_text(encoding="utf-8"))
 
         # Verify in-toto statement structure
         assert attestation["_type"] == "https://in-toto.io/Statement/v0.1"

--- a/tests/unit/test_attestation_provenance.py
+++ b/tests/unit/test_attestation_provenance.py
@@ -147,7 +147,7 @@ class TestHashGeneration:
         """Test generating all three hash algorithms."""
         from scripts.core.attestation.provenance import ProvenanceGenerator
 
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        with tempfile.NamedTemporaryFile(encoding="utf-8", mode="w", delete=False) as f:
             f.write('{"findings": []}')
             findings_path = Path(f.name)
 

--- a/tests/unit/test_dedup_enhanced.py
+++ b/tests/unit/test_dedup_enhanced.py
@@ -30,7 +30,7 @@ def cross_tool_fixtures():
     fixtures_path = (
         Path(__file__).parent.parent / "fixtures" / "cross_tool_findings.json"
     )
-    with open(fixtures_path) as f:
+    with open(fixtures_path, encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/tests/unit/test_github_actions_generator.py
+++ b/tests/unit/test_github_actions_generator.py
@@ -307,7 +307,9 @@ def test_actionlint_validation(basic_schedule):
     workflow_yaml = generator.generate(basic_schedule)
 
     # Write to temporary file
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(
+        encoding="utf-8", mode="w", suffix=".yml", delete=False
+    ) as f:
         f.write(workflow_yaml)
         temp_file = Path(f.name)
 

--- a/tests/unit/test_history_db_concurrency.py
+++ b/tests/unit/test_history_db_concurrency.py
@@ -85,7 +85,7 @@ def test_concurrent_writes_thread_safety(concurrency_db, sample_findings, tmp_pa
     summaries_dir = results_dir / "summaries"
     summaries_dir.mkdir()
     findings_file = summaries_dir / "findings.json"
-    with open(findings_file, "w") as f:
+    with open(findings_file, "w", encoding="utf-8") as f:
         json.dump({"findings": sample_findings}, f)
 
     # Thread worker function
@@ -167,7 +167,7 @@ def test_concurrent_reads_during_writes(concurrency_db, sample_findings, tmp_pat
     summaries_dir = results_dir / "summaries"
     summaries_dir.mkdir()
     findings_file = summaries_dir / "findings.json"
-    with open(findings_file, "w") as f:
+    with open(findings_file, "w", encoding="utf-8") as f:
         json.dump({"findings": sample_findings}, f)
 
     # Insert initial scans
@@ -265,7 +265,7 @@ def test_sqlite_locking_under_contention(concurrency_db, sample_findings, tmp_pa
     summaries_dir = results_dir / "summaries"
     summaries_dir.mkdir()
     findings_file = summaries_dir / "findings.json"
-    with open(findings_file, "w") as f:
+    with open(findings_file, "w", encoding="utf-8") as f:
         json.dump({"findings": sample_findings}, f)
 
     # Thread worker function with artificial contention
@@ -342,7 +342,7 @@ def test_database_corruption_recovery(concurrency_db, sample_findings, tmp_path)
     summaries_dir = results_dir / "summaries"
     summaries_dir.mkdir()
     findings_file = summaries_dir / "findings.json"
-    with open(findings_file, "w") as f:
+    with open(findings_file, "w", encoding="utf-8") as f:
         json.dump({"findings": sample_findings}, f)
 
     # Store initial scan
@@ -434,7 +434,7 @@ def test_partial_write_recovery(concurrency_db, sample_findings, tmp_path):
     summaries_dir = results_dir / "summaries"
     summaries_dir.mkdir()
     findings_file = summaries_dir / "findings.json"
-    with open(findings_file, "w") as f:
+    with open(findings_file, "w", encoding="utf-8") as f:
         json.dump({"findings": sample_findings}, f)
 
     # Store initial scan
@@ -511,7 +511,7 @@ def test_connection_pool_thread_safety(concurrency_db, sample_findings, tmp_path
     summaries_dir = results_dir / "summaries"
     summaries_dir.mkdir()
     findings_file = summaries_dir / "findings.json"
-    with open(findings_file, "w") as f:
+    with open(findings_file, "w", encoding="utf-8") as f:
         json.dump({"findings": sample_findings}, f)
 
     connection_ids = []

--- a/tests/unit/test_history_db_findings_format.py
+++ b/tests/unit/test_history_db_findings_format.py
@@ -38,7 +38,7 @@ class TestFindingsFormatHandling:
             }
         ]
         findings_file = summaries / "findings.json"
-        with open(findings_file, "w") as f:
+        with open(findings_file, "w", encoding="utf-8") as f:
             json.dump(findings_list, f)
 
         # Store scan (should succeed with list format)
@@ -86,7 +86,7 @@ class TestFindingsFormatHandling:
             ]
         }
         findings_file = summaries / "findings.json"
-        with open(findings_file, "w") as f:
+        with open(findings_file, "w", encoding="utf-8") as f:
             json.dump(findings_dict, f)
 
         # Store scan (should succeed with dict format)
@@ -120,7 +120,7 @@ class TestFindingsFormatHandling:
 
         # Create findings.json with empty list
         findings_file = summaries / "findings.json"
-        with open(findings_file, "w") as f:
+        with open(findings_file, "w", encoding="utf-8") as f:
             json.dump([], f)
 
         # Store scan (should succeed with 0 findings)
@@ -159,7 +159,7 @@ class TestFindingsFormatHandling:
 
         # Create findings.json with malformed format (string, not list/dict)
         findings_file = summaries / "findings.json"
-        with open(findings_file, "w") as f:
+        with open(findings_file, "w", encoding="utf-8") as f:
             json.dump("malformed", f)
 
         # Store scan (should handle gracefully with 0 findings)

--- a/tests/unit/test_history_db_performance.py
+++ b/tests/unit/test_history_db_performance.py
@@ -467,7 +467,7 @@ def test_export_pagination_for_large_datasets(perf_db, tmp_path):
         "total_count": len(scans),
     }
 
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         json.dump(export_data, f, indent=2)
 
     conn.close()
@@ -481,7 +481,7 @@ def test_export_pagination_for_large_datasets(perf_db, tmp_path):
     assert elapsed < 5.0  # <5s for 1000 scans
 
     # Verify exported data is valid JSON
-    with open(output_file) as f:
+    with open(output_file, encoding="utf-8") as f:
         data = json.load(f)
 
     assert len(data["scans"]) == 1000

--- a/tests/unit/test_tool_runner.py
+++ b/tests/unit/test_tool_runner.py
@@ -581,7 +581,9 @@ class TestErrorHandling:
         import stat
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            encoding="utf-8", mode="w", suffix=".sh", delete=False
+        ) as f:
             f.write("#!/bin/bash\necho test\n")
             script_path = f.name
 


### PR DESCRIPTION
Read-side half of the Windows console-encoding burn-down. Follows #695.

## What this does

Adds an explicit `encoding="utf-8"` to all 153 sites `ruff PLW1514` flags — 49 in `scripts/`, 104 in `tests/` — committed separately so the production-behaviour change is reviewable on its own.

Without an explicit encoding, `open()` / `read_text()` / `write_text()` inherit the locale codec, which is cp1252 on a stock Windows box.

One site is a latent bug rather than hardening: `open(github_output, "a")` writes `$GITHUB_OUTPUT`, which GitHub reads as UTF-8. On a Windows runner that call emitted cp1252, corrupting any non-ASCII value passed between steps.

Every hunk was reviewed against the three hazards that make `PLW1514`'s fix "unsafe": no binary-mode call was touched, no call already specified an encoding, and no target is deliberately non-UTF-8.

## Two measured findings that change what this is worth

**1. It fixes zero failures.** A native-console run reads `40 failed / 22 errors` both before and after, with identical failing-test ID sets. `PLW1514` and the actual read-side failure class are nearly disjoint.

Ruff flags `p.read_text()` only when it can prove the receiver is a `Path`. It does **not** flag `(tmp_path / "x.html").read_text()` — it cannot type a `/` division result — and that is the dominant idiom in pytest. Ruff reports "All checks passed!" on `tests/reporters/test_html_security.py`, whose line 54 is `out_path.read_text()` and is the source of all 22 errors. An AST scan needing no type inference finds **~1198** unspecified-encoding sites against ruff's 153.

**2. The rule cannot be enforced as the plan intended.** `PLW1514` requires `preview = true`, and that flag is **global** — it enables preview rules for every selected family, not just the one named. Measured cost: **318** unrelated errors (`RUF069` ×124, `FURB113` ×75, `RUF201` ×37, …), precisely the unpinned-ruleset ambush #678 exists to prevent. Selecting `PLW1514` specifically does not help, because the flag is what widens the surface.

`pyproject.toml` is therefore deliberately **unchanged**. The durable guard for this class has to be the full-suite `windows-native-encoding` CI job (PR 3), not a lint rule — which is also the only thing that can see the sites ruff is blind to.

## Verification

- Native console (`PYTHONUTF8` unset): `40 failed / 22 errors` before and after, **zero new failures** by `comm -13` against the post-#695 baseline ID set.
- EOL integrity verified clean on every changed file (`--ignore-cr-at-eol` numstat matches raw).
- `ruff check .` and `black --check` clean.

## Still open after this

The remaining `40 failed / 22 errors` are ruff-invisible `.read_text()` calls on `/`-built paths. PR 3 covers those plus the CI guard job and the two residual non-encoding failures, both already root-caused.
