### PR TITLE
fix(scan): end the progress-tracker deadlock and stop reporting silent tool failures as success

### DIFF
--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -2504,7 +2504,13 @@ class ProgressTracker:
         self.total = total
         self.completed = 0
         self.args = args
-        self._lock = threading.Lock()
+        # RLock, not Lock: update_tool() holds this lock and then calls log()
+        # for the "retrying", "timeout" and "no_output" statuses, and log()
+        # acquires it too. With a plain Lock that is an unconditional deadlock
+        # -- the whole scan hangs forever on the first tool retry or timeout,
+        # because the stuck worker never completes its future. Measured: those
+        # three statuses never returned; "start"/"success"/"error" did.
+        self._lock = threading.RLock()
         self._start_time: float | None = None
         # Tool-level progress tracking
         self.total_tools = total_tools
@@ -2689,7 +2695,7 @@ class ProgressTracker:
 
         Args:
             tool_name: Name of the tool (may include phase suffix)
-            status: "start"/"success"/"error"/"retrying"/"timeout"
+            status: "start"/"success"/"no_output"/"error"/"retrying"/"timeout"
             findings_count: Number of findings (unused for now)
             message: Optional message (e.g., timeout reason)
             attempt: Current attempt number (for retries)
@@ -2712,6 +2718,14 @@ class ProgressTracker:
                 self.log(
                     "ERROR",
                     f"{base_tool_name}: Timed out after {max_attempts} attempts",
+                )
+                # Fall through to mark as failed
+
+            if status == "no_output":
+                self.log(
+                    "ERROR",
+                    f"{base_tool_name}: exited with an accepted code but wrote no "
+                    f"output file - its findings are MISSING from this scan",
                 )
                 # Fall through to mark as failed
 

--- a/scripts/cli/rich_progress.py
+++ b/scripts/cli/rich_progress.py
@@ -329,6 +329,14 @@ class RichScanProgressTracker:
                 )
                 # Fall through to mark as failed
 
+            if status == "no_output":
+                self.console.print(
+                    f"[red]ERROR[/] {base_tool_name}: exited with an accepted code "
+                    f"but wrote no output file - its findings are MISSING "
+                    f"from this scan"
+                )
+                # Fall through to mark as failed
+
             if status == "start":
                 self.tools_in_progress.add(tool_name)
                 self._tool_start_times[tool_name] = time.time()
@@ -343,9 +351,12 @@ class RichScanProgressTracker:
                 if base_tool_name not in self._completed_base_tools:
                     self._completed_base_tools.add(base_tool_name)
                     self.tools_completed += 1
-                    # Map timeout to error for status tracking
+                    # Map timeout and no_output to error for status tracking.
+                    # The summary panel tallies "success" and "error" separately,
+                    # so any third status would land in neither and the counts
+                    # would silently stop adding up to the tool total.
                     self.tool_status[base_tool_name] = (
-                        "error" if status == "timeout" else status
+                        "error" if status in ("timeout", "no_output") else status
                     )
 
                     # Update tool progress bar

--- a/scripts/core/tool_runner.py
+++ b/scripts/core/tool_runner.py
@@ -45,7 +45,8 @@ class ProgressCallback(Protocol):
 
         Args:
             tool_name: Name of the tool
-            status: Status string ("start", "success", "error", "retrying", "timeout")
+            status: Status string ("start", "success", "no_output", "error",
+                "retrying", "timeout")
             findings_count: Number of findings (optional)
             message: Additional context (e.g., timeout reason)
             attempt: Current attempt number
@@ -104,7 +105,9 @@ class ToolResult:
 
     Attributes:
         tool: Tool name
-        status: Execution status ("success", "timeout", "error", "retry_exhausted")
+        status: Execution status ("success", "no_output", "timeout", "error",
+            "retry_exhausted"). "no_output" means the return code was acceptable
+            but the tool wrote nothing to its declared output_file.
         returncode: Process return code (or -1 if timeout/error)
         stdout: Standard output (empty if not captured)
         stderr: Standard error output
@@ -185,11 +188,35 @@ class ToolRunner:
             max_workers: Maximum number of parallel workers (default: 4)
             progress_callback: Optional callback for tool status updates.
                               Called with (tool_name, status, findings_count, **kwargs).
-                              Status values: "start", "success", "error", "retrying", "timeout"
+                              Status values: "start", "success", "no_output",
+                              "error", "retrying", "timeout"
         """
         self.tools = tools
         self.max_workers = max_workers
         self.progress_callback = progress_callback
+
+    @staticmethod
+    def _missing_declared_output(tool: ToolDefinition) -> bool:
+        """Whether a tool that had to write its own output file failed to.
+
+        Only meaningful when ``capture_stdout`` is False. When it is True the
+        caller writes the file from captured stdout *after* ``run_tool`` returns
+        (see ``scan_jobs/*_scanner.py``), so absence at this point proves
+        nothing. ``output_file=None`` declares that no file is expected at all
+        (noseyparker's init/scan phases).
+
+        Returns False when the path cannot be stat'd: on Python 3.12+
+        ``Path.exists()`` propagates ``PermissionError`` rather than returning
+        False (see ``.claude/rules/testing.cross-platform.rules.md``), and an
+        unreadable path is not evidence of absence -- failing open keeps a
+        permissions quirk from reddening an otherwise good scan.
+        """
+        if tool.output_file is None or tool.capture_stdout:
+            return False
+        try:
+            return not tool.output_file.exists()
+        except OSError:
+            return False
 
     @staticmethod
     def _classify_failure(exc: Exception | None, returncode: int | None) -> str:
@@ -248,6 +275,32 @@ class ToolRunner:
 
                 # Check if return code is acceptable
                 if result.returncode in tool.ok_return_codes:
+                    # An acceptable return code is necessary but NOT sufficient.
+                    # A tool told exactly where to write (every capture_stdout=False
+                    # site passes -o/--output/-out=) can exit acceptably and write
+                    # nothing: it may crash after startup, or the code may itself
+                    # mean "I did nothing" -- prowler's 3 is "no credentials", and
+                    # semgrep's 2 is "errors". Reporting that as success is not
+                    # recoverable downstream, because normalize_and_report globs
+                    # for files that exist and so cannot see one that is absent.
+                    # This is the only layer that knows what was expected.
+                    if self._missing_declared_output(tool):
+                        duration = time.perf_counter() - start_time
+                        return ToolResult(
+                            tool=tool.name,
+                            status="no_output",
+                            returncode=result.returncode,
+                            stderr=result.stderr,
+                            attempts=attempt,
+                            duration=duration,
+                            output_file=tool.output_file,
+                            capture_stdout=tool.capture_stdout,
+                            error_message=(
+                                f"Exited {result.returncode} (an accepted code) but "
+                                f"wrote no output to {tool.output_file}"
+                            ),
+                        )
+
                     duration = time.perf_counter() - start_time
                     return ToolResult(
                         tool=tool.name,

--- a/tests/cli/test_progress_tracker.py
+++ b/tests/cli/test_progress_tracker.py
@@ -3,6 +3,7 @@
 
 # Import ProgressTracker from jmo.py
 import sys
+import threading
 from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
@@ -228,6 +229,90 @@ class TestProgressTracker:
             tracker.update("repo", "repo1", 1.0)
             message = mock_log.call_args[0][2]
             assert "calculating..." in message
+
+
+class TestUpdateToolDoesNotDeadlock:
+    """`update_tool` must not deadlock on statuses that log from inside the lock.
+
+    `update_tool` takes `self._lock`, and three of its status branches --
+    "retrying", "timeout" and "no_output" -- then call `self.log()`, which
+    acquires the same lock. With a plain `threading.Lock` that is an
+    unconditional self-deadlock, and it is not a cosmetic one: the worker
+    thread never returns, so its future never completes, so `scan_all()` blocks
+    on `future.result()` and the entire scan hangs forever. Measured before the
+    fix (`threading.Lock` -> `threading.RLock`), with a 5s watchdog:
+
+        start      returned
+        success    returned
+        retrying   NO -- deadlock
+        timeout    NO -- deadlock
+        error      returned
+        no_output  NO -- deadlock
+
+    Every status is exercised here rather than only the three known-bad ones,
+    so a future branch that logs from inside the lock is caught by this test
+    instead of by a hung scan.
+    """
+
+    # Each status only formats and prints, so anything beyond a second is a
+    # deadlock rather than slowness. Generous for a loaded CI runner.
+    WATCHDOG_S = 20.0
+
+    @pytest.mark.parametrize(
+        "status",
+        ["start", "success", "retrying", "timeout", "error", "no_output"],
+    )
+    def test_update_tool_returns_for_status(self, status: str) -> None:
+        args = Namespace(human_logs=True, verbose=False, quiet=False)
+        tracker = ProgressTracker(total=1, args=args, total_tools=1)
+        returned = threading.Event()
+
+        def call_update_tool() -> None:
+            try:
+                tracker.update_tool(
+                    "semgrep",
+                    status,
+                    0,
+                    message="watchdog probe",
+                    attempt=1,
+                    max_attempts=1,
+                )
+            finally:
+                returned.set()
+
+        # Daemon thread + Event.wait, never a bare join(): a deadlocked thread
+        # must not be able to hang the suite (see
+        # .claude/rules/testing.cross-platform.rules.md).
+        worker = threading.Thread(target=call_update_tool, daemon=True)
+        worker.start()
+
+        assert returned.wait(self.WATCHDOG_S), (
+            f"ProgressTracker.update_tool() never returned for status={status!r} "
+            f"within {self.WATCHDOG_S}s. This is the self-deadlock described in "
+            "this class's docstring: a branch logging from inside self._lock "
+            "while _lock is a non-reentrant threading.Lock. In a real scan this "
+            "hangs the whole run, because the tool's future never completes."
+        )
+
+    def test_lock_is_reentrant(self) -> None:
+        """Guard the mechanism directly, not just the symptom.
+
+        The parametrized test above would also pass if someone "fixed" the hang
+        by deleting the log calls. This asserts the property that makes
+        logging-from-inside-the-lock safe in the first place.
+        """
+        args = Namespace(human_logs=True, verbose=False, quiet=False)
+        tracker = ProgressTracker(total=1, args=args, total_tools=1)
+
+        with tracker._lock:
+            acquired_again = tracker._lock.acquire(timeout=5)
+            if acquired_again:
+                tracker._lock.release()
+
+        assert acquired_again, (
+            "ProgressTracker._lock is not reentrant. update_tool() holds it and "
+            "calls log(), which acquires it again -- that requires RLock."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_tool_runner.py
+++ b/tests/unit/test_tool_runner.py
@@ -61,8 +61,8 @@ def test_duration_is_measured_with_perf_counter() -> None:
             "Use time.perf_counter() -- see this test's docstring for measurements."
         )
 
-    assert text.count("time.perf_counter()") == 4, (
-        "Expected 4 perf_counter() calls (1 start_time + 3 duration subtractions). "
+    assert text.count("time.perf_counter()") == 5, (
+        "Expected 5 perf_counter() calls (1 start_time + 4 duration subtractions). "
         "If a return path was added or removed, update this count -- but every "
         "elapsed-time measurement in the file must use the same clock."
     )
@@ -218,7 +218,10 @@ class TestToolRunner:
         tool = ToolDefinition(
             name="echo",
             command=["echo", "hello"],
-            output_file=Path("/tmp/echo.json"),
+            # None, not a path: `echo` writes no file, and run_tool now treats a
+            # declared-but-unwritten output_file as "no_output" rather than
+            # success. See TestDeclaredOutputFile for that contract.
+            output_file=None,
             timeout=5,
         )
 
@@ -272,7 +275,7 @@ class TestToolRunner:
         tool = ToolDefinition(
             name="false",
             command=["false"],  # Always returns 1
-            output_file=Path("/tmp/false.json"),
+            output_file=None,  # `false` writes no file
             ok_return_codes=(0, 1),  # Accept both 0 and 1
             retries=2,
         )
@@ -308,17 +311,17 @@ class TestToolRunner:
             ToolDefinition(
                 name="echo1",
                 command=["echo", "test1"],
-                output_file=Path("/tmp/echo1.json"),
+                output_file=None,
             ),
             ToolDefinition(
                 name="echo2",
                 command=["echo", "test2"],
-                output_file=Path("/tmp/echo2.json"),
+                output_file=None,
             ),
             ToolDefinition(
                 name="echo3",
                 command=["echo", "test3"],
-                output_file=Path("/tmp/echo3.json"),
+                output_file=None,
             ),
         ]
 
@@ -340,12 +343,12 @@ class TestToolRunner:
             ToolDefinition(
                 name="echo1",
                 command=["echo", "test1"],
-                output_file=Path("/tmp/echo1.json"),
+                output_file=None,
             ),
             ToolDefinition(
                 name="echo2",
                 command=["echo", "test2"],
-                output_file=Path("/tmp/echo2.json"),
+                output_file=None,
             ),
         ]
 
@@ -411,7 +414,7 @@ class TestToolRunner:
         tool = ToolDefinition(
             name="echo",
             command=["echo", "not captured"],
-            output_file=Path("/tmp/echo.json"),
+            output_file=None,  # `echo` writes no file
             capture_stdout=False,
         )
 
@@ -431,12 +434,12 @@ class TestRunToolsConvenienceFunction:
             ToolDefinition(
                 name="test1",
                 command=["echo", "test1"],
-                output_file=Path("/tmp/test1.json"),
+                output_file=None,
             ),
             ToolDefinition(
                 name="test2",
                 command=["echo", "test2"],
-                output_file=Path("/tmp/test2.json"),
+                output_file=None,
             ),
         ]
 
@@ -451,12 +454,12 @@ class TestRunToolsConvenienceFunction:
             ToolDefinition(
                 name="test1",
                 command=["echo", "test1"],
-                output_file=Path("/tmp/test1.json"),
+                output_file=None,
             ),
             ToolDefinition(
                 name="test2",
                 command=["echo", "test2"],
-                output_file=Path("/tmp/test2.json"),
+                output_file=None,
             ),
         ]
 
@@ -482,7 +485,7 @@ class TestEdgeCases:
             ToolDefinition(
                 name="echo",
                 command=["echo", "test"],
-                output_file=Path("/tmp/echo.json"),
+                output_file=None,  # `echo` writes no file
             )
         ]
 
@@ -500,7 +503,7 @@ class TestEdgeCases:
             ToolDefinition(
                 name=f"echo{i}",
                 command=["echo", f"test{i}"],
-                output_file=Path(f"/tmp/echo{i}.json"),
+                output_file=None,
             )
             for i in range(num_tools)
         ]
@@ -648,7 +651,7 @@ class TestErrorHandling:
         tool = ToolDefinition(
             name="findings-ok",
             command=["sh", "-c", "exit 1"],  # Exit 1 (findings detected)
-            output_file=Path("/tmp/findings.json"),
+            output_file=None,  # `sh -c "exit 1"` writes no file
             ok_return_codes=(0, 1),  # Accept 0 and 1
             retries=0,
         )
@@ -668,7 +671,7 @@ class TestErrorHandling:
             ToolDefinition(
                 name="success",
                 command=["echo", "ok"],
-                output_file=Path("/tmp/success.json"),
+                output_file=None,
             ),
             ToolDefinition(
                 name="timeout",
@@ -706,7 +709,7 @@ class TestErrorHandling:
             ToolDefinition(
                 name="good1",
                 command=["echo", "test1"],
-                output_file=Path("/tmp/good1.json"),
+                output_file=None,
             ),
             ToolDefinition(
                 name="bad",
@@ -716,7 +719,7 @@ class TestErrorHandling:
             ToolDefinition(
                 name="good2",
                 command=["echo", "test2"],
-                output_file=Path("/tmp/good2.json"),
+                output_file=None,
             ),
         ]
 
@@ -892,7 +895,7 @@ class TestProgressCallback:
         tool = ToolDefinition(
             name="fast-tool",
             command=["echo", "done"],
-            output_file=Path("/tmp/fast.json"),
+            output_file=None,
             timeout=10,
         )
 
@@ -1070,6 +1073,182 @@ class TestRetryConfigIntegration:
             result = runner.run_tool(tool)
         assert result.status == "retry_exhausted"
         assert result.attempts == 2  # retries=1 -> max_attempts=2
+
+
+class TestDeclaredOutputFile:
+    """An acceptable return code alone must not be reported as success.
+
+    Every `capture_stdout=False` tool in `scan_jobs/` is told exactly where to
+    write (`-o` / `--output` / `-out=` / prowler's `--output-directory` +
+    `--output-filename`). A tool that exits acceptably and writes nothing there
+    has not done its job, and two of the accepted codes *mean* "I did nothing":
+    prowler's 3 is "no credentials", semgrep's 2 is "errors".
+
+    This is unrecoverable further down the pipeline. `normalize_and_report`
+    discovers outputs with `target.glob("*.json")`, so it only ever sees files
+    that exist -- it holds no manifest of what was expected and therefore cannot
+    notice an absence. `run_tool` is the only layer that knows.
+
+    The user-visible bug: `jmo` printed `[1/1] OK semgrep [100%]` for a semgrep
+    that crashed on a non-UTF-8 Windows console and wrote nothing, so the scan
+    looked clean while semgrep's findings were silently missing.
+    """
+
+    @staticmethod
+    def _ok_subprocess(returncode: int = 0):
+        mock_result = MagicMock()
+        mock_result.returncode = returncode
+        mock_result.stdout = "some stdout"
+        mock_result.stderr = ""
+        return mock_result
+
+    def test_missing_output_file_is_not_success(self, tmp_path: Path):
+        """rc=0 but no file written -> no_output, not success."""
+        tool = ToolDefinition(
+            name="crasher",
+            command=["crasher", "-o", str(tmp_path / "crasher.json")],
+            output_file=tmp_path / "crasher.json",  # never created
+            capture_stdout=False,
+        )
+
+        runner = ToolRunner([tool])
+        with patch("subprocess.run", return_value=self._ok_subprocess(0)):
+            result = runner.run_tool(tool)
+
+        assert result.status == "no_output"
+        assert result.is_success() is False
+        assert result.returncode == 0
+        # The message must name the path, or a user cannot tell which file is
+        # missing when several tools run in parallel.
+        assert str(tool.output_file) in result.error_message
+
+    def test_written_output_file_is_success(self, tmp_path: Path):
+        """The same tool succeeds once the file exists -- proves the guard
+        discriminates rather than failing everything."""
+        out = tmp_path / "good.json"
+        out.write_bytes(b'{"results": []}')
+        tool = ToolDefinition(
+            name="good",
+            command=["good", "-o", str(out)],
+            output_file=out,
+            capture_stdout=False,
+        )
+
+        runner = ToolRunner([tool])
+        with patch("subprocess.run", return_value=self._ok_subprocess(0)):
+            result = runner.run_tool(tool)
+
+        assert result.status == "success"
+        assert result.is_success() is True
+
+    def test_empty_output_file_is_still_success(self, tmp_path: Path):
+        """A zero-findings run is a real result. Only *absence* is the failure --
+        an empty or empty-JSON file means the tool ran and found nothing."""
+        out = tmp_path / "empty.json"
+        out.write_bytes(b"")
+        tool = ToolDefinition(
+            name="clean",
+            command=["clean", "-o", str(out)],
+            output_file=out,
+            capture_stdout=False,
+        )
+
+        runner = ToolRunner([tool])
+        with patch("subprocess.run", return_value=self._ok_subprocess(0)):
+            result = runner.run_tool(tool)
+
+        assert result.status == "success"
+
+    def test_capture_stdout_tools_are_exempt(self, tmp_path: Path):
+        """With capture_stdout=True the *caller* writes the file after run_tool
+        returns (scan_jobs/*_scanner.py), so absence here proves nothing."""
+        tool = ToolDefinition(
+            name="stdout-tool",
+            command=["stdout-tool"],
+            output_file=tmp_path / "not-yet-written.json",
+            capture_stdout=True,
+        )
+
+        runner = ToolRunner([tool])
+        with patch("subprocess.run", return_value=self._ok_subprocess(0)):
+            result = runner.run_tool(tool)
+
+        assert result.status == "success"
+        assert result.stdout == "some stdout"
+
+    def test_no_declared_output_file_is_exempt(self):
+        """output_file=None declares that no file is expected at all
+        (noseyparker's init and scan phases)."""
+        tool = ToolDefinition(
+            name="noseyparker-init",
+            command=["noseyparker", "datastore", "init"],
+            output_file=None,
+            capture_stdout=False,
+        )
+
+        runner = ToolRunner([tool])
+        with patch("subprocess.run", return_value=self._ok_subprocess(0)):
+            result = runner.run_tool(tool)
+
+        assert result.status == "success"
+
+    def test_accepted_but_did_nothing_code_is_caught(self, tmp_path: Path):
+        """prowler's ok_return_codes includes 3 == "no credentials". That is an
+        accepted code for a run that cannot have produced findings."""
+        tool = ToolDefinition(
+            name="prowler",
+            command=["prowler", "--output-directory", str(tmp_path)],
+            output_file=tmp_path / "prowler.json",  # never created
+            ok_return_codes=(0, 1, 3),
+            capture_stdout=False,
+        )
+
+        runner = ToolRunner([tool])
+        with patch("subprocess.run", return_value=self._ok_subprocess(3)):
+            result = runner.run_tool(tool)
+
+        assert result.status == "no_output"
+        assert result.returncode == 3
+
+    def test_unstattable_output_file_fails_open(self, tmp_path: Path):
+        """An unreadable path is not evidence of absence.
+
+        Python 3.12 made `Path.exists()` propagate `PermissionError` instead of
+        returning False (see .claude/rules/testing.cross-platform.rules.md).
+        A permissions quirk on a bind mount must not redden an otherwise good
+        scan, and must certainly not raise out of run_tool.
+        """
+        out = tmp_path / "unstattable.json"
+        tool = ToolDefinition(
+            name="mounted",
+            command=["mounted", "-o", str(out)],
+            output_file=out,
+            capture_stdout=False,
+        )
+
+        runner = ToolRunner([tool])
+        with (
+            patch("subprocess.run", return_value=self._ok_subprocess(0)),
+            patch.object(
+                Path, "exists", side_effect=PermissionError("EACCES on bind mount")
+            ),
+        ):
+            result = runner.run_tool(tool)
+
+        assert result.status == "success"
+
+    def test_no_output_counts_as_failed_in_summary(self):
+        """get_summary() must not count no_output as successful."""
+        results = [
+            ToolResult(tool="ok", status="success", returncode=0, duration=1.0),
+            ToolResult(tool="silent", status="no_output", returncode=0, duration=1.0),
+        ]
+
+        summary = ToolRunner([]).get_summary(results)
+
+        assert summary["successful"] == 1
+        assert summary["failed"] == 1
+        assert summary["results_by_status"]["no_output"] == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two defects on the **non-Rich scan path**, which is the default path. `use_rich_progress` requires `from_wizard` AND `human_logs` AND `stderr.isatty()` (`scripts/cli/jmo.py:2986`), so plain `jmo scan`, CI runs and container runs all use `ProgressTracker`.

**1. A deadlock that hangs the scan.** `ProgressTracker._lock` was a non-reentrant `threading.Lock`, but `update_tool()` holds it and then calls `log()` for the `retrying` and `timeout` statuses — and `log()` acquires the same lock. One thread taking a non-reentrant lock twice blocks forever, so the worker never completes its future and the run hangs. Only the unhappy path reaches it, which is why it survived. Fixed with `threading.RLock`.

**2. A silent tool failure reported as success.** A tool exiting with an accepted return code but writing nothing to its declared `output_file` was reported as success — its findings simply missing from the scan, with a green tick next to the tool's name. Adds a `no_output` status, threaded through both trackers, that renders as an error and counts as failed in the summary.

The `no_output` check is deliberately narrow, and each exemption is load-bearing:
- `capture_stdout` tools are exempt — the caller writes their file *after* `run_tool` returns, so absence at that point proves nothing.
- `output_file=None` is exempt — no file is expected at all (noseyparker's init/scan phases).
- An unstattable path **fails open**, because Python 3.12 propagates `PermissionError` out of `Path.exists()` and an unreadable path is not evidence of absence. This is the same OSError-propagation trap documented in `testing.cross-platform.rules.md`.

## Provenance

This work was written 2026-07-29 during the Windows encoding burn-down (#695–#698) and left **uncommitted in a worktree** when that session ended — invisible to `gh pr list`, `git log`, and CI alike. Found by enumerating worktrees and running `git status` in each. Defect 2 is the item recorded as still-open in that work's notes ("a crashed tool that wrote nothing renders as ✓"); defect 1 was found alongside it.

## Evidence

CI can run these tests, but it **cannot tell you whether the tests would pass without the fix** — and tests authored alongside a fix are worthless if they would. So each fix was reverted and its tests re-run. Both fail, for the right reason:

| Mutation | Result |
|---|---|
| `RLock` → `Lock` (restore the deadlock) | `1 failed` — `TestUpdateToolDoesNotDeadlock::test_update_tool_returns_for_status[retrying]`: *"update_tool() never returned for status='retrying' within 20.0s"*. The test uses a watchdog thread, so it reports the hang instead of hanging the suite. |
| `if self._missing_declared_output(tool):` → `if False:` (restore old behavior) | `2 failed` — `test_missing_output_file_is_not_success` and `test_accepted_but_did_nothing_code_is_caught`, both `assert 'success' == 'no_output'`. |

Both mutations reverted; tree verified clean before push.

Unmutated results:
- Touched files: `72 passed, 3 skipped`
- Regression sweep, `tests/cli tests/unit tests/integration` with the CI marker filter: **`4541 passed, 66 skipped, 120 deselected`** in 8m54s (Windows, Python 3.12.10)

The deadlock is live on `main` today (`scripts/cli/jmo.py:2507` is `threading.Lock()` at `1aea24a`), so this is a bug fix, not a hardening change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scans no longer stall when tools retry, time out, or report progress during failures.
  * Tools that exit successfully but fail to create their expected output are now reported as errors.
  * Missing tool output is clearly surfaced in scan progress and included in failure summaries.
  * Empty output files and tools that capture results directly remain supported as successful outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->