### PR TITLE
fix(doc-links): close three real gaps in the guard, and plan the 103-finding remediation

### DIFF
--- a/docs/SAMPLE_OUTPUTS.md
+++ b/docs/SAMPLE_OUTPUTS.md
@@ -191,4 +191,4 @@ Upload to GitHub: `gh code-scanning upload -r owner/repo -s findings.sarif`
 
 ---
 
-**Documentation:** [docs/RESULTS_GUIDE.md](docs/RESULTS_GUIDE.md) for complete output format specification.
+**Documentation:** [docs/RESULTS_GUIDE.md](RESULTS_GUIDE.md) for complete output format specification.

--- a/docs/TRENDS_GUIDE.md
+++ b/docs/TRENDS_GUIDE.md
@@ -746,7 +746,7 @@ docker run --rm \
 
 **Docker Compose Example:**
 
-See [docker-compose.trends.yml](../docker-compose.trends.yml) for complete example with volume persistence and multi-stage workflows.
+See [docker-compose.trends.yml](examples/docker-compose.trends.yml) for complete example with volume persistence and multi-stage workflows.
 
 ---
 

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -33,7 +33,7 @@ JMo Security Suite uses a **5-layer version management system** to ensure Docker
 
 1. **[versions.yaml](../versions.yaml)** — Single source of truth for all tool versions
 2. **[update_versions.py](../scripts/dev/update_versions.py)** — Automation script for updates
-3. **[version-check.yml](../.github/workflows/version-check.yml)** — Weekly CI checks + issue creation
+3. **[maintenance.yml](../.github/workflows/maintenance.yml) (`check-versions` job)** — Weekly CI checks + issue creation
 4. **[dependabot.yml](../.github/dependabot.yml)** — Python/Docker/Actions dependency updates
 5. **Dockerfile sync** — Automated version propagation across 3 Docker variants
 
@@ -72,7 +72,7 @@ binary_tools:
 
 ### Layer 2: Automated Version Checker
 
-**[.github/workflows/version-check.yml](../.github/workflows/version-check.yml)**
+**[.github/workflows/maintenance.yml](../.github/workflows/maintenance.yml) (`check-versions` job)**
 
 Runs weekly (Sunday 00:00 UTC) to:
 
@@ -436,7 +436,7 @@ Binary Tools:
 
 ### Weekly Version Check Workflow
 
-**[.github/workflows/version-check.yml](../.github/workflows/version-check.yml)**
+**[.github/workflows/maintenance.yml](../.github/workflows/maintenance.yml) (`check-versions` job)**
 
 **Trigger:** Weekly (Sunday 00:00 UTC) + manual dispatch
 
@@ -463,7 +463,7 @@ Binary Tools:
 # Trigger from GitHub UI: Actions → Version Consistency Check → Run workflow
 
 # Or via GitHub CLI:
-gh workflow run version-check.yml -f create_issues=true
+gh workflow run maintenance.yml -f task=check-versions
 ```
 
 ### CI Validation
@@ -631,7 +631,7 @@ gh pr create --title "deps(tools): monthly tool updates (Jan 2025)"
 
 Wait for:
 
-- ✅ version-check.yml validates consistency
+- ✅ maintenance.yml's `check-versions` job validates consistency
 - ✅ ci.yml tests pass (Ubuntu/macOS/Windows × Python 3.12/3.13)
 - ✅ Docker builds succeed (multi-arch: amd64, arm64)
 

--- a/docs/examples/slack-notifications.md
+++ b/docs/examples/slack-notifications.md
@@ -682,4 +682,4 @@ script:
 - [SCHEDULE_GUIDE.md](../SCHEDULE_GUIDE.md) — Complete schedule management guide
 - [Slack Block Kit Builder](https://app.slack.com/block-kit-builder) — Visual message builder
 - [Slack API: Incoming Webhooks](https://api.slack.com/messaging/webhooks) — Official documentation
-- [GitLab CI Examples](../.gitlab-ci.yml) — Complete GitLab CI configurations
+- [GitLab CI Examples](.gitlab-ci.yml) — Complete GitLab CI configurations

--- a/docs/internal/BUILD_OPTIMIZATION.md
+++ b/docs/internal/BUILD_OPTIMIZATION.md
@@ -1218,4 +1218,4 @@ GPU acceleration is **not applicable** to build optimization:
 - [Docker BuildKit Documentation](https://docs.docker.com/build/buildkit/)
 - [BuildKit Heredocs](https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/)
 - [Python ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html)
-- [JMo Security Tool Registry](../scripts/core/tool_registry.py)
+- [JMo Security Tool Registry](../../scripts/core/tool_registry.py)

--- a/docs/internal/MANUAL_TESTING_CHECKLIST.md
+++ b/docs/internal/MANUAL_TESTING_CHECKLIST.md
@@ -7,8 +7,8 @@
 **Related Documentation:**
 
 - [TESTING_MATRIX.md](TESTING_MATRIX.md) - Automated test coverage analysis
-- [PLATFORM_NOTES.md](PLATFORM_NOTES.md) - Cross-platform development guide
-- [TEST.md](../TEST.md) - Running the automated test suite
+- [PLATFORM_NOTES.md](../PLATFORM_NOTES.md) - Cross-platform development guide
+- [TEST.md](../../TEST.md) - Running the automated test suite
 
 ---
 
@@ -522,6 +522,6 @@ jmo scan --image node:14      # EOL, has CVEs
 **Last Updated:** 2026-02-15
 **Test Platform:** Windows 11, Python 3.12.11, Docker 29.1.5; WSL Ubuntu 24.04, Python 3.12.3, Docker 28.2.2
 **Tester:** Claude Code (automated + manual + pexpect interactive + Docker scan + WSL cross-platform verification)
-**Maintainer:** See [CONTRIBUTING.md](../CONTRIBUTING.md)
+**Maintainer:** See [CONTRIBUTING.md](../../CONTRIBUTING.md)
 **Docker Images Tested:** local-fast (9 tools), local-balanced (18 tools), local-deep (27 tools)
 **WSL Testing:** Ubuntu 24.04, /mnt/c scans, cron integration, line ending validation, cross-FS results access

--- a/docs/internal/PRE_COMMIT_HOOKS.md
+++ b/docs/internal/PRE_COMMIT_HOOKS.md
@@ -482,9 +482,9 @@ event scoping and no SKIP list.
 ## References
 
 - **Pre-commit Documentation:** <https://pre-commit.com/>
-- **Hook Configuration:** [.pre-commit-config.yaml](../.pre-commit-config.yaml)
+- **Hook Configuration:** [.pre-commit-config.yaml](../../.pre-commit-config.yaml)
 - **Dependency Management:** [DEPENDENCY_MANAGEMENT.md](DEPENDENCY_MANAGEMENT.md)
-- **CI Workflow:** [.github/workflows/ci.yml](../.github/workflows/ci.yml)
+- **CI Workflow:** [.github/workflows/ci.yml](../../.github/workflows/ci.yml)
 
 ---
 

--- a/docs/internal/TESTING_MATRIX.md
+++ b/docs/internal/TESTING_MATRIX.md
@@ -231,7 +231,7 @@ This matrix shows which tools are tested on which platforms and execution modes.
 
 ## Matrix 4: Compliance Frameworks x Tools
 
-All 28 tools benefit from universal compliance enrichment via [scripts/core/compliance_mapper.py](../scripts/core/compliance_mapper.py).
+All 28 tools benefit from universal compliance enrichment via [scripts/core/compliance_mapper.py](../../scripts/core/compliance_mapper.py).
 
 **Supported Frameworks:**
 
@@ -244,8 +244,8 @@ All 28 tools benefit from universal compliance enrichment via [scripts/core/comp
 
 **Test Coverage:**
 
-- [tests/unit/test_compliance_mapper_direct.py](../tests/unit/test_compliance_mapper_direct.py) - Direct mapper tests
-- [tests/reporters/test_compliance_reporter.py](../tests/reporters/test_compliance_reporter.py) - Compliance report generation
+- [tests/unit/test_compliance_mapper_direct.py](../../tests/unit/test_compliance_mapper_direct.py) - Direct mapper tests
+- [tests/reporters/test_compliance_reporter.py](../../tests/reporters/test_compliance_reporter.py) - Compliance report generation
 
 **Compliance Coverage:** 100% (all tools x all frameworks)
 
@@ -311,8 +311,8 @@ All 28 tools benefit from universal compliance enrichment via [scripts/core/comp
 
 **Test Files:**
 
-- [.github/workflows/ci.yml](../.github/workflows/ci.yml) - GitHub Actions primary CI
-- [.github/workflows/release.yml](../.github/workflows/release.yml) - GitHub Actions release automation
+- [.github/workflows/ci.yml](../../.github/workflows/ci.yml) - GitHub Actions primary CI
+- [.github/workflows/release.yml](../../.github/workflows/release.yml) - GitHub Actions release automation
 
 ---
 

--- a/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
+++ b/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
@@ -1,0 +1,379 @@
+# Remediation tracker: the 103 published-skill review findings
+
+**Strategy and per-chunk protocol:** [2026-08-05-published-skills-remediation.md](2026-08-05-published-skills-remediation.md)
+**Tracking issue:** [#718](https://github.com/jimmy058910/jmo-security-repo/issues/718)
+**Branch:** work each chunk off `dev`; PR into `dev`. Never `main`.
+
+## Progress
+
+**5 / 103 resolved.**
+
+| Chunk | Scope | Findings | Done | Status |
+|---|---|---:|---:|---|
+| **A** | jmo-profile-optimizer | 13 | 0 | not started |
+| **B** | dashboard-builder + documentation-updater | 13 | 1 | in progress |
+| **C** | adapter-generator + test-fabricator | 15 | 1 | in progress |
+| **D** | jmo-ci-debugger | 13 | 0 | not started |
+| **E** | target-type-expander + security-hardening | 19 | 0 | not started |
+| **F** | the 7 agents | 13 | 0 | not started |
+| **G** | tail: refactoring, compliance, systematic-debugging, references | 11 | 0 | not started |
+| **H** | repo config authored by PR #717 | 6 | 3 | in progress |
+| | **total** | **103** | **5** | |
+
+## How to mark a finding off
+
+Every finding ends in one of three states, and **all three count as resolved**:
+
+- `[x] FIXED` - changed the content; say what changed
+- `[x] DELETED` - removed the fictional example rather than repairing it
+- `[x] DISMISSED` - verified against the code and the claim is wrong; **say why**
+
+Tick the box, append the verdict inline, and update the Progress table in the
+same commit. A finding without a stated verdict is not resolved.
+
+Verify every claim against real code before acting. Measured so far: 3/3 claims
+against `check_doc_links.py` were real, but the `exit_codes` batch also implied
+changing two blocks where string keys are correct because those blocks are JSON.
+
+
+## Chunk A - jmo-profile-optimizer  (0/13)
+
+
+**`.claude/skills/jmo-profile-optimizer/references/memory-integration.md`**
+
+- [ ] **Critical** L231: Load the previous optimization count before constructing `memory_data`
+
+**`.claude/skills/jmo-profile-optimizer/references/optimization-patterns.md`**
+
+- [ ] **Critical** L241: Pass `timings` into `generate_recommendations`
+
+**`.claude/skills/jmo-profile-optimizer/SKILL.md`**
+
+- [ ] **Major** L65: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-profile-optimizer/references/memory-integration.md`**
+
+- [ ] **Major** L149: Define one timing object for comparison and storage
+- [ ] **Major** L163: Guard baseline ratio calculations
+- [ ] **Major** L216: Do not derive p95 from the maximum duration
+
+**`.claude/skills/jmo-profile-optimizer/references/optimization-patterns.md`**
+
+- [ ] **Major** L72: Align this parser with the report producer
+- [ ] **Major** L94: Handle empty timing sets
+
+**`.claude/skills/jmo-profile-optimizer/references/output-report-format.md`**
+
+- [ ] **Major** L104: Keep the Trivy recommendation enabled
+
+**`.claude/skills/jmo-profile-optimizer/SKILL.md`**
+
+- [ ] **Minor** L89: Use one bottleneck threshold
+
+**`.claude/skills/jmo-profile-optimizer/references/optimization-patterns.md`**
+
+- [ ] **Minor** L159: Use one valid denominator for all bottleneck percentages
+- [ ] **Minor** L226: Correct the timeout severity in the example
+- [ ] **Minor** L263: Carry the actual timeout rate into the recommendation
+
+## Chunk B - dashboard-builder + documentation-updater  (1/13)
+
+
+**`.claude/skills/jmo-dashboard-builder/SKILL.md`**
+
+- [ ] **Major** L15: (claim nested; read from the PR conversation)
+- [ ] **Major** L33: Use one bundle-size policy across the dashboard documentation
+- [ ] **Major** L145: (claim nested; read from the PR conversation)
+- [ ] **Major** L219: Fail when the findings placeholder is missing
+- [ ] **Major** L219: (claim nested; read from the PR conversation)
+- [ ] **Major** L230: Call the React reporter from the CLI
+
+**`.claude/skills/jmo-dashboard-builder/references/troubleshooting.md`**
+
+- [ ] **Major** L11: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-documentation-updater/SKILL.md`**
+
+- [ ] **Major** L111: Use paths relative to the Markdown file
+
+**`.claude/skills/jmo-documentation-updater/templates/doc-update-templates.md`**
+
+- [ ] **Major** L364: Make the verification checklist fail when required updates are missing
+
+**`.claude/skills/jmo-documentation-updater/SKILL.md`**
+
+- [ ] **Minor** L47: Fix the `DOCKER_README.md` quick-start link
+
+**`.claude/skills/jmo-documentation-updater/references/managing-skills-docs.md`**
+
+- [x] **Minor** L8: Describe the public/private allowlist accurately
+      -> RESOLVED: PR #717 - allowlist described accurately
+- [ ] **Minor** L14: Apply the changelog rule or narrow it
+
+**`.claude/skills/jmo-documentation-updater/templates/doc-update-templates.md`**
+
+- [ ] **Minor** L209: Limit the batch migration to reviewed files
+
+## Chunk C - adapter-generator + test-fabricator  (1/15)
+
+
+**`.claude/skills/jmo-adapter-generator/templates/adapter-template.py`**
+
+- [ ] **Major** L130: Use the `AdapterPlugin.get_fingerprint()` contract
+
+**`.claude/skills/jmo-test-fabricator/SKILL.md`**
+
+- [ ] **Major** L203: Keep compliance enrichment in `normalize_and_report.py`
+
+**`.claude/skills/jmo-test-fabricator/references/ci-platform-validation.md`**
+
+- [ ] **Major** L35: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-test-fabricator/references/integration-patterns.md`**
+
+- [ ] **Major** L155: Fail when the expected report is missing
+
+**`.claude/skills/jmo-test-fabricator/references/memory-integration.md`**
+
+- [ ] **Major** L91: Validate cached patterns before skipping schema analysis
+
+**`.claude/skills/jmo-test-fabricator/references/required-test-functions.md`**
+
+- [ ] **Major** L52: Assert the actual schema and fingerprint contract
+- [ ] **Major** L504: Test compliance enrichment at the reporting boundary
+- [ ] **Major** L783: Do not require non-empty tags from every adapter
+
+**`.claude/skills/jmo-adapter-generator/references/memory-integration.md`**
+
+- [ ] **Minor** L83: Keep compliance enrichment centralized
+
+**`.claude/skills/jmo-adapter-generator/templates/adapter-template.py`**
+
+- [ ] **Minor** L46: Normalize `PluginMetadata.name` from the adapter filename
+- [x] **Minor** L46: Use integer exit-code keys in `PluginMetadata`
+      -> RESOLVED: PR #717 - exit_codes int keys (10 sites); TWO other claims on this line still open
+
+**`.claude/skills/jmo-test-fabricator/SKILL.md`**
+
+- [ ] **Minor** L75: Limit the five-second requirement to fast tests
+
+**`.claude/skills/jmo-test-fabricator/references/ci-platform-validation.md`**
+
+- [ ] **Minor** L249: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-test-fabricator/references/common-mistakes.md`**
+
+- [ ] **Minor** L80: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-test-fabricator/references/coverage-strategies.md`**
+
+- [ ] **Minor** L26: Correct the uncovered-line count
+
+## Chunk D - jmo-ci-debugger  (0/13)
+
+
+**`.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md`**
+
+- [ ] **Major** L158: (claim nested; read from the PR conversation)
+- [ ] **Major** L463: (claim nested; read from the PR conversation)
+- [ ] **Major** L1405: (claim nested; read from the PR conversation)
+- [ ] **Major** L1466: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-ci-debugger/references/installation-config.md`**
+
+- [ ] **Major** L96: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-ci-debugger/references/memory-integration.md`**
+
+- [ ] **Major** L30: Handle invalid memory timestamps as cache misses
+- [ ] **Major** L34: Do not return stale mappings as fresh results
+- [ ] **Major** L99: Do not assign `high` confidence unconditionally
+- [ ] **Major** L153: Handle reports with no CWE identifiers
+
+**`.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md`**
+
+- [ ] **Minor** L3: Index failure pattern 18 everywhere
+- [ ] **Minor** L490: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-ci-debugger/references/error-pattern-matching.md`**
+
+- [ ] **Minor** L29: Use one regex dialect consistently
+
+**`.claude/skills/jmo-ci-debugger/references/prevention-strategies-full.md`**
+
+- [ ] **Minor** L158: Pass staged paths as discrete arguments
+
+## Chunk E - target-type-expander + security-hardening  (0/19)
+
+
+**`.claude/skills/jmo-security-hardening/examples/vulnerability-fix-examples.md`**
+
+- [ ] **Major** L159: (claim nested; read from the PR conversation)
+- [ ] **Major** L331: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-security-hardening/references/rollback-performance.md`**
+
+- [ ] **Major** L55: Remove force-push from the standard rollback procedure
+
+**`.claude/skills/jmo-target-type-expander/SKILL.md`**
+
+- [ ] **Major** L169: Do not convert scanner failures into missing-tool stubs
+- [ ] **Major** L174: Make sanitized output names collision-resistant
+- [ ] **Major** L244: Use one result-directory contract across producers and reporting
+
+**`.claude/skills/jmo-target-type-expander/examples/real-world-examples.md`**
+
+- [ ] **Major** L286: (claim nested; read from the PR conversation)
+- [ ] **Major** L533: Mirror target flags in `ci_parser`
+
+**`.claude/skills/jmo-target-type-expander/references/authentication-patterns.md`**
+
+- [ ] **Major** L68: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-security-hardening/SKILL.md`**
+
+- [ ] **Minor** L245: Correct the contradictory MEDIUM finding counts
+
+**`.claude/skills/jmo-security-hardening/examples/vulnerability-fix-examples.md`**
+
+- [ ] **Minor** L76: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-security-hardening/references/python-compat.md`**
+
+- [ ] **Minor** L23: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-security-hardening/templates/security-commit-template.md`**
+
+- [ ] **Minor** L84: Do not hard-code a co-author in the example
+
+**`.claude/skills/jmo-target-type-expander/SKILL.md`**
+
+- [ ] **Minor** L49: Make the implementation-step count consistent
+
+**`.claude/skills/jmo-target-type-expander/examples/real-world-examples.md`**
+
+- [ ] **Minor** L188: Make the batch-file syntax match the parser
+
+**`.claude/skills/jmo-target-type-expander/references/authentication-patterns.md`**
+
+- [ ] **Minor** L17: Reject empty environment credentials
+
+**`.claude/skills/jmo-target-type-expander/references/memory-integration.md`**
+
+- [ ] **Minor** L29: Handle cache misses explicitly
+
+**`.claude/skills/jmo-target-type-expander/references/tool-selection.md`**
+
+- [ ] **Minor** L64: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-security-hardening/templates/security-commit-template.md`**
+
+- [ ] **Trivial** L30: Record the repository-required verification
+
+## Chunk F - the 7 agents  (0/13)
+
+
+**`.claude/agents/code-quality-auditor.md`**
+
+- [ ] **Major** L319: (claim nested; read from the PR conversation)
+
+**`.claude/agents/coverage-gap-finder.md`**
+
+- [ ] **Major** L153: Make the proposed tests executable
+
+**`.claude/agents/dependency-analyzer.md`**
+
+- [ ] **Major** L50: Keep compliance enrichment in the report phase
+- [ ] **Major** L124: (claim nested; read from the PR conversation)
+
+**`.claude/agents/doc-sync-checker.md`**
+
+- [ ] **Major** L579: Fix the relative-link example
+
+**`.claude/agents/release-readiness.md`**
+
+- [ ] **Major** L38: Push only the release tag
+- [ ] **Major** L310: Do not infer branch parity from a one-sided log range
+- [ ] **Major** L336: Run the image tag that the checklist builds
+
+**`.claude/agents/security-auditor.md`**
+
+- [ ] **Major** L182: Correct the command-injection analysis
+- [ ] **Major** L273: Correct the path-traversal analysis
+- [ ] **Major** L551: (claim nested; read from the PR conversation)
+
+**`.claude/agents/codebase-explorer.md`**
+
+- [ ] **Minor** L18: (claim nested; read from the PR conversation)
+
+**`.claude/agents/security-auditor.md`**
+
+- [ ] **Minor** L367: Avoid mutating input findings during redaction
+
+## Chunk G - tail: refactoring, compliance, systematic-debugging, references  (0/11)
+
+
+**`.claude/skills/jmo-compliance-mapper/references/framework-version-updates.md`**
+
+- [ ] **Major** L14: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-refactoring-assistant/SKILL.md`**
+
+- [ ] **Major** L86: Enforce the 85% coverage floor in every refactoring checklist
+- [ ] **Major** L250: (claim nested; read from the PR conversation)
+- [ ] **Major** L250: Do not expose an unrestricted `--skip-tests` path
+
+**`.claude/skills/jmo-refactoring-assistant/references/test-migration-patterns.md`**
+
+- [ ] **Major** L47: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md`**
+
+- [ ] **Major** L110: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-compliance-mapper/examples/compliance-report-examples.md`**
+
+- [ ] **Minor** L69: (claim nested; read from the PR conversation)
+
+**`.claude/skills/jmo-compliance-mapper/references/memory-integration.md`**
+
+- [ ] **Minor** L67: Keep the framework-version schema complete
+
+**`.claude/skills/jmo-refactoring-assistant/references/best-practices-troubleshooting.md`**
+
+- [ ] **Minor** L13: Use the selected target in the import search
+
+**`.claude/skills/references/memory-integration-pattern.md`**
+
+- [ ] **Minor** L56: Write valid JSON in the storage example
+
+**`.claude/skills/jmo-refactoring-assistant/references/memory-integration.md`**
+
+- [ ] **Trivial** L81: Make rollback non-destructive
+
+## Chunk H - repo config authored by PR #717  (3/6)
+
+
+**`scripts/dev/check_doc_links.py`**
+
+- [x] **Major** L114: Scan every tracked Markdown file
+      -> RESOLVED: 1a4ab65 - coverage from git ls-files (87->162 files, 17 dead refs fixed)
+- [x] **Major** L182: Use the repository console-output helpers
+      -> RESOLVED: 1a4ab65 - harden_console_streams + safe_print
+
+**`.claude/rules/testing.rules.md`**
+
+- [ ] **Minor** L156: (claim nested; read from the PR conversation)
+
+**`.pre-commit-config.yaml`**
+
+- [ ] **Minor** L126: (claim nested; read from the PR conversation)
+
+**`ROADMAP.md`**
+
+- [ ] **Minor** L9: (claim nested; read from the PR conversation)
+
+**`scripts/dev/check_doc_links.py`**
+
+- [x] **Minor** L62: Handle multi-backtick inline code spans
+      -> RESOLVED: 1a4ab65 - multi-backtick code spans

--- a/docs/superpowers/plans/2026-08-05-published-skills-remediation.md
+++ b/docs/superpowers/plans/2026-08-05-published-skills-remediation.md
@@ -1,0 +1,149 @@
+# Remediating the newly-published `.claude/` skills and agents
+
+**Status:** discovery complete, execution not started
+**Branch:** `fix/coderabbit-findings-717` off `dev`
+**Tracking issue:** [#718](https://github.com/jimmy058910/jmo-security-repo/issues/718)
+**Endgame:** land on `dev`, then `dev -> main` as **v1.0.9**
+
+## What happened
+
+PR #717 split `.claude/` by audience and published 12 contributor skills plus 7
+agents. That put ~16,400 lines of instructional content under review for the
+first time in the project's history. The review returned **103 findings**:
+2 Critical, 61 Major, 38 Minor, 2 Trivial, across 53 files.
+
+None of this is a regression from #717. It is pre-existing drift that
+publication exposed — the content had never been linted, link-checked, or
+reviewed because it had never been tracked.
+
+## Discovery: the findings are not 103 independent problems
+
+Three things came out of reading them that change how the work should be run.
+
+### 1. Clusters collapse to single root causes
+
+The 13 `jmo-profile-optimizer` findings all reduce to one fact: **the skill
+documents a `timings.json` schema that has never existed.**
+
+| | Real (`scripts/cli/report_orchestrator.py:344-348`) | What the skill reads |
+|---|---|---|
+| total | `aggregate_seconds` | `total_duration_seconds` |
+| per-tool | `jobs: [{tool, path, seconds, count}]` — a flat list | `tools: {name: {...}}` — a dict |
+| profile | *absent* | `profile` |
+| timeouts / failures | **not recorded at all** | per-tool `timeouts`, `failures` |
+
+Its documented Phase 1 raises `KeyError` on the first line against real CLI
+output, and its timeout-rate analysis has no data source in the first place.
+Fixing the schema resolves most of the 13 as a side effect.
+
+Expect other clusters to behave the same way. **Read a cluster whole before
+fixing any member of it.**
+
+### 2. Finding density varies by more than 20x
+
+Density is the best available proxy for "is this content maintained."
+
+| Skill | Findings | Lines | Per 100 lines |
+|---|---:|---:|---:|
+| `jmo-dashboard-builder` | 7 | 379 | **1.85** |
+| `jmo-profile-optimizer` | 13 | 1033 | **1.26** |
+| `jmo-documentation-updater` | 6 | 755 | 0.79 |
+| `jmo-target-type-expander` | 11 | 1484 | 0.74 |
+| `jmo-refactoring-assistant` | 6 | 964 | 0.62 |
+| `jmo-security-hardening` | 8 | 1340 | 0.60 |
+| `jmo-compliance-mapper` | 3 | 575 | 0.52 |
+| `jmo-ci-debugger` | 13 | 3008 | 0.43 |
+| `jmo-adapter-generator` | 4 | 1343 | 0.30 |
+| `jmo-test-fabricator` | 11 | 3752 | 0.29 |
+| `jmo-systematic-debugging` | 1 | 1219 | 0.08 |
+| `jmo-e2e-verify` | **0** | 411 | **0.00** |
+
+`jmo-e2e-verify` is the control: it is the one skill that was already tracked
+before #717, and it came back clean. That is the standard the rest should meet.
+
+### 3. Verification cuts both ways — never batch-apply
+
+Measured on the findings worked so far:
+
+- **3/3** claims against `check_doc_links.py` were real, including one the
+  author (me) had introduced that same day.
+- The `exit_codes` batch was right about 5 sites where a naive grep found 2 —
+  **but** it also implied changing two `memory-integration.md` blocks where
+  string keys are *correct*, because those blocks are JSON documents.
+
+So: **verify every claim against the code, then fix or dismiss with a stated
+reason.** A finding dismissed with a reason is a completed finding.
+
+## The policy decision to make first
+
+Several skills document APIs and schemas that do not exist. For those, there are
+two honest responses, and the choice should be made **once, up front**, not
+per-file:
+
+- **Repair** — rewrite the example against the real code. Costly, and it only
+  holds until the next drift, because nothing tests instructional prose.
+- **Delete the fiction** — remove the invented example and point at the real
+  module. Cheaper, shorter, and cannot drift, because there is nothing left to
+  disagree with reality.
+
+**Recommendation: delete by default, repair only where the example teaches
+something the source does not.** A skill that says "read
+`scripts/cli/report_orchestrator.py:344` for the timings schema" is correct
+forever. A skill that reproduces that schema is wrong the moment it changes,
+and has been wrong for months already without anyone noticing.
+
+The instruction covering this work is explicit that deleting content that is no
+longer active or needed is in scope.
+
+## Segmentation
+
+Ordered by value: skills that **cannot work as documented** first, then density,
+then breadth. Each chunk is one session, one commit series, one push.
+
+| # | Chunk | Findings | Why this grouping |
+|---|---|---:|---|
+| **A** | `jmo-profile-optimizer` | 13 | Both Criticals live here, and the whole cluster is one fictional schema. Decide repair-vs-delete here and set the precedent. |
+| **B** | `jmo-dashboard-builder` + `jmo-documentation-updater` | 13 | Highest density, smallest files — fastest ratio of findings closed to lines read. |
+| **C** | `jmo-adapter-generator` + `jmo-test-fabricator` | 15 | The scaffold a contributor copies. Highest external blast radius; the `exit_codes` class already found here. |
+| **D** | `jmo-ci-debugger` | 13 | 3008 lines, the largest single reference corpus. Needs a whole session. |
+| **E** | `jmo-target-type-expander` + `jmo-security-hardening` | 19 | Both mid-density, both heavy on example code. |
+| **F** | 7 agents | 13 | Different shape: report templates, not procedures. Several are stale counts and commands. |
+| **G** | `jmo-refactoring-assistant`, `jmo-compliance-mapper`, `jmo-systematic-debugging`, `references/` | 11 | The tail. Low density; likely mostly dismissals. |
+
+Chunk A also carries one setup task: 4–5 findings have their claim nested such
+that only HTML comments trail the analysis block. Read those individually from
+the PR conversation.
+
+### Per-chunk protocol
+
+1. Pull that chunk's findings from the PR review.
+2. Read the whole cluster before editing — look for the single root cause.
+3. Verify each claim against real code. Record the verdict.
+4. Fix, or delete the fiction, or dismiss with a reason. All three are done.
+5. Run `python scripts/dev/check_doc_links.py` and the unit tests.
+6. Check line endings: `git diff --numstat` must equal
+   `git diff --ignore-cr-at-eol --numstat` on every changed file.
+7. Commit with the verdicts in the message; push; comment the tally on #718.
+
+### Acceptance
+
+- Every one of the 103 findings is fixed, deleted, or dismissed-with-reason.
+- `check_doc_links.py` passes over all 162 tracked Markdown files.
+- No published skill documents a schema, flag, or API that does not exist —
+  spot-check by grepping each documented symbol against `scripts/`.
+- Then `dev -> main` as **v1.0.9**.
+
+## Standing traps for every session
+
+- **`main` is never touched by this work.** Branch off `dev`; PR into `dev`.
+- **Line endings**: this repo is mixed CRLF/LF with no `.gitattributes`.
+  `Path.write_text()` and `sed -i` under MSYS both rewrite whole files. Use
+  `write_bytes()`. `cat -A` through an MSYS pipe misreports; the numstat
+  comparison is the only reliable check.
+- **Formatters are repo-wide.** `make fmt` runs `black .`; `.claude/` is
+  excluded via `pyproject.toml`, so leave that exclusion in place — the
+  adapter templates contain `{Tool}` placeholders and are not parseable Python.
+- **Console output**: anything printing repository content must go through
+  `harden_console_streams()` + `safe_print()` from `scripts/core/unicode_utils`.
+- **Read the `windows-2022` job log, not its check tick** — it is
+  `continue-on-error: true` and reports success over failures.

--- a/scripts/dev/check_doc_links.py
+++ b/scripts/dev/check_doc_links.py
@@ -31,22 +31,18 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# Documentation surfaces whose links must resolve in a fresh clone. Anything
-# tracked under .claude/ is included automatically (see collect_files) since
-# that directory is the public/private boundary this guard exists to hold.
-EXPLICIT_FILES = (
-    "CLAUDE.md",
-    "AGENTS.md",
-    "README.md",
-    "CONTRIBUTING.md",
-    "QUICKSTART.md",
-    "ROADMAP.md",
-    "TEST.md",
-    "docs/index.md",
-    "docs/KNOWN_LIMITATIONS.md",
+# Run directly (`python scripts/dev/check_doc_links.py`) and sys.path[0] is
+# scripts/dev, not the repo root - so scripts.core is not importable without
+# this. Same bootstrap as scripts/dev/reconcile_scan_accounting.py.
+if __package__ in (None, ""):  # pragma: no cover - only on direct execution
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.core.unicode_utils import (  # noqa: E402
+    harden_console_streams,
+    safe_print,
 )
 
-# Historical records. Exempt by design - see the module docstring.
+# Historical records, exempt by design - see the module docstring.
 ARCHIVAL_PREFIXES = (
     "docs/superpowers/",
     "CHANGELOG.md",
@@ -59,7 +55,11 @@ LINK_PATTERN = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 # navigation - the agent and skill files quote broken links on purpose, to
 # teach what a broken link looks like.
 FENCE_PATTERN = re.compile(r"^\s{0,3}(?P<marker>`{3,}|~{3,})\s*(?P<info>\S.*)?$")
-INLINE_CODE_PATTERN = re.compile(r"`[^`]*`")
+# A code span is delimited by backtick strings of EQUAL length, so ``x`` is one
+# span and not two empty ones. Matching only single backticks left the contents
+# of a double-backtick span visible to LINK_PATTERN, which reported a quoted
+# sample as a real BROKEN reference.
+INLINE_CODE_PATTERN = re.compile(r"(?P<ticks>`+)(?:(?!(?P=ticks)).)*(?P=ticks)")
 
 # A GitHub line anchor (`file.py#L42`, `file.py#L42-L51`). These are citations
 # pointing at a line of source on the web, not links into the repo tree.
@@ -106,12 +106,16 @@ def tracked_paths() -> set[str]:
 
 
 def collect_files(tracked: set[str]) -> list[str]:
-    """Documentation surfaces to check: the explicit list plus all of .claude/."""
-    files = [f for f in EXPLICIT_FILES if f in tracked]
-    files.extend(
-        sorted(p for p in tracked if p.startswith(".claude/") and p.endswith(".md"))
+    """Every tracked Markdown file except the archival ones.
+
+    Derived from `git ls-files` rather than an allowlist. An allowlist silently
+    stops covering whatever it was not updated for: the previous one named nine
+    files and left 75 tracked Markdown files unchecked, which between them held
+    17 dead references that CI reported as green.
+    """
+    return sorted(
+        p for p in tracked if p.endswith(".md") and not p.startswith(ARCHIVAL_PREFIXES)
     )
-    return files
 
 
 def is_tracked(target: str, tracked: set[str]) -> bool:
@@ -161,25 +165,31 @@ def check_file(rel_path: str, tracked: set[str]) -> list[str]:
 
 
 def main() -> int:
-    print("Checking documentation links resolve to tracked files...")
+    # This tool prints file paths and link text - arbitrary repository content -
+    # so a single character the console cannot encode would otherwise crash the
+    # guard itself on a non-UTF-8 Windows console. Harden the stream once rather
+    # than guarding each call site.
+    harden_console_streams()
+
+    safe_print("Checking documentation links resolve to tracked files...")
     tracked = tracked_paths()
 
-    files = [f for f in collect_files(tracked) if not f.startswith(ARCHIVAL_PREFIXES)]
+    files = collect_files(tracked)
     problems: list[str] = []
     for rel_path in files:
         problems.extend(check_file(rel_path, tracked))
 
     if problems:
         for line in sorted(problems):
-            print(line)
-        print(f"\n{len(problems)} dead reference(s) across {len(files)} file(s).")
-        print("BROKEN    -> fix the path, or remove the link.")
-        print("UNTRACKED -> the file exists locally but ships to nobody. Either")
-        print("             track it (see the .claude/ allowlist in .gitignore)")
-        print("             or stop referencing it from a tracked file.")
+            safe_print(line)
+        safe_print(f"\n{len(problems)} dead reference(s) across {len(files)} file(s).")
+        safe_print("BROKEN    -> fix the path, or remove the link.")
+        safe_print("UNTRACKED -> the file exists locally but ships to nobody. Either")
+        safe_print("             track it (see the .claude/ allowlist in .gitignore)")
+        safe_print("             or stop referencing it from a tracked file.")
         return 1
 
-    print(f"All links in {len(files)} tracked file(s) resolve to tracked paths.")
+    safe_print(f"All links in {len(files)} tracked file(s) resolve to tracked paths.")
     return 0
 
 

--- a/tests/unit/test_import_direction.py
+++ b/tests/unit/test_import_direction.py
@@ -163,3 +163,59 @@ class TestDocLinks:
 
         assert mod.LINE_ANCHOR_PATTERN.search("scripts/cli/jmo.py#L245")
         assert not mod.LINE_ANCHOR_PATTERN.search("docs/USER_GUIDE.md#configuration")
+
+    def test_code_spans_of_any_backtick_width_are_suppressed(self) -> None:
+        """A code span is delimited by backtick runs of equal length.
+
+        Matching only single backticks left the contents of a ``double`` span
+        visible, so a quoted sample link was reported as a real BROKEN
+        reference. Doubles exist precisely to quote text containing backticks,
+        which is exactly how documentation shows a link.
+        """
+        mod = _load_check_doc_links()
+
+        for ticks in ("`", "``", "```"):
+            line = f"see {ticks}[sample](does/not/exist.md){ticks} above"
+            kept = "\n".join(mod.navigable_lines(line))
+            assert (
+                "does/not/exist.md" not in kept
+            ), f"leaked from a {len(ticks)}-backtick span"
+
+        # A genuine link on an ordinary line must still be seen.
+        kept = "\n".join(mod.navigable_lines("see [real](docs/index.md)"))
+        assert "docs/index.md" in kept
+
+    def test_every_tracked_markdown_file_is_checked(self) -> None:
+        """Coverage comes from `git ls-files`, not a hand-maintained list.
+
+        An allowlist stops covering whatever nobody remembered to add to it:
+        the previous one named nine files and left 75 tracked Markdown files
+        unchecked, which between them held 17 dead references CI called green.
+        """
+        mod = _load_check_doc_links()
+        tracked = mod.tracked_paths()
+        checked = set(mod.collect_files(tracked))
+
+        expected = {
+            p
+            for p in tracked
+            if p.endswith(".md") and not p.startswith(mod.ARCHIVAL_PREFIXES)
+        }
+        assert checked == expected
+        assert len(checked) > 100, "coverage collapsed to a small subset"
+
+        # Archival records are exempt by design; they name deleted paths on purpose.
+        assert not any(p.startswith(mod.ARCHIVAL_PREFIXES) for p in checked)
+
+    def test_console_output_is_hardened(self) -> None:
+        """The checker prints repository content, so its stream must be hardened.
+
+        Paths and link text are arbitrary; one character a cp1252 console cannot
+        encode would otherwise crash the guard itself. Per unicode_utils, fix the
+        stream once rather than guarding each call site.
+        """
+        source = DOC_CHECKER.read_text(encoding="utf-8")
+        assert "harden_console_streams()" in source
+        assert "safe_print(" in source
+        # No bare print() left behind at statement indentation.
+        assert not re.search(r"^\s+print\(", source, re.MULTILINE)


### PR DESCRIPTION
Two things, both off the review of #717.

## Three verified-real defects in the guard itself

Each was checked against the code before changing anything, and each now has a regression test proven to fail without the fix.

| Defect | Effect |
|---|---|
| `INLINE_CODE_PATTERN` matched only single backticks | A ``double-backtick`` span leaked its link, so a quoted sample was reported as a real `BROKEN` reference |
| `collect_files` returned a 9-entry allowlist | The guard checked **87 files of 162**. The 75 unchecked ones held **17 dead references CI reported as green** |
| Bare `print()` of repository paths | One character a cp1252 console cannot encode would crash the guard itself |

All 17 dead references are fixed. Fourteen were relative-depth errors — `docs/internal/*.md` sits two levels down, so `../CONTRIBUTING.md` resolved to `docs/CONTRIBUTING.md`. Three pointed at `.github/workflows/version-check.yml`, removed in the 8→4 workflow consolidation; that job is `check-versions` in `maintenance.yml`, so the documented `gh workflow run version-check.yml` could not have worked either.

Coverage now comes from `git ls-files` rather than a list, because an allowlist silently stops covering whatever nobody remembered to add — the same failure mode as the `.claude/` skip this guard was written to remove.

## Discovery and tracking for the remaining 98

The review left **103 findings, not the 27 first reported** — that count came from an unpaginated API call.

- `docs/superpowers/plans/2026-08-05-published-skills-remediation.md` — strategy: 7 chunks ordered by value, the repair-vs-delete policy decision, per-chunk protocol, acceptance criteria, standing traps.
- `docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md` — the checklist: all 103 as individual boxes with severity and claim. **5/103 resolved.**

Key discovery: the findings are not independent. All 13 `jmo-profile-optimizer` findings reduce to one fact — the skill documents a `timings.json` schema that has never existed. `report_orchestrator.py:344-348` writes `aggregate_seconds` and a flat `jobs` list; the skill reads `total_duration_seconds` and a `tools` dict, and analyses per-tool timeout counts that are never recorded at all.

`jmo-e2e-verify` — the one skill already tracked before #717 — came back with **zero** findings. It is the control, and the standard.

## Verification

- `check_doc_links.py` passes over all **162** tracked Markdown files
- 12 unit tests pass; both new regression tests mutation-proven (reverting the fence rule and the coverage source each reddens its test), restored byte-identically
- `black` / `ruff` / `mypy` clean; line endings verified — raw and CR-insensitive numstat match on every changed file