### PR TITLE
test(profiling): give timings.json a contract test PR CI actually runs

### DIFF
--- a/tests/integration/test_performance_profiling.py
+++ b/tests/integration/test_performance_profiling.py
@@ -11,8 +11,10 @@ Related:
 """
 
 import json
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -99,25 +101,29 @@ def test_timings_data_structure(tmp_path):
 
     timings_file = tmp_path / "results" / "summaries" / "timings.json"
 
-    if timings_file.exists():
-        timings = json.loads(timings_file.read_text())
+    # #723: this used to be `if timings_file.exists():`, so when the file was
+    # never produced the whole body was skipped and the test passed having
+    # asserted nothing. Assert it instead.
+    assert timings_file.exists(), "report --profile did not write timings.json"
 
-        # Verify timings is a dictionary
-        assert isinstance(timings, dict)
+    timings = json.loads(timings_file.read_text())
 
-        # Check for actual fields from normalize_and_report.py profiling
-        # Fields: aggregate_seconds, recommended_threads, jobs, meta
-        assert "aggregate_seconds" in timings, "Expected 'aggregate_seconds' field"
-        assert isinstance(timings["aggregate_seconds"], (int, float))
-        assert timings["aggregate_seconds"] >= 0
+    # Verify timings is a dictionary
+    assert isinstance(timings, dict)
 
-        # Verify jobs array exists and contains tool timing data
-        assert "jobs" in timings, "Expected 'jobs' array with tool timings"
-        assert isinstance(timings["jobs"], list)
+    # Check for actual fields from normalize_and_report.py profiling
+    # Fields: aggregate_seconds, recommended_threads, jobs, meta
+    assert "aggregate_seconds" in timings, "Expected 'aggregate_seconds' field"
+    assert isinstance(timings["aggregate_seconds"], (int, float))
+    assert timings["aggregate_seconds"] >= 0
 
-        # Verify meta field exists
-        assert "meta" in timings, "Expected 'meta' field"
-        assert isinstance(timings["meta"], dict)
+    # Verify jobs array exists and contains tool timing data
+    assert "jobs" in timings, "Expected 'jobs' array with tool timings"
+    assert isinstance(timings["jobs"], list)
+
+    # Verify meta field exists
+    assert "meta" in timings, "Expected 'meta' field"
+    assert isinstance(timings["meta"], dict)
 
 
 @pytest.mark.requires_tools
@@ -283,3 +289,148 @@ def test_timings_json_is_valid_json(tmp_path):
             assert isinstance(timings, dict)
         except json.JSONDecodeError as e:
             pytest.fail(f"timings.json is not valid JSON: {e}")
+
+
+# --- #723: a contract test that PR CI actually runs -------------------------
+#
+# Every test above is `requires_tools` + `slow`, so `ci.yml`'s marker filter
+# excludes all of them: the timings.json schema had no PR-time guard at all.
+# That is how the schema documented by jmo-profile-optimizer drifted completely
+# away from the producer without anything going red (#718 chunk A / PR #720).
+#
+# This test needs no scanner. `gather_results()` discovers tool output by
+# filename under `individual-*/`, so fabricated stubs drive the real producer.
+
+EXPECTED_TIMINGS_KEYS = {"aggregate_seconds", "recommended_threads", "jobs", "meta"}
+EXPECTED_JOB_KEYS = {"tool", "path", "seconds", "count"}
+
+
+def _fabricate_results(tmp_path):
+    """A results directory the report phase can aggregate, with no real tools."""
+    target = tmp_path / "results" / "individual-repos" / "demo"
+    target.mkdir(parents=True)
+    # Adapters tolerate an empty result set; the job is still timed, which is
+    # what the contract is about.
+    (target / "trivy.json").write_text(json.dumps({"Results": []}), encoding="utf-8")
+    (target / "semgrep.json").write_text(json.dumps({"results": []}), encoding="utf-8")
+    return tmp_path / "results"
+
+
+def _isolated_env():
+    """Env that keeps the child importable while its cwd is a temp dir.
+
+    `history_db.DEFAULT_DB_PATH` is the relative `.jmo/history.db`, so it
+    follows the process cwd. Running the child from tmp_path keeps these tests
+    out of the repository's real history database.
+    """
+    env = dict(os.environ)
+    repo_root = Path(__file__).resolve().parents[2]
+    env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+    return env
+
+
+def _run_report_with_profile(results_dir, tmp_path):
+    """Run `jmo report --profile` and return the parsed timings.json."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.cli.jmo",
+            "report",
+            str(results_dir),
+            "--profile",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        cwd=str(tmp_path),
+        env=_isolated_env(),
+    )
+    timings_file = results_dir / "summaries" / "timings.json"
+    assert timings_file.exists(), (
+        "jmo report --profile did not write timings.json.\n"
+        f"exit={result.returncode}\nstderr tail:\n{result.stderr[-1500:]}"
+    )
+    return json.loads(timings_file.read_text(encoding="utf-8"))
+
+
+def test_timings_json_matches_the_producer_contract(tmp_path):
+    """timings.json has exactly the keys report_orchestrator writes.
+
+    Pinned deliberately with `==`, not `<=`: a *removed* key breaks consumers
+    just as badly as a renamed one, and a silently *added* key is a schema
+    change that should be a conscious edit here.
+
+    Source of truth: scripts/cli/report_orchestrator.py (the `timings` dict).
+    """
+    timings = _run_report_with_profile(_fabricate_results(tmp_path), tmp_path)
+
+    assert set(timings) == EXPECTED_TIMINGS_KEYS, (
+        "timings.json top-level keys drifted from the producer.\n"
+        f"  missing: {sorted(EXPECTED_TIMINGS_KEYS - set(timings))}\n"
+        f"  unexpected: {sorted(set(timings) - EXPECTED_TIMINGS_KEYS)}"
+    )
+
+    assert isinstance(timings["aggregate_seconds"], (int, float))
+    assert timings["aggregate_seconds"] >= 0
+    assert isinstance(timings["recommended_threads"], int)
+    assert timings["recommended_threads"] > 0
+    assert isinstance(timings["meta"], dict)
+
+
+def test_timings_jobs_is_a_flat_list_of_per_file_entries(tmp_path):
+    """`jobs` is a flat list keyed by (tool, file), not a per-tool dict.
+
+    The published skill read `data["tools"]` as a dict of per-tool aggregates.
+    No such key exists, and a tool appears once per result file rather than
+    once overall -- which is what makes real percentiles possible.
+    """
+    timings = _run_report_with_profile(_fabricate_results(tmp_path), tmp_path)
+
+    assert isinstance(timings["jobs"], list), "jobs must be a list, not a mapping"
+    assert (
+        len(timings["jobs"]) == 2
+    ), f"expected one job per fabricated tool output, got {len(timings['jobs'])}"
+
+    for job in timings["jobs"]:
+        assert (
+            set(job) == EXPECTED_JOB_KEYS
+        ), f"job entry keys drifted: {sorted(set(job) ^ EXPECTED_JOB_KEYS)}"
+        assert isinstance(job["tool"], str) and job["tool"]
+        assert isinstance(job["path"], str) and job["path"]
+        assert isinstance(job["seconds"], (int, float)) and job["seconds"] >= 0
+        assert isinstance(job["count"], int) and job["count"] >= 0
+
+    assert {j["tool"] for j in timings["jobs"]} == {"trivy", "semgrep"}
+
+
+def test_timings_json_absent_without_the_profile_flag(tmp_path):
+    """`--profile` is what produces the file; nothing else should."""
+    results_dir = _fabricate_results(tmp_path)
+    subprocess.run(
+        [sys.executable, "-m", "scripts.cli.jmo", "report", str(results_dir)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        cwd=str(tmp_path),
+        env=_isolated_env(),
+    )
+    assert not (results_dir / "summaries" / "timings.json").exists()
+
+
+def test_documented_keys_that_must_not_exist(tmp_path):
+    """Guard against the specific fiction that shipped in a published skill.
+
+    jmo-profile-optimizer documented `total_duration_seconds`, `profile` and a
+    `tools` dict, plus per-tool `timeouts`/`executions`. None are produced. If
+    any ever appears, the deleted timeout analysis can be revisited -- until
+    then this keeps the absence explicit rather than assumed.
+    """
+    timings = _run_report_with_profile(_fabricate_results(tmp_path), tmp_path)
+
+    for absent in ("total_duration_seconds", "profile", "tools", "threads", "timeout"):
+        assert absent not in timings, (
+            f"'{absent}' now exists in timings.json -- see #722 and the Phase 4 "
+            "note in .claude/skills/jmo-profile-optimizer/references/"
+            "optimization-patterns.md before relying on it"
+        )


### PR DESCRIPTION
Refs #723.

## The gap

Every test in `tests/integration/test_performance_profiling.py` was `@pytest.mark.requires_tools` + `@pytest.mark.slow`. `ci.yml`'s filter is `-m "not smoke and not requires_tools and not docker"`, so **all six were excluded from PR CI**. The `timings.json` schema had no PR-time guard at all.

That is how the schema documented by `jmo-profile-optimizer` drifted completely away from the producer without anything going red — see #718 chunk A / #720, where executing the documented parser against real output raised `KeyError: 'total_duration_seconds'`.

## Correcting the issue as I filed it

#723 claimed no test asserted the real keys. **That was wrong** — `test_timings_data_structure` did assert `aggregate_seconds`, `jobs` and `meta` with types.

The real problem is worse in a different way: those assertions sat inside `if timings_file.exists():`, so whenever the file was *not* produced the entire body was skipped and the test passed having asserted nothing. That guard is now an assertion.

## What's added

Four tests that need **no scanner**. `gather_results()` discovers tool output by filename under `individual-*/`, so fabricated stubs drive the real producer through the real CLI in **~2.3s**:

| Test | Guards |
|---|---|
| `..._matches_the_producer_contract` | top-level keys are **exactly** `{aggregate_seconds, recommended_threads, jobs, meta}` |
| `..._jobs_is_a_flat_list_of_per_file_entries` | `jobs` is a flat list of per-*(tool, file)* entries with exactly `{tool, path, seconds, count}` — not the per-tool dict the skill assumed |
| `..._absent_without_the_profile_flag` | `--profile` is what produces the file |
| `..._documented_keys_that_must_not_exist` | the shipped fiction stays absent: `total_duration_seconds`, `profile`, `tools`, `threads`, `timeout` |

Keys are pinned with `==`, not `<=`: a **removed** key breaks consumers as badly as a renamed one, and a silently **added** key is a schema change that should be a conscious edit to this test.

## Test isolation bug fixed along the way

`history_db.DEFAULT_DB_PATH` is the **relative** `.jmo/history.db`, so it follows the process cwd — these tests would otherwise write into the repository's real history database. The child now runs with `cwd=tmp_path` and `PYTHONPATH` set.

## Proven able to fail

All four passed on first run, which proves nothing on its own. Two mutations of the producer:

| Mutation | Result |
|---|---|
| `aggregate_seconds` → `total_duration_seconds` (the exact drift the skill assumed) | **2 tests red** |
| job key `count` → `findings_count` | **1 test red** |

Producer restored afterwards, verified by an empty `git diff`.

## Verification

- 4 passed in 2.28s under the **exact CI marker filter** (the 6 old tests correctly deselected)
- `black` / `ruff` / `mypy` / `bandit` clean via pre-commit
- Line endings: `--numstat` == `--ignore-cr-at-eol`

Leaves the six `requires_tools` tests otherwise untouched — I can't run them locally without scanners, and changing tests I cannot verify would be the same mistake this PR exists to fix.
