### PR TITLE
build(makefile): probe both venv layouts so Windows stops using PATH python

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,7 @@ See [docs/USER_GUIDE.md](docs/USER_GUIDE.md) for complete configuration referenc
 | Tool not found | `jmo tools check`, then `jmo tools install` |
 | Tool startup crash | `jmo tools clean --force && jmo tools install <tool>` |
 | Pre-commit fails | `make fmt`, `make lint` |
+| `No module named pytest` (or any dep) when the venv demonstrably has it | You are on a different interpreter. On Windows the venv is `.venv/Scripts/python.exe`, never `.venv/bin/python`, and `chmod +x` is a no-op there — so `[ -x .venv/bin/python ]` is false *whatever* exists, and PATH `python3` wins. On a box with other tooling installed that is somebody else's venv. Invoke `.venv/Scripts/python.exe -m pytest` (or `uv run pytest`, which resolves the project venv on every platform — note it syncs against `uv.lock` first, so it may change your env). `Makefile:6` probes both layouts as of #722. |
 | `uv.lock needs to be updated, but --check was provided` | Deps changed in `pyproject.toml` without relocking. `make deps-lock && git add uv.lock`. Local `uv sync` refreshes a stale lock silently; CI and pre-commit hard-fail — that asymmetry is deliberate |
 | CI failures | Check matrix tests, coverage, pre-commit |
 | SQLite locked | `jmo history optimize` (runs VACUUM + ANALYZE; there is no `vacuum` subcommand) |

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,16 @@
 
 .PHONY: help fmt lint typecheck test test-fast test-parallel test-profile test-e2e test-e2e-visual test-e2e-report verify clean tools verify-env analyze-completeness verify-completeness dev-deps dev-setup pre-commit-install pre-commit-run install-git-hooks upgrade-pip deps-sync deps-lock deps-upgrade docker-build docker-build-all docker-build-local docker-push docker-test validate-readme check-pypi-readme collect-metrics metrics verify-badges samples-clean samples-scan samples-report samples-verify regenerate-samples dist dist-clean dist-verify clean-build clean-test clean-caches clean-all
 
-# Prefer workspace venv if available
-PY := $(shell [ -x .venv/bin/python ] && echo .venv/bin/python || echo python3)
+# Prefer workspace venv if available.
+#
+# Both layouts must be probed: a venv puts its interpreter in `bin/` on POSIX
+# and in `Scripts/` on Windows. Probing only `bin/` meant every Windows checkout
+# silently fell through to PATH `python3` -- a different interpreter with none
+# of this project's dependencies, and on a machine with other tooling installed
+# (an agent runtime, another project's venv) not even a system Python. The
+# failure is a bare `No module named pytest`, which reads like a broken install
+# rather than the wrong interpreter.
+PY := $(shell for p in .venv/bin/python .venv/Scripts/python.exe; do [ -x "$$p" ] && echo "$$p" && break; done || echo python3)
 
 help:
 	@echo "Targets:"


### PR DESCRIPTION
`Makefile:6` tested only `.venv/bin/python` — the POSIX layout. A Windows venv
puts its interpreter at `.venv/Scripts/python.exe`, and `chmod +x` is a no-op on
Windows where `[ -x ]` keys off the file extension. So the probe **could not have
succeeded on Windows under any arrangement of files**: it fell through to PATH
`python3` 100% of the time, for all 25 `$(PY)` call sites including every test
target.

On a machine with other tooling installed, that is not even a system Python. Here
it resolved to an unrelated agent runtime's venv, so `make test` reported
`No module named pytest` — which reads like a broken install rather than the
wrong interpreter.

## Why this is safe for CI

The new candidate is probed **second**. A POSIX checkout matches
`.venv/bin/python` first and breaks the loop exactly as before, so Linux
behaviour is unchanged by construction — the added branch only runs where the
old one had already failed.

This matters because `release.rules.md` documents CI depending on this logic
(`make test-e2e-visual` runs `.venv`'s python).

## Evidence gate

CI cannot catch this: every runner is Linux or macOS-shaped for this code path,
so the broken branch is never exercised. The verification is evaluating the
expression against each of the four possible layouts.

| Layout | `$(PY)` resolves to | vs. before |
|---|---|---|
| both present | `.venv/bin/python` | unchanged |
| POSIX only (CI) | `.venv/bin/python` | unchanged |
| **Windows only** | `.venv/Scripts/python.exe` | **was `python3`** |
| neither | `python3` | unchanged |

Also measured on this machine: `[ -x ]` returns false for an extensionless
`chmod +x` file, confirming the old probe's failure mode is total rather than
occasional.

Adds one CLAUDE.md troubleshooting row so the symptom (`No module named pytest`
from a venv that demonstrably has it) maps to the cause.