### PR TITLE
fix(history): stop silently discarding `slim` scans, and close the profile-enumeration class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,37 @@ The split is mechanical rather than remembered. `.gitignore` carries an explicit
 
 > Agent teams require `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json (experimental).
 
+### Optional: local knowledge graph (not shipped)
+
+Unlike everything else in this section, this is **maintainer-local and absent
+from a clone**. It is recorded here because a session that has it should use it,
+and because the Windows setup has a trap worth writing down once.
+
+[Graphify](https://github.com/Graphify-Labs/graphify) (`pip`/`uv` package
+`graphifyy`) indexes the repo into a queryable graph under `graphify-out/`,
+which is gitignored. Deterministic AST parsing — no LLM, no API cost. A git
+`post-commit` hook rebuilds it incrementally.
+
+| Task | Command |
+|---|---|
+| Refresh after many commits | `graphify update .` |
+| Ask a structural question | `graphify query "what connects X to Y?"` |
+| Explain one symbol | `graphify explain "store_scan"` |
+| Path between two symbols | `graphify path "A" "B"` |
+
+Check freshness with the graph's own `built_at_commit` key, **not** the file
+mtime — clustering rewrites `graph.json` without re-extracting, so mtime reads
+fresher than the content is.
+
+**Windows trap.** The hook probes for an interpreter and gives up silently
+(`could not locate a Python with graphify installed`) when every probe fails.
+Under Git Bash all four can fail at once: a hook installed from WSL pins a
+`/home/...` path; MSYS strips `.exe` from `command -v graphify`, so the launcher
+is read as a shebang and rejected; and `graphify` lives in a uv-tool venv the
+default `python` cannot import. The fix is one gitignored file —
+`graphify-out/.graphify_python` containing the absolute interpreter path. The
+MCP server needs the extra: `uv tool install "graphifyy[mcp]"`.
+
 ## Architecture Overview
 
 ### Two-Phase Workflow

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -936,7 +936,7 @@ def _add_schedule_args(
     create_parser.add_argument(
         "--profile",
         required=True,
-        choices=["fast", "balanced", "deep"],
+        choices=list(PROFILE_TOOLS),
         help="Scan profile",
     )
     create_parser.add_argument("--repos-dir", help="Repository directory to scan")
@@ -989,7 +989,7 @@ def _add_schedule_args(
     update_parser.add_argument("name", help="Schedule name")
     update_parser.add_argument("--cron", help="New cron expression")
     update_parser.add_argument(
-        "--profile", choices=["fast", "balanced", "deep"], help="New scan profile"
+        "--profile", choices=list(PROFILE_TOOLS), help="New scan profile"
     )
     update_parser.add_argument(
         "--suspend", action="store_true", help="Suspend schedule"
@@ -1169,7 +1169,7 @@ See: docs/HISTORY_GUIDE.md for complete documentation.
     store_parser.add_argument(
         "--profile",
         default="balanced",
-        choices=["fast", "balanced", "deep"],
+        choices=list(PROFILE_TOOLS),
         help="Scan profile that was used (default: balanced)",
     )
     store_parser.add_argument(
@@ -1188,7 +1188,7 @@ See: docs/HISTORY_GUIDE.md for complete documentation.
     list_parser.add_argument("--branch", help="Filter by branch name")
     list_parser.add_argument(
         "--profile",
-        choices=["fast", "balanced", "deep"],
+        choices=list(PROFILE_TOOLS),
         help="Filter by profile",
     )
     list_parser.add_argument(

--- a/scripts/cli/wizard_flows/cicd_flow.py
+++ b/scripts/cli/wizard_flows/cicd_flow.py
@@ -62,6 +62,8 @@ class CICDFlow(BaseWizardFlow):
         )
         profile = self.prompter.prompt_choice(
             "Select scan profile:",
+            # curated-profile-subset: CI/CD needs a short feedback loop, so
+            # `deep` (40-70 min) is deliberately not offered here.
             choices=["fast", "balanced"],
             default="fast",
         )

--- a/scripts/cli/wizard_flows/deployment_flow.py
+++ b/scripts/cli/wizard_flows/deployment_flow.py
@@ -72,6 +72,8 @@ class DeploymentFlow(BaseWizardFlow):
 
         profile = self.prompter.prompt_choice(
             "Select scan profile:",
+            # curated-profile-subset: a deployment gate needs real coverage, so
+            # `fast` is deliberately not offered here.
             choices=["balanced", "deep"],
             default=profile_default,
         )

--- a/scripts/cli/wizard_flows/repo_flow.py
+++ b/scripts/cli/wizard_flows/repo_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from .base_flow import BaseWizardFlow
-from .profile_config import get_profile_warning
+from .profile_config import PROFILES, get_profile_warning
 
 
 class RepoFlow(BaseWizardFlow):
@@ -30,17 +30,19 @@ class RepoFlow(BaseWizardFlow):
         # Display detected repositories
         self._print_detected_repos(self.detected_targets)
 
-        # Profile selection with recommendations
+        # Profile selection with recommendations. Both the descriptions and the
+        # choices come from PROFILES, which derives its tool counts from
+        # PROFILE_TOOLS -- the hardcoded copy here had drifted to the wrong
+        # counts and omitted `slim` entirely (#721).
         profile_info = [
-            "fast: 3 tools, 5-8 minutes (pre-commit, quick checks)",
-            "balanced: 8 tools, 15-20 minutes (CI/CD, regular audits)",
-            "deep: 12 tools, 30-60 minutes (security audits, compliance)",
+            f"{key}: {spec['description']}, {spec['est_time']}"
+            for key, spec in PROFILES.items()
         ]
         self.prompter.print_summary_box("📊 Profile Options", profile_info)
 
         profile = self.prompter.prompt_choice(
             "Select scan profile:",
-            choices=["fast", "balanced", "deep"],
+            choices=list(PROFILES),
             default="balanced",
         )
 

--- a/scripts/cli/wizard_flows/stack_flow.py
+++ b/scripts/cli/wizard_flows/stack_flow.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from .base_flow import BaseWizardFlow
-from .profile_config import get_profile_warning
+from .profile_config import PROFILES, get_profile_warning
 
 
 class EntireStackFlow(BaseWizardFlow):
@@ -39,7 +39,7 @@ class EntireStackFlow(BaseWizardFlow):
         # Profile selection
         profile = self.prompter.prompt_choice(
             "Select scan profile:",
-            choices=["fast", "balanced", "deep"],
+            choices=list(PROFILES),
             default="balanced",
         )
 

--- a/scripts/core/history_db.py
+++ b/scripts/core/history_db.py
@@ -103,7 +103,12 @@ CREATE TABLE IF NOT EXISTS scans (
     duration_seconds REAL,
 
     -- Constraints
-    CHECK (profile IN ('fast', 'balanced', 'deep')),
+    -- NOTE: `profile` is deliberately unconstrained here. A SQL CHECK can only
+    -- enumerate a fixed list, and the real rule is "a profile that exists in
+    -- tool_registry.PROFILE_TOOLS or in the user's jmo.yml `profiles:` dict" --
+    -- neither of which SQL can see. The previous enumeration predated the
+    -- `slim` profile and silently rejected every slim scan (#721). Validation
+    -- lives in store_scan(), against the registry, so it cannot drift again.
     CHECK (target_type IN ('repo', 'image', 'iac', 'url', 'gitlab', 'k8s', 'unknown'))
 );
 """
@@ -784,6 +789,30 @@ def _enforce_database_permissions(db_path: Path) -> None:
         logger.warning(f"Failed to set database permissions: {e}")
 
 
+def get_known_profiles() -> set[str]:
+    """Profile names that may legitimately appear in history.
+
+    Derived at call time from the tool registry plus any profile the user
+    defined under ``profiles:`` in ``jmo.yml`` (a free-form dict). Never
+    hardcode the list: the previous enumeration of fast/balanced/deep predated
+    the ``slim`` profile and silently discarded every slim scan (#721).
+    """
+    from scripts.core.tool_registry import PROFILE_TOOLS
+
+    known = set(PROFILE_TOOLS)
+
+    try:
+        from scripts.core.config import load_config
+
+        known |= set(load_config("jmo.yml").profiles)
+    except (OSError, ValueError, TypeError, KeyError) as e:
+        # No readable jmo.yml on this path (common in tests and library use).
+        # The registry alone is a correct, if narrower, answer.
+        logger.debug(f"Could not read profiles from jmo.yml: {e}")
+
+    return known
+
+
 def store_scan(
     results_dir: Path,
     profile: str,
@@ -803,7 +832,7 @@ def store_scan(
 
     Args:
         results_dir: Path to scan results directory (contains findings.json)
-        profile: Profile name ("fast" | "balanced" | "deep")
+        profile: Profile name; any key of PROFILE_TOOLS or a jmo.yml profile
         tools: List of tool names that were run
         db_path: Path to SQLite database file
         commit_hash: Git commit hash (optional, auto-detected if None)
@@ -838,8 +867,12 @@ def store_scan(
     if not findings_json.exists():
         raise FileNotFoundError(f"findings.json not found: {findings_json}")
 
-    if profile not in ("fast", "balanced", "deep"):
-        raise ValueError(f"Invalid profile: {profile}")
+    known_profiles = get_known_profiles()
+    if profile not in known_profiles:
+        raise ValueError(
+            f"Unknown profile: {profile!r}. "
+            f"Known profiles: {', '.join(sorted(known_profiles))}"
+        )
 
     # Validate encryption prerequisites (Phase 6 Step 6.2)
     if encrypt_findings:

--- a/scripts/migrations/v1_2_0.py
+++ b/scripts/migrations/v1_2_0.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Migration v1.1.0 -> v1.2.0: drop the legacy `profile` CHECK on `scans`.
+
+The `scans.profile` CHECK enumerated ('fast', 'balanced', 'deep') and predated
+the `slim` profile. Every slim scan was rejected at insert time while
+`jmo report` logged a WARN and still exited 0, so the scan silently never
+entered history (#721). User-defined profiles from `jmo.yml` were rejected for
+the same reason.
+
+A SQL CHECK can only enumerate a fixed list; the real rule is "a profile that
+exists in tool_registry.PROFILE_TOOLS or in the user's jmo.yml". Validation
+therefore moves into store_scan(), and this migration removes the constraint
+from existing databases.
+
+Why the schema is edited in place rather than rebuilt
+-----------------------------------------------------
+SQLite cannot drop a CHECK constraint, so the usual remedy is create-copy-drop-
+rename. Measured against this schema, that is actively dangerous:
+
+- `findings` and `scan_metadata` both carry `ON DELETE CASCADE` foreign keys to
+  `scans(id)`, and `get_connection()` sets `PRAGMA foreign_keys=ON`. `DROP TABLE
+  scans` therefore performs an implicit DELETE that cascades and destroys every
+  finding in the database.
+- Two triggers on `findings` reference `scans`, which makes
+  `ALTER TABLE ... RENAME` fail outright with
+  "error in trigger update_scan_counts_on_insert: no such table: main.scans".
+- Six indexes and two views would also need faithful recreation.
+
+Editing the stored DDL moves no data and drops nothing, so all eleven dependent
+objects survive untouched. The result is verified with `integrity_check` and
+`foreign_key_check` before the migration is allowed to commit.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+
+from scripts.core.history_migrations import Migration
+
+# Matches the legacy constraint with or without a trailing comma, tolerating
+# whitespace and quoting differences.
+_PROFILE_CHECK = re.compile(
+    r"\n?[ \t]*CHECK[ \t]*\(\s*profile\s+IN\s*\([^)]*\)\s*\)[ \t]*,?",
+    re.IGNORECASE,
+)
+
+
+class Migration_1_1_0_to_1_2_0(Migration):
+    """Remove the enumerated `profile` CHECK from the scans table."""
+
+    @property
+    def version(self) -> str:
+        return "1.2.0"
+
+    def migrate_up(self, conn: sqlite3.Connection) -> None:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='scans'"
+        ).fetchone()
+        if row is None:
+            return  # no scans table yet; init_database() creates the fixed schema
+
+        old_sql = row[0]
+        if not _PROFILE_CHECK.search(old_sql):
+            return  # already fixed, or created fresh -- idempotent no-op
+
+        new_sql = _PROFILE_CHECK.sub("", old_sql, count=1)
+        if "CHECK" in old_sql.upper() and new_sql == old_sql:
+            raise RuntimeError("failed to remove the profile CHECK from scans DDL")
+
+        schema_version = conn.execute("PRAGMA schema_version").fetchone()[0]
+
+        conn.execute("PRAGMA writable_schema=ON")
+        try:
+            conn.execute(
+                "UPDATE sqlite_master SET sql=? WHERE type='table' AND name='scans'",
+                (new_sql,),
+            )
+            # Bump so every connection reloads the edited schema.
+            conn.execute(f"PRAGMA schema_version={schema_version + 1}")
+        finally:
+            conn.execute("PRAGMA writable_schema=OFF")
+
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        if integrity != "ok":
+            raise RuntimeError(f"integrity_check failed after migration: {integrity}")
+
+        violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise RuntimeError(
+                f"foreign_key_check failed after migration: {violations}"
+            )
+
+    def migrate_down(self, conn: sqlite3.Connection) -> None:
+        """Rollback is intentionally a no-op.
+
+        Restoring the constraint would re-introduce the defect, and any slim or
+        user-defined-profile scan stored since would then violate it.
+        """

--- a/tests/unit/test_history_db.py
+++ b/tests/unit/test_history_db.py
@@ -387,7 +387,13 @@ class TestStoreScan:
             )
 
     def test_store_scan_invalid_profile(self, tmp_path):
-        """Test that store_scan raises ValueError for invalid profile."""
+        """Test that store_scan raises ValueError for an unknown profile.
+
+        The message changed in #721 from "Invalid profile: X" to
+        "Unknown profile: 'X'. Known profiles: ..." -- the old wording gave the
+        user no way to discover which values were valid, which is what let the
+        missing `slim` profile go unnoticed.
+        """
         db_path = tmp_path / "test.db"
 
         results_dir = tmp_path / "results"
@@ -397,7 +403,7 @@ class TestStoreScan:
         findings_json = summaries_dir / "findings.json"
         findings_json.write_text(json.dumps({"findings": []}))
 
-        with pytest.raises(ValueError, match="Invalid profile"):
+        with pytest.raises(ValueError, match="Unknown profile"):
             store_scan(
                 results_dir=results_dir,
                 profile="invalid_profile",
@@ -7104,6 +7110,108 @@ class TestExecuteReadonlyQuery:
         """Empty query raises ValueError."""
         with pytest.raises(ValueError, match="must not be empty"):
             execute_readonly_query(readonly_db, "")
+
+
+class TestProfileAcceptedByHistory:
+    """The set of storable profiles must track the tool registry.
+
+    Regression guard for #721: the `scans.profile` CHECK constraint enumerated
+    fast/balanced/deep and predated the `slim` profile, so every slim scan was
+    rejected at insert time while `jmo report` logged a WARN and still exited 0
+    -- the scan silently never entered history.
+
+    These tests fail if a profile is added to PROFILE_TOOLS (or defined in
+    jmo.yml) without history being able to store it.
+    """
+
+    @staticmethod
+    def _insert_scan(conn, scan_id: str, profile: str) -> None:
+        """Insert a minimal scan row, exercising only the profile constraint."""
+        conn.execute(
+            """
+            INSERT INTO scans (
+                id, timestamp, timestamp_iso, profile, tools, targets,
+                target_type, total_findings, critical_count, high_count,
+                medium_count, low_count, info_count, jmo_version
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, ?)
+            """,
+            (scan_id, 0, "1970-01-01T00:00:00", profile, "[]", "[]", "repo", "test"),
+        )
+
+    def test_every_registry_profile_is_storable(self, tmp_path):
+        """Every profile in PROFILE_TOOLS can be stored in history."""
+        from scripts.core.tool_registry import PROFILE_TOOLS
+
+        db_path = tmp_path / "test.db"
+        init_database(db_path)
+        conn = get_connection(db_path)
+
+        rejected = []
+        for profile in sorted(PROFILE_TOOLS):
+            try:
+                self._insert_scan(conn, f"scan-{profile}", profile)
+            except sqlite3.IntegrityError as exc:
+                rejected.append(f"{profile}: {exc}")
+        conn.commit()
+
+        assert (
+            not rejected
+        ), "history rejected profiles the tool can actually run: " + "; ".join(rejected)
+
+    @staticmethod
+    def _results_dir(tmp_path):
+        """Minimal results directory that store_scan will accept."""
+        summaries = tmp_path / "results" / "summaries"
+        summaries.mkdir(parents=True)
+        (summaries / "findings.json").write_text(json.dumps({"findings": []}))
+        return tmp_path / "results"
+
+    def test_store_scan_rejects_unknown_profile(self, tmp_path):
+        """Removing the CHECK must not let garbage profiles into history.
+
+        The constraint previously rejected unknown values as a side effect of
+        enumerating them. Validation now lives here instead, against the
+        registry, so it covers slim and user-defined profiles too.
+        """
+        with pytest.raises(ValueError, match="[Uu]nknown profile"):
+            store_scan(
+                results_dir=self._results_dir(tmp_path),
+                profile="definitely-not-a-profile",
+                tools=[],
+                db_path=tmp_path / "test.db",
+            )
+
+    def test_store_scan_accepts_slim(self, tmp_path):
+        """#721 end-to-end: a slim scan reaches the database via store_scan."""
+        scan_id = store_scan(
+            results_dir=self._results_dir(tmp_path),
+            profile="slim",
+            tools=["trivy"],
+            db_path=tmp_path / "test.db",
+        )
+        conn = get_connection(tmp_path / "test.db")
+        row = conn.execute(
+            "SELECT profile FROM scans WHERE id = ?", (scan_id,)
+        ).fetchone()
+        assert row[0] == "slim"
+
+    def test_user_defined_profile_is_storable(self, tmp_path):
+        """A custom profile from jmo.yml `profiles:` can be stored.
+
+        `Config.profiles` is a free-form dict, so users may define profiles the
+        registry has never heard of. History must not silently discard them.
+        """
+        db_path = tmp_path / "test.db"
+        init_database(db_path)
+        conn = get_connection(db_path)
+
+        self._insert_scan(conn, "scan-custom", "nightly-compliance")
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT profile FROM scans WHERE id = ?", ("scan-custom",)
+        ).fetchone()
+        assert row[0] == "nightly-compliance"
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_history_migrations.py
+++ b/tests/unit/test_history_migrations.py
@@ -191,3 +191,215 @@ def test_migration_idempotent(tmp_path: Path):
     assert (
         scan_notes_count == 1
     ), f"scan_notes should appear exactly once, found {scan_notes_count} times"
+
+
+# --- #721: legacy `profile` CHECK constraint -------------------------------
+
+
+def _build_legacy_scans_table(db_path: Path) -> None:
+    """Recreate `scans` with the pre-#721 CHECK that enumerated 3 profiles.
+
+    Derived from the live DDL so that unrelated column changes stay in sync;
+    only the constraint that #721 removed is added back.
+    """
+    from scripts.core.history_db import CREATE_SCANS_TABLE
+
+    legacy_ddl = CREATE_SCANS_TABLE.replace(
+        "CHECK (target_type IN",
+        "CHECK (profile IN ('fast', 'balanced', 'deep')),\n    CHECK (target_type IN",
+    )
+    assert "CHECK (profile IN" in legacy_ddl, "legacy fixture failed to inject CHECK"
+
+    conn = get_connection(db_path)
+
+    # DROP TABLE takes the indexes with it, so capture and restore them --
+    # otherwise the fixture is an unfaithful legacy database and any test
+    # asserting the migration preserves indexes would pass vacuously.
+    index_ddl = [
+        row[0]
+        for row in conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name='scans'"
+        )
+        if row[0]  # implicit indexes have sql = NULL
+    ]
+
+    conn.execute("DROP TABLE scans")
+    conn.executescript(legacy_ddl)
+    for ddl in index_ddl:
+        conn.execute(ddl)
+    conn.commit()
+
+
+def _insert_scan(conn, scan_id: str, profile: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO scans (
+            id, timestamp, timestamp_iso, profile, tools, targets,
+            target_type, total_findings, critical_count, high_count,
+            medium_count, low_count, info_count, jmo_version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, ?)
+        """,
+        (scan_id, 0, "1970-01-01T00:00:00", profile, "[]", "[]", "repo", "test"),
+    )
+
+
+def test_migration_lets_legacy_db_store_slim_scans(tmp_path: Path):
+    """#721: an existing database can store `slim` scans after migrating.
+
+    Changing CREATE_SCANS_TABLE only fixes databases created afterwards.
+    SQLite cannot drop a CHECK constraint in place, so an existing database
+    keeps rejecting slim scans until the table is rebuilt.
+    """
+    db_path = tmp_path / "legacy.db"
+    init_database(db_path)
+    _build_legacy_scans_table(db_path)
+
+    conn = get_connection(db_path)
+    _insert_scan(conn, "pre-existing", "balanced")
+    conn.commit()
+
+    result = run_migrations(db_path)
+    assert result["errors"] == [], f"migration failed: {result['errors']}"
+
+    conn = get_connection(db_path)
+    _insert_scan(conn, "after-migration", "slim")
+    conn.commit()
+
+    stored = {
+        row[0]
+        for row in conn.execute("SELECT profile FROM scans ORDER BY id").fetchall()
+    }
+    assert stored == {"balanced", "slim"}
+
+
+def _insert_finding(conn, scan_id: str, fingerprint: str) -> None:
+    """Insert a minimal findings row for the scan (columns read from schema)."""
+    notnull = [
+        (row[1], row[2])
+        for row in conn.execute("PRAGMA table_info(findings)")
+        if row[3]
+    ]
+    values = {}
+    for name, coltype in notnull:
+        if name == "scan_id":
+            values[name] = scan_id
+        elif name == "fingerprint":
+            values[name] = fingerprint
+        elif name == "severity":
+            values[name] = "HIGH"
+        else:
+            values[name] = 0 if coltype.upper() in ("INTEGER", "REAL") else "x"
+    conn.execute(
+        f"INSERT INTO findings ({','.join(values)}) "
+        f"VALUES ({','.join('?' * len(values))})",
+        list(values.values()),
+    )
+
+
+def test_migration_preserves_existing_rows(tmp_path: Path):
+    """#721: the migration must not lose data in any table.
+
+    `findings` and `scan_metadata` both declare ON DELETE CASCADE against
+    `scans(id)`, and get_connection() sets PRAGMA foreign_keys=ON. A migration
+    that drops and recreates `scans` therefore destroys every finding in the
+    database -- silently, which is the same failure mode as the bug itself.
+    """
+    db_path = tmp_path / "legacy.db"
+    init_database(db_path)
+    _build_legacy_scans_table(db_path)
+
+    conn = get_connection(db_path)
+    for i, profile in enumerate(["fast", "balanced", "deep"]):
+        _insert_scan(conn, f"scan-{i}", profile)
+    conn.execute(
+        "UPDATE scans SET total_findings = 42, duration_seconds = 1.5 WHERE id = 'scan-1'"
+    )
+    for i in range(3):
+        _insert_finding(conn, "scan-0", f"fp-{i}")
+    conn.execute(
+        "INSERT INTO scan_metadata (scan_id, key, value) VALUES ('scan-0','k','v')"
+    )
+    conn.commit()
+
+    before = conn.execute(
+        "SELECT id, profile, total_findings, duration_seconds FROM scans ORDER BY id"
+    ).fetchall()
+    assert len(before) == 3
+
+    result = run_migrations(db_path)
+    assert result["errors"] == [], f"migration failed: {result['errors']}"
+
+    conn = get_connection(db_path)
+    after = conn.execute(
+        "SELECT id, profile, total_findings, duration_seconds FROM scans ORDER BY id"
+    ).fetchall()
+    assert [tuple(r) for r in after] == [tuple(r) for r in before]
+
+    # The cascade guard: these are what a drop-and-recreate would destroy.
+    assert (
+        conn.execute("SELECT COUNT(*) FROM findings").fetchone()[0] == 3
+    ), "findings were destroyed -- ON DELETE CASCADE fired during the migration"
+    assert (
+        conn.execute("SELECT COUNT(*) FROM scan_metadata").fetchone()[0] == 1
+    ), "scan_metadata was destroyed -- ON DELETE CASCADE fired during the migration"
+
+
+def test_migration_keeps_dependent_schema_objects(tmp_path: Path):
+    """#721: indexes, triggers and views on `scans` must survive.
+
+    Eleven objects depend on `scans` (2 FK tables, 6 indexes, 2 triggers,
+    2 views). A rebuild drops the indexes and triggers with the table, and
+    `ALTER TABLE ... RENAME` fails outright because the triggers on `findings`
+    reference `scans`.
+    """
+    db_path = tmp_path / "legacy.db"
+    init_database(db_path)
+
+    conn = get_connection(db_path)
+    before = {
+        (row[0], row[1])
+        for row in conn.execute(
+            "SELECT type, name FROM sqlite_master WHERE type IN "
+            "('index','trigger','view') AND sql LIKE '%scans%'"
+        )
+    }
+    assert before, "fixture found no dependent objects to protect"
+
+    _build_legacy_scans_table(db_path)
+    result = run_migrations(db_path)
+    assert result["errors"] == [], f"migration failed: {result['errors']}"
+
+    conn = get_connection(db_path)
+    after = {
+        (row[0], row[1])
+        for row in conn.execute(
+            "SELECT type, name FROM sqlite_master WHERE type IN "
+            "('index','trigger','view') AND sql LIKE '%scans%'"
+        )
+    }
+    assert before - after == set(), f"migration destroyed: {sorted(before - after)}"
+
+
+def test_migration_is_idempotent_on_fresh_db(tmp_path: Path):
+    """#721: the migration is a no-op on a database that never had the CHECK.
+
+    init_database() records version 1.0.0 even though it now creates the fixed
+    schema, so run_migrations() will attempt this migration on fresh databases.
+    """
+    db_path = tmp_path / "fresh.db"
+    init_database(db_path)
+
+    conn = get_connection(db_path)
+    _insert_scan(conn, "scan-slim", "slim")
+    conn.commit()
+
+    result = run_migrations(db_path)
+    assert result["errors"] == [], f"migration failed: {result['errors']}"
+
+    result_again = run_migrations(db_path)
+    assert result_again["errors"] == []
+    assert result_again["applied"] == [], "migrations should not re-apply"
+
+    conn = get_connection(db_path)
+    rows = conn.execute("SELECT profile FROM scans").fetchall()
+    assert [r[0] for r in rows] == ["slim"]

--- a/tests/unit/test_profile_enumeration_guard.py
+++ b/tests/unit/test_profile_enumeration_guard.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Guard: no module may hardcode a partial list of scan profile names.
+
+Regression guard for #721. The `slim` profile was added to
+`tool_registry.PROFILE_TOOLS` but never propagated to the eight places that
+enumerated profiles by hand, so slim scans were rejected by the history
+database, both wizard flows, `jmo schedule create/update --profile`, and
+`jmo history store/list --profile`.
+
+Fixing those eight sites fixes the instance. This test fixes the class: adding
+a ninth profile to the registry now fails here rather than silently producing a
+half-supported profile.
+
+The check is deliberately narrow -- it flags only a literal sequence whose
+elements are *all* profile names and which is a *proper subset* of the
+registry. `sorted(PROFILE_TOOLS)` and unrelated string lists are untouched.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts.core.tool_registry import PROFILE_TOOLS
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _literal_string_sequences(tree: ast.AST):
+    """Yield (lineno, tuple-of-strings) for every list/tuple/set literal."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            values = []
+            for element in node.elts:
+                if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                    values.append(element.value)
+                else:
+                    break
+            else:
+                if values:
+                    yield node.lineno, tuple(values)
+
+
+# A deliberately curated subset declares itself at the site. The wizard flows
+# offer narrowed choices on purpose (CI/CD should not run `deep`; a production
+# deployment should not run `fast`), and that is design, not drift. Requiring
+# the marker keeps intent distinguishable from an enumeration nobody updated.
+EXEMPTION_MARKER = "curated-profile-subset:"
+
+
+def _is_exempt(lines: list[str], lineno: int) -> bool:
+    """True if the marker appears on the literal's line or the two above it."""
+    start = max(0, lineno - 3)
+    return any(EXEMPTION_MARKER in line for line in lines[start:lineno])
+
+
+def find_partial_profile_enumerations(scripts_dir: Path | None = None) -> list[str]:
+    """Return 'path:line -> [...]' for each hardcoded partial profile list."""
+    scripts_dir = scripts_dir or SCRIPTS_DIR
+    known = set(PROFILE_TOOLS)
+    violations: list[str] = []
+
+    for path in sorted(scripts_dir.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (SyntaxError, UnicodeDecodeError):
+            continue  # templates and generated files are not our concern
+
+        lines = source.splitlines()
+        for lineno, values in _literal_string_sequences(tree):
+            unique = set(values)
+            if len(unique) >= 2 and unique < known and not _is_exempt(lines, lineno):
+                rel = path.relative_to(scripts_dir.parent).as_posix()
+                violations.append(f"{rel}:{lineno} -> {list(values)}")
+
+    return violations
+
+
+def test_no_module_hardcodes_a_partial_profile_list():
+    """Every profile enumeration must derive from PROFILE_TOOLS.
+
+    Fails if a module lists some-but-not-all profile names literally. Derive
+    from the registry instead:
+
+        choices=sorted(PROFILE_TOOLS)
+    """
+    violations = find_partial_profile_enumerations()
+    assert not violations, (
+        "these modules hardcode a partial profile list and will silently "
+        "exclude any profile added to PROFILE_TOOLS (#721):\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_guard_detects_a_planted_violation(tmp_path):
+    """The guard must be able to fail.
+
+    A guard that cannot fail is indistinguishable from no guard -- which is
+    exactly how the original enumeration survived. This plants a violation and
+    asserts it is caught.
+    """
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True)
+    partial = sorted(PROFILE_TOOLS)[:2]
+    (scripts_dir / "planted.py").write_text(
+        f"choices = {partial!r}\n", encoding="utf-8"
+    )
+
+    violations = find_partial_profile_enumerations(scripts_dir)
+    assert any(
+        "planted.py" in v for v in violations
+    ), f"guard failed to detect a planted partial enumeration {partial}"
+
+
+def test_guard_allows_the_full_registry(tmp_path):
+    """Deriving from the registry must not be flagged.
+
+    Without this, the guard could be "passed" by listing every profile
+    literally, which would drift again on the next addition.
+    """
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "derived.py").write_text(
+        "from scripts.core.tool_registry import PROFILE_TOOLS\n"
+        "choices = sorted(PROFILE_TOOLS)\n",
+        encoding="utf-8",
+    )
+
+    assert find_partial_profile_enumerations(scripts_dir) == []


### PR DESCRIPTION
Closes #721.

## The bug

`jmo scan --profile-name slim` produced a scan that **never entered the history database**. `scans.profile` carried a CHECK constraint enumerating `('fast','balanced','deep')` that predated the `slim` profile, so the insert was rejected — while `jmo report` logged a WARN, printed a traceback, and **still exited 0**.

Every slim scan was invisible to `jmo history`, `jmo diff`, and trend analysis. `slim` is the documented cloud/IaC profile (13 tools, AWS/Azure/GCP/K8s), so this silently discarded a whole category of scan.

## It was 8 sites, not 1

| Site | Fix |
|---|---|
| `history_db.py:106` CHECK constraint | removed |
| `history_db.py:846` `store_scan()` — a **second** hardcoded copy | → `get_known_profiles()` |
| `jmo.py` ×4 — `schedule create/update`, `history store/list` | → `list(PROFILE_TOOLS)` |
| wizard `repo_flow` — choices **and** a stale info box | → `PROFILES` |
| wizard `stack_flow` — choices | → `PROFILES` |

A SQL CHECK cannot express the real rule — *"a profile in `PROFILE_TOOLS` or in the user's `jmo.yml` `profiles:` dict"* — so validation moves into `store_scan()` against the registry, where it cannot drift again.

`repo_flow`'s info box was **separately** stale: it advertised `fast: 3 tools / balanced: 8 / deep: 12` against actual **9 / 17 / 28**, while correct registry-derived data sat in `profile_config.PROFILES` one module away.

**Two sites were deliberately left alone.** `cicd_flow` (`fast`/`balanced`) and `deployment_flow` (`balanced`/`deep`) are curated on purpose — CI/CD shouldn't offer `deep`, a deployment gate shouldn't offer `fast`. They're marked `curated-profile-subset:` with reasons, so intent stays distinguishable from drift.

## The migration, and why it does not rebuild the table

SQLite can't drop a CHECK, so the textbook remedy is create-copy-drop-rename. **Measured against this schema, that is actively dangerous:**

- `findings` and `scan_metadata` both declare `ON DELETE CASCADE` on `scans(id)`, and `get_connection()` sets `PRAGMA foreign_keys=ON`. Measured: **`DROP TABLE scans` destroyed 25/25 findings and 1/1 scan_metadata rows.**
- Two triggers on `findings` reference `scans`, so `ALTER TABLE … RENAME` fails outright. Handling those reveals the next dependency (views).
- **Eleven** objects depend on `scans`: 2 FK tables, 6 indexes, 2 triggers, 2 views.

`v1_2_0` edits the stored DDL via `writable_schema` instead — it moves no data and drops nothing, so all eleven survive untouched. It is idempotent, and verifies `integrity_check` + `foreign_key_check` before it's allowed to commit.

## Tests — written first, and each shown to fail without the fix

- every `PROFILE_TOOLS` key is storable *(failed naming `slim` explicitly)*
- a user-defined `jmo.yml` profile is storable
- `store_scan` rejects an unknown profile / accepts `slim` end-to-end
- a legacy database can store `slim` after migrating
- the migration preserves rows in `scans`, **`findings` and `scan_metadata`**
- the migration preserves indexes, triggers and views
- the migration is a no-op on a fresh database
- a guard failing if any module hardcodes a partial profile list — **plus a planted-violation test proving the guard itself can fail**

Two of the migration tests passed *before* the migration existed (with nothing to migrate, "data was preserved" is trivially true). Mutating the migration into a plausible create-copy-drop-rename turns **3 of them red** — that's what earned them.

The guard found **8 sites where grep found 6**, and correctly flagged **2 that turned out to be intentional** — hence the exemption marker rather than a blanket fix.

## Verification

| Gate | Result |
|---|---|
| `tests/unit` + `tests/cli`, CI marker filter | **4528 passed, 57 skipped, 0 failed** |
| Mutation test on the migration | 3 tests go red — guards proven |
| `black` / `ruff` / `mypy` / `bandit` / import-direction | all pass (pre-commit) |
| Line endings | `--numstat` == `--ignore-cr-at-eol` on all 11 files |

## Also in this branch

One unrelated docs commit (`11aebc9`): a CLAUDE.md note recording the optional local knowledge graph and a Windows setup trap. Kept as a separate commit; folded in here rather than opening a second PR for three paragraphs. Passes doc-links — it names no untracked path as a link.
