### PR TITLE
release: v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to JMo Security will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-07-30
+
+Two classes of silent failure are fixed in this release: a scan that could hang forever, and tools whose findings went missing while the scan reported success. Both affected the **default** (non-wizard) scan path, including CI and container runs. Windows users additionally get a `jmo` that no longer crashes on a console that isn't UTF-8.
+
+### Fixed
+
+- **Scans no longer hang when a tool retries or times out.** `ProgressTracker._lock` was a non-reentrant `threading.Lock`, but `update_tool()` held it and then called `log()` for the `retrying` and `timeout` statuses — and `log()` acquires the same lock. A single thread taking a non-reentrant lock twice blocks forever, so the worker's future never completed and the whole run stalled. Only the unhappy path reached it, which is why it survived several releases. Now a `threading.RLock`. The Rich progress display was unaffected, but it is only selected for wizard scans with human logs on a TTY — so plain `jmo scan`, CI, and container runs all took the affected path. ([#700](https://github.com/jimmy058910/jmo-security-repo/pull/700))
+- **A tool that exits cleanly but writes no output is no longer reported as success.** Previously such a tool rendered with a green checkmark while its findings were silently absent from the scan. A new `no_output` status renders as an error and counts as failed in the summary. The check is deliberately narrow: tools using `capture_stdout` are exempt (their file is written after the run returns), a tool declaring no `output_file` is exempt, and an unreadable path fails open, since Python 3.12 propagates `PermissionError` out of `Path.exists()` and an unstattable path is not evidence of absence. ([#700](https://github.com/jimmy058910/jmo-security-repo/pull/700))
+- **`jmo` no longer crashes with `UnicodeEncodeError` on a non-UTF-8 console.** Windows consoles defaulting to cp1252 (and cp437/cp850) could kill the CLI outright on emoji or box-drawing output. Console streams are now hardened at the stream level rather than at individual call sites, with a fallback table as a quality layer rather than the guarantee. File I/O now specifies an explicit encoding across the codebase. ([#695](https://github.com/jimmy058910/jmo-security-repo/pull/695), [#696](https://github.com/jimmy058910/jmo-security-repo/pull/696), [#698](https://github.com/jimmy058910/jmo-security-repo/pull/698))
+- **Tool durations no longer report as `0.0` on Windows.** Timing used `time.monotonic()`, which on Windows is backed by `GetTickCount64` at ~15 ms granularity — coarser than the operations being measured. Now `time.perf_counter()` (~100 ns). ([#692](https://github.com/jimmy058910/jmo-security-repo/pull/692))
+- **Dashboard transitive advisories** — `brace-expansion` and `js-yaml` pinned to patched versions via `overrides`. ([#676](https://github.com/jimmy058910/jmo-security-repo/pull/676))
+
+### Changed
+
+- **Dev dependencies migrated to PEP 735 `[dependency-groups]` with a tracked `uv.lock`.** **This changes contributor setup:** `pip install -e ".[dev]"` no longer works — use **`uv sync --group dev`**. `requirements-dev.in`, `requirements-dev.txt`, and `scripts/dev/update_dependencies.py` are removed; `uv.lock` is now the only lockfile and Dependabot runs on the `uv` ecosystem, so bot and human PRs resolve symmetrically. This structurally eliminates the lockfile-drift class where two different resolvers fought over one file — which had been silently dropping `pywin32` and breaking Windows dev installs. Relock with `make deps-lock`. ([#683](https://github.com/jimmy058910/jmo-security-repo/pull/683), [#687](https://github.com/jimmy058910/jmo-security-repo/pull/687), [#689](https://github.com/jimmy058910/jmo-security-repo/pull/689))
+- **Adopted `mcp` 2.0** — `FastMCP` is now `MCPServer`. ([#693](https://github.com/jimmy058910/jmo-security-repo/pull/693))
+- **Ruff's ruleset is now pinned explicitly** rather than inheriting the tool's expanding defaults, which had reddened CI on unchanged code across a version bump. ([#678](https://github.com/jimmy058910/jmo-security-repo/pull/678), [#681](https://github.com/jimmy058910/jmo-security-repo/pull/681))
+
+### Security
+
+- **Retired the `tuf` `--ignore-vuln` suppression** now that a fix is reachable (sigstore 4.5.0 lifted its `tuf<7` cap). Only the disputed, fix-less `PYSEC-2025-183` ignore remains, and `test_dep_audit_drift.py` now fails if a retired ignore returns. An ignore is justified only while nothing is adoptable. ([#688](https://github.com/jimmy058910/jmo-security-repo/pull/688), closes [#539](https://github.com/jimmy058910/jmo-security-repo/issues/539))
+
+### Internal
+
+- **Visual-regression CI restored** — the `e2e-visual` job installed `pytest-playwright` with bare `pip`, which after the uv migration resolved to the runner's system Python while the tests ran from `.venv`; the plugin was invisible and the job collected zero tests. Now installed through the lock. ([#699](https://github.com/jimmy058910/jmo-security-repo/pull/699))
+- **Release Playbook** with hard-won gotchas added to the release docs. ([#644](https://github.com/jimmy058910/jmo-security-repo/pull/644))
+- **Contributor guidance**: merges are gated on evidence a CI run cannot provide, and plans are treated as hypotheses until measured. ([#697](https://github.com/jimmy058910/jmo-security-repo/pull/697))
+- Dependency bumps across the python, github-actions, dashboard, and api groups, plus the weekly security-tool and pre-commit-hook auto-update.
+
 ## [1.0.6] - 2026-07-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jmo-security"
-version = "1.0.6"
+version = "1.0.7"
 description = "JMo Security Audit Suite (terminal-first, multi-tool, unified outputs, multi-target scanning)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -41,7 +41,7 @@ from scripts.core.unicode_utils import (
 logger = logging.getLogger(__name__)
 
 # Version (from pyproject.toml)
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 
 def _merge_dict(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/jmo_mcp/__init__.py
+++ b/scripts/jmo_mcp/__init__.py
@@ -18,5 +18,5 @@ Architecture:
 - Transport: stdio, HTTP, SSE
 """
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 __all__ = ["jmo_server"]

--- a/uv.lock
+++ b/uv.lock
@@ -699,7 +699,7 @@ wheels = [
 
 [[package]]
 name = "jmo-security"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Mechanical release-prep for **v1.0.7**, kept separate from content per the repo's 2-PR release cadence.

- Bumps the **three** hand-maintained version sites: `pyproject.toml:7`, `scripts/cli/jmo.py:44`, `scripts/jmo_mcp/__init__.py:21`. (No test asserts these stay in sync — worth adding sometime; the MCP one is easy to miss.)
- Relocks `uv.lock` for the new project version. Diff is exactly one line (`version = "1.0.6"` -> `"1.0.7"`), not a resolve churn — the `uv-lock` pre-commit hook caught the stale lock and blocked the first commit attempt, which is the gate working as designed.
- Adds the v1.0.7 `CHANGELOG.md` entry covering the **41 commits** since v1.0.6.

## Why now

Two silent-failure bugs on the **default** (non-wizard) scan path are present in the currently-published v1.0.6 artifacts, so they affect anyone using the PyPI package or the GHCR images today:

1. **A deadlock that hangs the scan.** `ProgressTracker._lock` was a non-reentrant `threading.Lock`, while `update_tool()` held it and then called `log()` — which acquires the same lock — for the `retrying` and `timeout` statuses. Any scan whose tool retried or timed out hung permanently.
2. **Tools reporting success while writing nothing**, so their findings were missing from the scan behind a green checkmark.

Both fixed in #700; a fix on `main` doesn't reach users until a tag rebuilds the images and republishes the package.

Also shipping: the Windows console-encoding burn-down (#695/#696/#698), the `perf_counter` timing fix (#692), mcp 2.0 (#693), the uv.lock dependency migration (#683/#687/#688), and the e2e-visual CI restoration (#699).

## Contributor-facing change worth flagging

The uv migration means **`pip install -e ".[dev]"` no longer works** — setup is now `uv sync --group dev`. Called out explicitly under "Changed" in the changelog since it will otherwise surprise contributors.

## Verification

CI on this PR is the gate for the mechanical change itself. The content it releases was verified in its own PRs — #700 in particular carried mutation testing (each fix reverted to prove its tests genuinely fail without it: 1 failed for the deadlock, 2 failed for the no-output guard) plus a 4541-passed regression sweep.

After merge: tag `v1.0.7` to trigger `release.yml`. Per prior release lessons, the tag push alone drives the pipeline — no `workflow_dispatch` on top of it.