### PR TITLE
feat(scan): persist the per-tool timings the scan phase already measures

### DIFF
--- a/.claude/rules/testing.cross-platform.rules.md
+++ b/.claude/rules/testing.cross-platform.rules.md
@@ -306,5 +306,26 @@ Pytest invocations in CI workflows use these filter sets. Each filter is tuned t
 
 - **Always exclude `requires_tools` and `smoke`** unless the runner explicitly installs the prerequisite (real tool binaries or the released PyPI wheel).
 - **Always exclude `docker`** unless the runner has a Docker daemon (Linux runners do; macOS/Windows runners require setup).
-- **Include `slow`** only when the job has a generous timeout budget (nightly, full e2e). Exclude in PR-time CI (`ci.yml`).
+- **`slow` is NOT excluded from PR-time CI.** `ci.yml`'s **sharded** jobs (`:312`, `:327`) run `-m "not smoke and not requires_tools and not docker"` — slow tests included. Only the **Quick coverage check** (`:352`) and `nightly-cross-platform` (`:448`) add `and not slow`. Exclude it when the job's budget is tight, not because it is PR-time.
 - **Use `-m "<marker>"` to RUN only that marker**'s tests after installing prerequisites; use `-m "not <marker>"` to EXCLUDE.
+
+### Reproducing a shard locally
+
+**Use the sharded filter, not the coverage filter.** They are not the same suite,
+and the coverage one is strictly smaller:
+
+```bash
+# What the shards actually run -- this is the one to reproduce
+pytest tests/ -p no:xdist -m "not smoke and not requires_tools and not docker"
+```
+
+Verifying with `and not slow` appended is verifying against fewer tests than gate
+the PR. Measured on #722: a full local `tests/unit tests/cli` sweep came back
+**4552 passed, 0 failed** with the coverage filter, while shard 3 failed on
+`tests/integration/test_scan_accounting.py` — a `@pytest.mark.slow` test the
+local filter had deselected. Two independent gaps compounded: the wrong marker
+filter *and* omitting `tests/integration/` from the path list.
+
+The bullet above this one used to say slow was excluded in PR-time CI, which is
+what produced that run. It contradicted the table in this same section — when
+they disagree, the table is generated from the workflows and wins.

--- a/.claude/skills/jmo-profile-optimizer/SKILL.md
+++ b/.claude/skills/jmo-profile-optimizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jmo-profile-optimizer
-description: Analyze report-phase timing data from `jmo report --profile` and tune profile configuration (threads, timeouts, per-tool flags) against measured evidence. Use when report aggregation is slow or a profile needs rebalancing.
+description: Analyze scan-phase tool timings (`scan-timings.json`) and report-phase parse timings (`jmo report --profile`), then tune profile configuration (threads, timeouts, per-tool flags) against measured evidence. Use when a scan or its report is slow, or a profile needs rebalancing.
 argument-hint: <profile-name>
 user-invocable: true
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
@@ -21,9 +21,13 @@ Measure before optimizing. Every recommendation must cite actual timing data.
 
 ### What this skill can and cannot measure
 
-`jmo report --profile` writes `<results-dir>/summaries/timings.json`, which
-records the **report phase**: how long JMo took to read and normalize each tool's
-output. It does **not** record how long the tools took to run.
+There are **two** timing files, and they measure different phases. Confusing
+them is how this skill drifted in the first place.
+
+| File | Written by | Measures |
+|---|---|---|
+| `<results-dir>/summaries/timings.json` | `jmo report --profile` | **report** phase — how long adapters took to *parse* tool output |
+| `<results-dir>/individual-*/<target>/scan-timings.json` | `jmo scan` (always) | **scan** phase — how long each tool took to *run* |
 
 | Question | Answerable | Source |
 |---|---|---|
@@ -31,12 +35,13 @@ output. It does **not** record how long the tools took to run.
 | How many findings does each tool produce? | yes | `timings.json` `jobs[].count` |
 | Is the report worker count right? | yes | `recommended_threads` vs `meta.max_workers` |
 | How long did the whole scan take? | yes | `jmo history list` / `jmo history show` |
-| How long did **one tool** take to run? | **no** | not recorded anywhere |
-| What is a tool's timeout or failure rate? | **no** | not recorded anywhere |
+| How long did **one tool** take to run? | yes | `scan-timings.json` `tools[].duration` |
+| Did a tool time out **on this scan**? | yes | `scan-timings.json` `tools[].error_message` starts `"Timeout after "` — **not** `status`, which never takes the `"timeout"` value its docstring claims |
+| What is a tool's timeout **rate across scans**? | **no** | `scan-timings.json` is per-scan; nothing aggregates it yet (#722) |
 
-If the question is "why is the scan slow", this skill can only narrow it to
-whole-scan durations from history plus configured timeouts. Per-tool scan
-timing needs instrumentation that does not exist yet.
+So "why is the scan slow" is now answerable per tool, from the scan's own
+output. "Is tool X *usually* slow, or was that one run" is not — that needs the
+per-scan files collected over time, which nothing does yet.
 
 ---
 

--- a/.claude/skills/jmo-profile-optimizer/references/memory-integration.md
+++ b/.claude/skills/jmo-profile-optimizer/references/memory-integration.md
@@ -214,8 +214,10 @@ Every ratio goes through `pct_change`, so a zero or absent baseline produces a
 `no_sample` entry instead of `ZeroDivisionError`. Newly introduced tools are
 skipped explicitly rather than compared against nothing.
 
-> **Timeout and failure rates are not compared, because JMo does not record
-> them.** See [optimization-patterns.md Phase 4](optimization-patterns.md#phase-4-timeout-and-failure-analysis--no-data-source).
+> **Timeout and failure rates are not compared.** Per-tool outcomes exist for a
+> single scan (`scan-timings.json`), but nothing aggregates them across runs, so
+> there is no rate to compare a baseline against. See
+> [optimization-patterns.md Phase 4](optimization-patterns.md#phase-4-timeout-and-failure-analysis).
 
 ### Example comparison output
 

--- a/.claude/skills/jmo-profile-optimizer/references/optimization-patterns.md
+++ b/.claude/skills/jmo-profile-optimizer/references/optimization-patterns.md
@@ -14,11 +14,11 @@ tuning.
 > JMo took to **read and normalize tool output** — not how long the tools took to
 > **run**.
 >
-> **JMo records no per-tool scan duration, timeout count, or failure count
-> anywhere.** `history_db` stores a single `duration_seconds` per *scan*
-> (`scripts/core/history_db.py:103`) with no tool breakdown. Do not infer tool
-> runtime, timeout rate, or failure rate from this file — see
-> [Phase 4](#phase-4-timeout-and-failure-analysis--no-data-source).
+> **Do not infer tool runtime, timeouts, or failures from this file.** Those
+> live in `scan-timings.json`, written by the scan phase — see
+> [Phase 4](#phase-4-timeout-and-failure-analysis). `history_db` still stores a
+> single `duration_seconds` per *scan* (`scripts/core/history_db.py:103`) with
+> no tool breakdown, so cross-scan *rates* remain unavailable.
 
 ---
 
@@ -200,27 +200,58 @@ against wall clock would let them exceed it.
 
 ---
 
-## Phase 4: Timeout and Failure Analysis — no data source
+## Phase 4: Timeout and Failure Analysis
 
 Earlier revisions of this skill documented an `analyze_timeouts()` function
 computing per-tool timeout and failure rates from
-`metrics["timeouts"] / metrics["executions"]`.
+`metrics["timeouts"] / metrics["executions"]`. Those keys never existed, and
+when this skill was rewritten there was no per-tool scan data at all, so the
+analysis was deleted rather than repaired.
 
-**JMo records none of those values.** `timings.json` carries parse timings only;
-`history_db` stores one `duration_seconds` per *scan*
-(`scripts/core/history_db.py:103`) with no per-tool breakdown; and the scan
-orchestrator reads `config.timeout` to pass to each tool but never records
-whether a tool hit it. The analysis was removed rather than repaired, because
-there is nothing in the codebase to repair it against.
+**#722 added the data source.** Every scan now writes
+`<results-dir>/individual-*/<target>/scan-timings.json`, built from the
+`ToolResult` objects `ToolRunner` had always produced and the scan jobs had
+always discarded.
 
-Restoring it needs per-tool scan instrumentation, which is a code change, not a
-documentation change.
+Schema — the authority is `scripts/core/scan_timings.py`, and `schema_version`
+guards it:
 
-What can be stated about timeouts today:
+| Key | Meaning |
+|---|---|
+| `schema_version` | `1`. Refuse a shape you do not recognise rather than misreading it. |
+| `target` / `target_type` | Which target, and one of `repo` / `image` / `iac` / `url` / `k8s`. |
+| `wall_seconds` | Elapsed time of the whole parallel tool batch. |
+| `tools[]` | One entry per invocation: `tool`, `status`, `returncode`, `attempts`, `duration`, `output_file`, `error_message`. |
 
-- The **configured** value, read from `jmo.yml` (`timeout`, and
-  `per_tool.<tool>.timeout`).
-- Whether a tool produced **no output at all**, from the scan's own accounting.
+`tools[].status` carries **four** values, not a coarse pass/fail:
+`success`, `no_output`, `error`, `retry_exhausted`. Read `no_output`
+carefully — it means an *accepted* return code with an empty artifact, which
+is a tool that appeared to work and did not.
+
+> **Do not test `status == "timeout"`.** `ToolResult`'s docstring claims that
+> value but `scripts/core/tool_runner.py` never assigns it (measured: the only
+> `"timeout"` literal is a progress-callback UI signal). A timed-out tool
+> reports `error` or `retry_exhausted` with
+> `error_message` beginning `"Timeout after "` — which is how all five scan
+> jobs detect it. Match on `error_message` until #727 resolves the producer.
+
+### The denominator trap
+
+Tools run concurrently, so `sum(tools[].duration)` **exceeds** `wall_seconds`.
+Use `wall_seconds` as the denominator for "what share of the scan was tool X".
+Using the sum understates every tool by the parallelism factor — the same
+invalid-denominator defect this skill was reviewed for.
+
+### What is still not answerable
+
+A **rate** needs more than one scan. `scan-timings.json` is per-scan and per-
+target, and nothing collects it across runs — `history_db` still stores only
+one `duration_seconds` per scan (`scripts/core/history_db.py:103`) with no
+per-tool breakdown. So:
+
+- "did `dependency-check` time out on this scan" — yes, read `status`.
+- "does `dependency-check` time out 30% of the time" — no. That needs the
+  history persistence deferred out of #722.
 
 ---
 
@@ -382,4 +413,7 @@ budget scan time by image count rather than by repository count.
 
 > Whether any of these settings actually helps is not measurable from
 > `timings.json` — it records report-phase parsing only. Verify a timeout change
-> by re-running the scan and comparing `jmo history list` durations.
+> against `scan-timings.json`: re-run the scan and compare that tool's
+> `duration` and `status`. A cap that "fixed" a slow tool by killing it shows up
+> as `status: "timeout"`, which a whole-scan duration from `jmo history list`
+> would have reported as an improvement.

--- a/.claude/skills/jmo-profile-optimizer/references/output-report-format.md
+++ b/.claude/skills/jmo-profile-optimizer/references/output-report-format.md
@@ -109,8 +109,10 @@ optimizing the adapter.
 4. Store the updated baseline (automatic, final phase)
 
 **Verifying a timeout change:** `timings.json` cannot confirm it — it records
-report-phase parsing only. Compare whole-scan durations with
-`jmo history list` before and after.
+report-phase parsing only. Read that tool's `duration` and `status` in
+`scan-timings.json` before and after. Do not judge it by whole-scan duration
+alone: a cap tight enough to kill a healthy tool makes the scan *faster* while
+producing `status: "timeout"` and no findings.
 
 ---
 
@@ -132,5 +134,7 @@ report-phase parsing only. Compare whole-scan durations with
 | Updated Configuration | Ready-to-paste `jmo.yml` per-tool overrides |
 | Next Steps | Applying and verifying the changes |
 
-**Not included:** per-tool timeout and failure rates. JMo does not record them —
-see [optimization-patterns.md Phase 4](optimization-patterns.md#phase-4-timeout-and-failure-analysis--no-data-source).
+**Not included:** per-tool timeout and failure *rates*. A rate needs many scans,
+and nothing aggregates `scan-timings.json` across runs yet. Per-tool outcomes
+**for a single scan** are available — see
+[optimization-patterns.md Phase 4](optimization-patterns.md#phase-4-timeout-and-failure-analysis).

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -312,7 +312,7 @@ def _add_report_args(subparsers: argparse._SubParsersAction) -> Any:
     rp.add_argument(
         "--profile",
         action="store_true",
-        help="Collect per-tool timing and write timings.json (for profile SELECTION use --profile-name on scan/ci)",
+        help="Write timings.json: per-adapter PARSE timing for the report phase (tool run times live in scan-timings.json, written by scan). For profile SELECTION use --profile-name on scan/ci",
     )
     rp.add_argument(
         "--threads",
@@ -352,7 +352,7 @@ def _add_ci_args(subparsers: argparse._SubParsersAction) -> Any:
     cp.add_argument(
         "--profile",
         action="store_true",
-        help="Collect timings.json during report (for profile SELECTION use --profile-name)",
+        help="Write timings.json: per-adapter PARSE timing for the report phase (tool run times live in scan-timings.json, written by scan). For profile SELECTION use --profile-name",
     )
     cp.add_argument(
         "--policy",

--- a/scripts/cli/scan_jobs/iac_scanner.py
+++ b/scripts/cli/scan_jobs/iac_scanner.py
@@ -10,10 +10,12 @@ Integrates with ToolRunner for execution management.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from pathlib import Path
 
 from ...core.config import RetryConfig
+from ...core.scan_timings import write_scan_timings
 from ...core.tool_runner import ToolDefinition, ToolRunner
 from ..path_sanitizers import _sanitize_path_component, _validate_output_path
 from ..scan_utils import find_tool, report_tool_failure, write_stub
@@ -146,7 +148,18 @@ def scan_iac_file(
     runner = ToolRunner(
         tools=tool_defs,
     )
+    tools_started = time.perf_counter()
     results = runner.run_all_parallel()
+
+    # ToolRunner already timed and classified every invocation. Record that
+    # before the loop below reduces the results to booleans (#722).
+    write_scan_timings(
+        out_dir,
+        results,
+        target=safe_name,
+        target_type="iac",
+        wall_seconds=time.perf_counter() - tools_started,
+    )
 
     # Process results
     attempts_map: dict[str, int] = {}

--- a/scripts/cli/scan_jobs/image_scanner.py
+++ b/scripts/cli/scan_jobs/image_scanner.py
@@ -10,10 +10,12 @@ Integrates with ToolRunner for execution management.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from pathlib import Path
 
 from ...core.config import RetryConfig
+from ...core.scan_timings import write_scan_timings
 from ...core.tool_runner import ToolDefinition, ToolRunner
 from ..path_sanitizers import _sanitize_path_component, _validate_output_path
 from ..scan_utils import find_tool, report_tool_failure, write_stub
@@ -145,7 +147,18 @@ def scan_image(
     runner = ToolRunner(
         tools=tool_defs,
     )
+    tools_started = time.perf_counter()
     results = runner.run_all_parallel()
+
+    # ToolRunner already timed and classified every invocation. Record that
+    # before the loop below reduces the results to booleans (#722).
+    write_scan_timings(
+        out_dir,
+        results,
+        target=safe_name,
+        target_type="image",
+        wall_seconds=time.perf_counter() - tools_started,
+    )
 
     # Process results
     attempts_map: dict[str, int] = {}

--- a/scripts/cli/scan_jobs/k8s_scanner.py
+++ b/scripts/cli/scan_jobs/k8s_scanner.py
@@ -9,10 +9,12 @@ Integrates with ToolRunner for execution management.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from pathlib import Path
 
 from ...core.config import RetryConfig
+from ...core.scan_timings import write_scan_timings
 from ...core.tool_runner import ToolDefinition, ToolRunner
 from ..scan_utils import find_tool, report_tool_failure, write_stub
 
@@ -127,7 +129,18 @@ def scan_k8s_resource(
     runner = ToolRunner(
         tools=tool_defs,
     )
+    tools_started = time.perf_counter()
     results = runner.run_all_parallel()
+
+    # ToolRunner already timed and classified every invocation. Record that
+    # before the loop below reduces the results to booleans (#722).
+    write_scan_timings(
+        out_dir,
+        results,
+        target=safe_name,
+        target_type="k8s",
+        wall_seconds=time.perf_counter() - tools_started,
+    )
 
     # Process results
     attempts_map: dict[str, int] = {}

--- a/scripts/cli/scan_jobs/repository_scanner.py
+++ b/scripts/cli/scan_jobs/repository_scanner.py
@@ -53,11 +53,13 @@ Integrates with ToolRunner for parallel execution and resilient error handling.
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable
 from pathlib import Path
 
 from ...core.config import RetryConfig
 from ...core.paths import get_yara_rules_dir
+from ...core.scan_timings import write_scan_timings
 from ...core.tool_runner import ToolDefinition, ToolRunner
 from ..path_sanitizers import _sanitize_path_component, _validate_output_path
 from ..scan_utils import find_tool, report_tool_failure, write_stub
@@ -1399,7 +1401,19 @@ def scan_repository(
         tools=tool_defs,
         progress_callback=progress_callback,  # type: ignore[arg-type]
     )
+    tools_started = time.perf_counter()
     results = runner.run_all_parallel()
+
+    # ToolRunner already timed and classified every invocation. Record that
+    # before the loop below reduces the results to booleans, which is where it
+    # used to be lost (#722).
+    write_scan_timings(
+        out_dir,
+        results,
+        target=name,
+        target_type="repo",
+        wall_seconds=time.perf_counter() - tools_started,
+    )
 
     # Process results
     attempts_map: dict[str, int] = {}

--- a/scripts/cli/scan_jobs/url_scanner.py
+++ b/scripts/cli/scan_jobs/url_scanner.py
@@ -12,11 +12,13 @@ Integrates with ToolRunner for execution management.
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import urlparse
 
 from ...core.config import RetryConfig
+from ...core.scan_timings import write_scan_timings
 from ...core.tool_runner import ToolDefinition, ToolRunner
 from ..scan_utils import find_tool, report_tool_failure, write_stub
 
@@ -199,7 +201,18 @@ def scan_url(
     runner = ToolRunner(
         tools=tool_defs,
     )
+    tools_started = time.perf_counter()
     results = runner.run_all_parallel()
+
+    # ToolRunner already timed and classified every invocation. Record that
+    # before the loop below reduces the results to booleans (#722).
+    write_scan_timings(
+        out_dir,
+        results,
+        target=safe_name,
+        target_type="url",
+        wall_seconds=time.perf_counter() - tools_started,
+    )
 
     # Process results
     attempts_map: dict[str, int] = {}

--- a/scripts/core/scan_timings.py
+++ b/scripts/core/scan_timings.py
@@ -1,0 +1,115 @@
+"""Persist the per-tool measurements the scan phase already takes.
+
+`ToolRunner` times every invocation with `perf_counter` and returns a
+`ToolResult` carrying `duration`, `status`, `returncode` and `attempts`. Until
+#722 nothing read those fields: each scan job iterated the results, kept
+`.tool` and `.status`, and reduced them to a dict of booleans. The measurement
+existed and was discarded one line before it could be recorded.
+
+This module writes it out. It deliberately does no measuring of its own -- the
+numbers here are the ones `ToolRunner` already produced.
+
+Related:
+- `scripts/cli/report_orchestrator.py` writes the sibling `timings.json`, which
+  covers the **report** phase (how long adapters took to parse tool output).
+  This file covers the **scan** phase (how long the tools took to run). They
+  answer different questions and neither substitutes for the other.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from scripts.core.tool_runner import ToolResult
+
+logger = logging.getLogger(__name__)
+
+SCAN_TIMINGS_FILENAME = "scan-timings.json"
+
+# Bumped when the document's shape changes. Consumers (jmo-profile-optimizer,
+# any external tooling) can then refuse a shape they do not understand instead
+# of silently misreading it -- which is exactly how the report-phase schema
+# drifted for months without anything noticing (#718 chunk A).
+SCAN_TIMINGS_SCHEMA_VERSION = 1
+
+
+def build_scan_timings(
+    results: list[ToolResult],
+    *,
+    target: str,
+    target_type: str,
+    wall_seconds: float,
+) -> dict[str, Any]:
+    """Build the scan-timings document for one target.
+
+    Args:
+        results: The `ToolResult` list `ToolRunner.run_all_parallel()` returned.
+        target: Target identifier (repository name, image ref, URL, ...).
+        target_type: One of 'repo', 'image', 'iac', 'url', 'k8s'.
+        wall_seconds: Elapsed time of the parallel tool batch.
+
+    Returns:
+        A JSON-serializable dict.
+
+    `wall_seconds` is recorded rather than derived because tools run
+    concurrently: the per-tool durations sum to more than the elapsed time, so
+    that sum is an invalid denominator for "what share of the scan was tool X".
+    Keeping the real elapsed span removes the need to reconstruct it wrongly.
+    """
+    return {
+        "schema_version": SCAN_TIMINGS_SCHEMA_VERSION,
+        "target": target,
+        "target_type": target_type,
+        "wall_seconds": round(wall_seconds, 3),
+        # `to_dict()` and never `dataclasses.asdict()`: the latter would include
+        # `stdout` and `stderr`, and on a secret scanner stdout *is* the
+        # secrets. This artifact is meant to be pasteable into an issue.
+        "tools": [r.to_dict() for r in results],
+    }
+
+
+def write_scan_timings(
+    out_dir: Path,
+    results: list[ToolResult],
+    *,
+    target: str,
+    target_type: str,
+    wall_seconds: float,
+) -> Path | None:
+    """Write `scan-timings.json` into a target's output directory.
+
+    Args:
+        out_dir: The target's output directory (sibling of `trivy.json` etc.).
+        results: The `ToolResult` list from `ToolRunner.run_all_parallel()`.
+        target: Target identifier.
+        target_type: One of 'repo', 'image', 'iac', 'url', 'k8s'.
+        wall_seconds: Elapsed time of the parallel tool batch.
+
+    Returns:
+        The path written, or None if it could not be written.
+
+    Never raises on a write failure. This runs after every tool has finished --
+    up to 70 minutes on a `deep` profile -- so an unwritable diagnostic file
+    must not discard a completed scan's results. The failure is logged instead,
+    because an artifact that goes missing without saying so is the failure mode
+    this repository keeps relearning.
+    """
+    path = out_dir / SCAN_TIMINGS_FILENAME
+    document = build_scan_timings(
+        results,
+        target=target,
+        target_type=target_type,
+        wall_seconds=wall_seconds,
+    )
+    try:
+        path.write_text(json.dumps(document, indent=2), encoding="utf-8")
+    except OSError as e:
+        logger.warning(
+            "Could not write %s to %s: %s", SCAN_TIMINGS_FILENAME, out_dir, e
+        )
+        return None
+    return path

--- a/scripts/dev/reconcile_scan_accounting.py
+++ b/scripts/dev/reconcile_scan_accounting.py
@@ -240,6 +240,17 @@ def parse_log(log_text: str) -> Diagnostics:
     )
 
 
+# Filenames under `individual-*/<target>/` that are scan metadata rather than a
+# tool's findings. Every other `*.json` there is mapped to a tool by its stem, so
+# an unlisted artifact is reported as `stray_output` -- correctly, since that is
+# the check that catches a tool nobody declared having written a file.
+#
+# Keep this an explicit allowlist, never a pattern. The invariant is worth more
+# than the convenience: a new artifact should have to be named here on purpose,
+# because the alternative is a rule loose enough to also swallow a real tool.
+NON_TOOL_ARTIFACTS = frozenset({"scan-timings"})
+
+
 def parse_outputs(results_dir: Path) -> tuple[dict[str, int], frozenset[str]]:
     """Map tool -> record count for every output file that actually parses."""
     counts: dict[str, int] = {}
@@ -249,6 +260,8 @@ def parse_outputs(results_dir: Path) -> tuple[dict[str, int], frozenset[str]]:
             continue
         for f in sorted(target.glob("*.json")):
             tool = f.stem
+            if tool in NON_TOOL_ARTIFACTS:
+                continue
             raw = f.read_text(encoding="utf-8", errors="replace")
             n: int | None = None
             try:

--- a/tests/cli/test_cli_args.py
+++ b/tests/cli/test_cli_args.py
@@ -48,3 +48,50 @@ def test_cmd_report_missing_results_dir_returns_error(tmp_path: Path):
     )
     rc = cmd_report(args)
     assert rc == 2
+
+
+def _profile_flag_help(monkeypatch, subcommand: str) -> str:
+    """The `--profile` help string as argparse would print it for a subcommand."""
+    monkeypatch.setattr(sys, "argv", ["jmo", subcommand, "--help"])
+    import argparse
+
+    captured = {}
+
+    def record(self, *a, **k):
+        for action in self._actions:
+            if "--profile" in action.option_strings:
+                captured["help"] = action.help
+        raise SystemExit(0)
+
+    monkeypatch.setattr(argparse.ArgumentParser, "print_help", record)
+    try:
+        parse_args()
+    except SystemExit:
+        pass
+    return captured.get("help", "")
+
+
+def test_profile_flag_help_names_the_phase_it_times(monkeypatch):
+    """`--profile` must not read as if it timed the tools.
+
+    It writes `timings.json`, which measures how long *adapters took to parse*
+    tool output -- the report phase. The old wording, "Collect per-tool timing
+    and write timings.json", reads as per-tool *scan* timing, and that is
+    exactly how it was read: issue #722 was filed asking for instrumentation
+    that this flag was believed to provide and never did.
+
+    Scan-phase tool durations live in `scan-timings.json`, written by the scan
+    jobs. Both files exist now, so the flag has to say which one it is.
+    """
+    for subcommand in ("report", "ci"):
+        help_text = _profile_flag_help(monkeypatch, subcommand).lower()
+
+        assert "parse" in help_text, (
+            f"`jmo {subcommand} --profile` does not say it times parsing. "
+            f"Got: {help_text!r}"
+        )
+        assert "scan-timings.json" in help_text, (
+            f"`jmo {subcommand} --profile` does not point at the scan-phase "
+            f"file, so a user looking for tool run times has no signpost. "
+            f"Got: {help_text!r}"
+        )

--- a/tests/cli/test_scan_timings_persistence.py
+++ b/tests/cli/test_scan_timings_persistence.py
@@ -1,0 +1,183 @@
+"""Every scan job must persist the timings its ToolRunner produced.
+
+`ToolRunner` measures each invocation and hands back a `ToolResult` carrying
+`duration`, `status`, `returncode` and `attempts`. Each scan job then iterated
+those results, kept `.tool` and `.status`, and dropped the rest -- so "which
+tool made my scan slow?" had no answer in JMo's own output even though JMo had
+measured it (#722).
+
+Five jobs share that loop, and the shape of this bug is *omission*: a job that
+simply never calls the writer looks completely normal. So these tests are
+parameterized across all five, and a separate test asserts the parameterization
+still covers every job that runs tools -- otherwise a sixth scanner added later
+would silently opt out of instrumentation and nothing would go red.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.cli.scan_jobs.iac_scanner import scan_iac_file
+from scripts.cli.scan_jobs.image_scanner import scan_image
+from scripts.cli.scan_jobs.k8s_scanner import scan_k8s_resource
+from scripts.cli.scan_jobs.repository_scanner import scan_repository
+from scripts.cli.scan_jobs.url_scanner import scan_url
+from scripts.core.scan_timings import SCAN_TIMINGS_FILENAME
+from scripts.core.tool_runner import ToolResult
+
+SCAN_JOBS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "cli" / "scan_jobs"
+
+
+def _repo_target(tmp_path: Path) -> dict:
+    repo = tmp_path / "test-repo"
+    repo.mkdir()
+    return {"repo": repo}
+
+
+def _iac_target(tmp_path: Path) -> dict:
+    # write_bytes, not write_text: Path.write_text translates LF to CRLF on
+    # Windows (newline=None -> os.linesep).
+    tf = tmp_path / "main.tf"
+    tf.write_bytes(b'resource "aws_s3_bucket" "b" {}\n')
+    return {"iac_type": "terraform", "iac_path": tf}
+
+
+# (module under scripts.cli.scan_jobs, entry point, target kwargs, tool, target_type)
+SCANNERS = [
+    pytest.param(
+        "repository_scanner",
+        scan_repository,
+        _repo_target,
+        "trivy",
+        "repo",
+        id="repository",
+    ),
+    pytest.param("iac_scanner", scan_iac_file, _iac_target, "checkov", "iac", id="iac"),
+    pytest.param(
+        "k8s_scanner",
+        scan_k8s_resource,
+        lambda _: {
+            "k8s_info": {"context": "ctx", "namespace": "ns", "all_namespaces": ""}
+        },
+        "trivy",
+        "k8s",
+        id="k8s",
+    ),
+    pytest.param(
+        "image_scanner",
+        scan_image,
+        lambda _: {"image": "nginx:latest"},
+        "trivy",
+        "image",
+        id="image",
+    ),
+    pytest.param(
+        "url_scanner",
+        scan_url,
+        lambda _: {"url": "https://example.com"},
+        "zap",
+        "url",
+        id="url",
+    ),
+]
+
+PARAMETERIZED_MODULES = {p.values[0] for p in SCANNERS}
+
+
+def _run(module: str, scan_func, target_kwargs: dict, tool: str, tmp_path: Path):
+    """Run a scan job whose single tool succeeds, with ToolRunner mocked out."""
+    with patch(f"scripts.cli.scan_jobs.{module}.ToolRunner") as MockRunner:
+        mock_runner = MagicMock()
+        MockRunner.return_value = mock_runner
+        mock_runner.run_all_parallel.return_value = [
+            ToolResult(
+                tool=tool,
+                status="success",
+                returncode=0,
+                attempts=1,
+                duration=12.5,
+            )
+        ]
+        return scan_func(
+            **target_kwargs,
+            results_dir=tmp_path,
+            tools=[tool],
+            timeout=600,
+            retries=0,
+            per_tool_config={},
+            allow_missing_tools=True,
+            find_tool_func=lambda t: f"/usr/bin/{t}",
+            write_stub_func=lambda name, path: None,
+        )
+
+
+def _read_timings(tmp_path: Path) -> dict:
+    """Find and parse the one scan-timings.json written under tmp_path."""
+    written = list(tmp_path.rglob(SCAN_TIMINGS_FILENAME))
+    assert written, (
+        f"no {SCAN_TIMINGS_FILENAME} was written. The scan job ran its tools, "
+        f"received their durations from ToolRunner, and discarded them -- which "
+        f"is the #722 defect this test exists to prevent."
+    )
+    assert len(written) == 1, f"expected exactly one timings file, got {written}"
+    return json.loads(written[0].read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("module,scan_func,target,tool,target_type", SCANNERS)
+def test_scan_job_persists_its_tool_durations(
+    module, scan_func, target, tool, target_type, tmp_path
+):
+    """The duration ToolRunner measured reaches disk instead of being dropped."""
+    _run(module, scan_func, target(tmp_path), tool, tmp_path)
+
+    doc = _read_timings(tmp_path)
+    entries = {t["tool"]: t for t in doc["tools"]}
+
+    assert tool in entries, f"{module}: {tool} ran but is absent from the timings"
+    assert (
+        entries[tool]["duration"] == 12.5
+    ), f"{module}: the measured duration did not survive to disk"
+    assert entries[tool]["status"] == "success"
+
+
+@pytest.mark.parametrize("module,scan_func,target,tool,target_type", SCANNERS)
+def test_scan_job_records_its_own_target_type(
+    module, scan_func, target, tool, target_type, tmp_path
+):
+    """Each job labels its output, so timings can be grouped across a mixed scan.
+
+    A single `jmo scan` can cover repositories, images and URLs at once. Without
+    the type, per-tool numbers from a container scan and a repo scan are
+    indistinguishable once collected -- and trivy runs in both.
+    """
+    _run(module, scan_func, target(tmp_path), tool, tmp_path)
+
+    assert _read_timings(tmp_path)["target_type"] == target_type
+
+
+def test_every_tool_running_scan_job_is_covered_here():
+    """The parameterization must not fall behind the scan_jobs package.
+
+    This bug's shape is omission: a job that never calls the writer looks
+    entirely normal and no assertion fires. Discovering the jobs from the source
+    instead of a hand-kept list means a sixth scanner cannot quietly opt out of
+    instrumentation -- adding one turns this test red until it is wired up.
+    """
+    runs_tools = set()
+    for path in SCAN_JOBS_DIR.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == "run_all_parallel":
+                runs_tools.add(path.stem)
+
+    assert runs_tools == PARAMETERIZED_MODULES, (
+        "scan jobs that invoke tools are no longer the same set this file "
+        "covers.\n"
+        f"  not covered here: {sorted(runs_tools - PARAMETERIZED_MODULES)}\n"
+        f"  no longer run tools: {sorted(PARAMETERIZED_MODULES - runs_tools)}"
+    )

--- a/tests/unit/test_scan_accounting.py
+++ b/tests/unit/test_scan_accounting.py
@@ -26,6 +26,7 @@ from scripts.dev.reconcile_scan_accounting import (
     ACCOUNTED_STATES,
     Diagnostics,
     parse_log,
+    parse_outputs,
     reconcile,
 )
 
@@ -331,3 +332,31 @@ def test_progress_glyphs_are_not_mistaken_for_durable_accounts() -> None:
     result = reconcile(declared=["trivy"], diags=diags, output_counts={})
     assert result.unaccounted == ["trivy"]
     assert not result.ok
+
+
+def test_scan_timings_is_not_counted_as_a_tool_output(tmp_path) -> None:
+    """`scan-timings.json` is metadata about the scan, not a tool's output.
+
+    `parse_outputs` maps every `*.json` under `individual-*/<target>/` to a tool
+    by filename stem, so a non-tool artifact dropped in that directory is
+    reported as `stray_output` -- an output file nothing declared. That is the
+    reconciler working correctly; the fix is to tell it which filenames are
+    scan metadata rather than to loosen the invariant, which is the only thing
+    standing between a silently-unaccounted tool and a green scan (#722).
+    """
+    target = tmp_path / "individual-repos" / "demo"
+    target.mkdir(parents=True)
+    (target / "trivy.json").write_bytes(b'{"Results": []}')
+    (target / "scan-timings.json").write_bytes(
+        b'{"schema_version": 1, "target": "demo", "target_type": "repo", '
+        b'"wall_seconds": 1.0, "tools": []}'
+    )
+
+    counts, unparseable = parse_outputs(tmp_path)
+
+    assert "scan-timings" not in counts, (
+        "scan-timings.json was counted as a tool output, so the reconciler "
+        "will report it as an artifact nothing declared"
+    )
+    assert "trivy" in counts, "a real tool output must still be counted"
+    assert unparseable == frozenset()

--- a/tests/unit/test_scan_timings.py
+++ b/tests/unit/test_scan_timings.py
@@ -1,0 +1,251 @@
+"""The scan phase must persist the per-tool measurements it already takes.
+
+`ToolRunner` has always produced a `ToolResult` per invocation carrying
+`duration` (a real `perf_counter` span), `status`, `returncode` and `attempts`.
+Every scan job then iterated those results reading only `.tool` and `.status`,
+collapsed them to a dict of booleans, and dropped the rest on the floor -- so
+"which tool made my scan slow?" was unanswerable from JMo's own data even though
+JMo had measured the answer (#722).
+
+These tests pin the file that keeps it. Two properties matter more than the
+schema itself:
+
+* **Nothing captured from the tool's own streams may be written.** `stdout` on a
+  secret scanner's result is the secrets it found. `to_dict()` already excludes
+  `stdout`/`stderr`; a future `asdict()` "simplification" would turn this
+  artifact into a leak, so it is asserted rather than assumed.
+* **`status` is not collapsed into a coarser outcome enum.** #722 proposed a
+  four-value outcome with `skipped` in it; `ToolRunner`'s four real values are
+  different, and `no_output` -- an accepted return code with nothing written --
+  is the exact shape of the #700 bug class. Mapping between the two vocabularies
+  would discard the signal that found a real defect.
+
+See `TOOL_RUNNER_STATUSES` below for why that count is four and not the five
+`ToolResult`'s docstring advertises (#727).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from scripts.core.scan_timings import (
+    SCAN_TIMINGS_FILENAME,
+    SCAN_TIMINGS_SCHEMA_VERSION,
+    write_scan_timings,
+)
+from scripts.core.tool_runner import ToolResult
+
+EXPECTED_TOP_LEVEL_KEYS = {
+    "schema_version",
+    "target",
+    "target_type",
+    "wall_seconds",
+    "tools",
+}
+
+
+def _write(tmp_path: Path, results: list[ToolResult], **kwargs) -> dict:
+    """Write a timings file into tmp_path and return the parsed document."""
+    params = {
+        "target": "demo",
+        "target_type": "repo",
+        "wall_seconds": 1.0,
+        **kwargs,
+    }
+    path = write_scan_timings(tmp_path, results, **params)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_writes_the_file_beside_the_tool_outputs(tmp_path: Path) -> None:
+    """The artifact lands in the target's own output directory.
+
+    Consumers discover it the same way they discover `trivy.json` -- by name
+    inside `individual-<type>s/<target>/` -- so it must be a sibling of the
+    tool output it describes, not a separate tree to correlate.
+    """
+    path = write_scan_timings(
+        tmp_path,
+        [ToolResult(tool="trivy", status="success", returncode=0, duration=3.5)],
+        target="demo",
+        target_type="repo",
+        wall_seconds=3.6,
+    )
+
+    assert path == tmp_path / SCAN_TIMINGS_FILENAME
+    assert path.exists(), "write_scan_timings returned a path it did not create"
+
+
+def test_top_level_keys_are_pinned_to_the_producer(tmp_path: Path) -> None:
+    """Pinned with `==`, matching the timings.json contract test from #723.
+
+    A removed key breaks a consumer exactly as badly as a renamed one, and a
+    silently added key is a schema change that should be a conscious edit here.
+    This is the guard the report-phase `timings.json` lacked for months while
+    the published skill drifted completely away from it.
+    """
+    doc = _write(tmp_path, [ToolResult(tool="trivy", status="success")])
+
+    assert set(doc) == EXPECTED_TOP_LEVEL_KEYS, (
+        "scan-timings.json top-level keys drifted from the producer.\n"
+        f"  missing: {sorted(EXPECTED_TOP_LEVEL_KEYS - set(doc))}\n"
+        f"  unexpected: {sorted(set(doc) - EXPECTED_TOP_LEVEL_KEYS)}"
+    )
+    assert doc["schema_version"] == SCAN_TIMINGS_SCHEMA_VERSION
+    assert doc["target"] == "demo"
+    assert doc["target_type"] == "repo"
+
+
+def test_per_tool_entries_are_exactly_tool_result_to_dict(tmp_path: Path) -> None:
+    """The per-tool record is `ToolResult.to_dict()`, not a re-derived shape.
+
+    Re-deriving would create a second vocabulary for data that already has one,
+    and every rename in `ToolResult` would then need a matching edit here to
+    stay honest -- which is precisely the drift this file exists to prevent.
+    """
+    result = ToolResult(
+        tool="semgrep",
+        status="success",
+        returncode=0,
+        attempts=2,
+        duration=12.5,
+        output_file=Path("semgrep.json"),
+    )
+
+    doc = _write(tmp_path, [result])
+
+    assert doc["tools"] == [result.to_dict()]
+
+
+def test_never_serializes_tool_stdout_or_stderr(tmp_path: Path) -> None:
+    """A scanner's captured output is its findings. It must not land here.
+
+    trufflehog's stdout is a list of live credentials. `scan-timings.json` is a
+    performance artifact users paste into issues, so anything read off the
+    tool's own streams is disqualified regardless of how convenient it is.
+    """
+    doc_text = json.dumps(
+        _write(
+            tmp_path,
+            [
+                ToolResult(
+                    tool="trufflehog",
+                    status="success",
+                    returncode=0,
+                    duration=4.0,
+                    stdout='{"Raw": "AKIA_SECRET_FROM_STDOUT"}',
+                    stderr="stderr-content-marker",
+                )
+            ],
+        )
+    )
+
+    assert "AKIA_SECRET_FROM_STDOUT" not in doc_text, (
+        "tool stdout reached scan-timings.json. On a secret scanner that is the "
+        "secrets themselves. Serialize via ToolResult.to_dict(), never asdict()."
+    )
+    assert "stderr-content-marker" not in doc_text, (
+        "tool stderr reached scan-timings.json; it can carry scanned file "
+        "content and paths well beyond what a timing artifact needs."
+    )
+
+
+# The four values `tool_runner.py` actually assigns to `ToolResult.status`.
+#
+# Deliberately NOT five. `ToolResult`'s own docstring claims a `"timeout"`
+# status, and #722's rescoping read that claim off the docstring rather than the
+# code -- but `run_tool` never assigns it. A timed-out tool gets `error` or
+# `retry_exhausted` with `error_message="Timeout after Ns"`, which is why all
+# five scan jobs detect timeouts by string-matching that message. Listing
+# `"timeout"` here would make this file assert against fiction, which is the
+# exact defect class the #718 remediation exists to remove.
+TOOL_RUNNER_STATUSES = ["success", "no_output", "error", "retry_exhausted"]
+
+
+@pytest.mark.parametrize("status", TOOL_RUNNER_STATUSES)
+def test_preserves_every_tool_runner_status_verbatim(
+    tmp_path: Path, status: str
+) -> None:
+    """Each status survives; none is folded into a coarser outcome.
+
+    `no_output` is the one that matters most: an accepted return code with an
+    empty artifact is how checkov's broken Windows wrapper was graded a success
+    across all 5 repos of a public-repo benchmark while the scan exited 0. A
+    four-value outcome enum of the shape #722 proposed has nowhere to put it.
+    """
+    doc = _write(tmp_path, [ToolResult(tool="checkov", status=status)])
+
+    assert doc["tools"][0]["status"] == status
+
+
+def test_records_wall_seconds_apart_from_the_sum_of_durations(
+    tmp_path: Path,
+) -> None:
+    """Both numbers are kept, because they answer different questions.
+
+    Tools run concurrently, so the per-tool durations sum to more than the
+    elapsed time. Using that sum as the denominator for "what share of my scan
+    was tool X" understates every tool by the parallelism factor -- the same
+    invalid-denominator defect the profile-optimizer review caught (#718 chunk
+    A). Recording the real elapsed span removes the temptation to reconstruct
+    it wrongly.
+    """
+    doc = _write(
+        tmp_path,
+        [
+            ToolResult(tool="trivy", status="success", duration=30.0),
+            ToolResult(tool="semgrep", status="success", duration=45.0),
+        ],
+        wall_seconds=48.0,
+    )
+
+    assert doc["wall_seconds"] == 48.0
+    assert sum(t["duration"] for t in doc["tools"]) == 75.0, (
+        "per-tool durations must be preserved individually, not normalised "
+        "against wall_seconds"
+    )
+
+
+def test_empty_result_set_still_writes_a_file(tmp_path: Path) -> None:
+    """ "No tools ran" is a measurement, and a missing file cannot express it.
+
+    Without the file, a scan where every tool was skipped is indistinguishable
+    from a build where this feature is not working at all.
+    """
+    doc = _write(tmp_path, [], wall_seconds=0.0)
+
+    assert doc["tools"] == []
+    assert doc["wall_seconds"] == 0.0
+
+
+def test_an_unwritable_directory_does_not_abort_the_scan(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A diagnostic artifact must never cost a completed scan its results.
+
+    This runs after every tool has finished -- up to 70 minutes of work on a
+    `deep` profile. Raising here would discard all of it to protect a timing
+    file, so the failure is logged and the scan continues.
+
+    Logged, not swallowed: a silently absent artifact is the failure mode this
+    repository keeps relearning, so it has to name itself on a durable stream
+    rather than only in a progress glyph.
+    """
+    missing = tmp_path / "does" / "not" / "exist"
+
+    with caplog.at_level(logging.WARNING, logger="scripts.core.scan_timings"):
+        path = write_scan_timings(
+            missing,
+            [ToolResult(tool="trivy", status="success")],
+            target="demo",
+            target_type="repo",
+            wall_seconds=1.0,
+        )
+
+    assert path is None, "an unwritable destination must report no file written"
+    assert (
+        SCAN_TIMINGS_FILENAME in caplog.text
+    ), f"the write failed on no stream. caplog was: {caplog.text!r}"


### PR DESCRIPTION
Closes the measurable part of #722.

## The rescoping held up

`ToolRunner` has always timed every invocation with `perf_counter` and returned
a `ToolResult` carrying `duration`, `status`, `returncode` and `attempts`. All
five scan jobs then iterated those results, kept `.tool` and `.status`, reduced
them to a dict of booleans, and dropped the rest — so *"which tool made my scan
slow?"* had no answer in JMo's own output even though JMo had measured it.

**This adds no measurement.** It persists objects that already existed.

Every scan now writes `individual-*/<target>/scan-timings.json`:
`schema_version`, `target`, `target_type`, `wall_seconds`, and `tools[]` (one
`ToolResult.to_dict()` per invocation).

## Three decisions worth reviewing

- **`to_dict()`, never `asdict()`.** The latter includes `stdout`/`stderr`, and
  on a secret scanner stdout *is* the secrets. Asserted, not assumed.
- **`wall_seconds` recorded, not derived.** Tools run concurrently, so
  `sum(durations)` exceeds elapsed time and is an invalid denominator for
  per-tool share — the same defect the profile-optimizer review caught.
- **`status` kept verbatim.** #722 proposed a four-value outcome enum; mapping
  onto it destroys `no_output` (an accepted return code with an empty artifact),
  which is the #700 bug class.

A write failure logs and returns `None` rather than raising: this runs after
every tool has finished, up to 70 minutes on `deep`, and a diagnostic file must
not cost a completed scan its results.

## A defect found on the way — filed as #727

`ToolResult`'s docstring documents a `"timeout"` status that `tool_runner.py`
**never assigns** (the only `"timeout"` literal is a progress-callback UI
signal). A timed-out tool gets `error`/`retry_exhausted` with
`error_message="Timeout after Ns"` — which is why all five scan jobs detect
timeouts by string-matching that message.

#722's own rescoping comment had claimed `status` already covered `timeout`,
having read the docstring rather than the code. Not fixed inline: two existing
tests pin the current values and collapsing `retry_exhausted` loses the
exhausted-budget signal, so it is a design call, not a typo. The skill and tests
here document the **four** real values.

## Evidence gate

CI cannot catch a serialization leak or a lossy status mapping — both produce
green tests, because the tests are the thing that would have to assert them. So
the verification is **mutation**: break the guard, confirm it goes red.

| Mutation | Result |
|---|---|
| `to_dict()` → `dataclasses.asdict()` | **2 red**, incl. `AKIA_SECRET_FROM_STDOUT` found in the artifact |
| `status` → #722's 4-value enum | **3 red** — exactly the statuses it would have destroyed, incl. `no_output` |

Both restored from a file backup (not `git checkout --`) and re-verified green.

| Check | Result |
|---|---|
| new tests | **26 passed** |
| `tests/unit` + `tests/cli` | **4552 passed, 57 skipped, 0 failed** (11m45s) — see correction below |
| skip count vs. baseline | **57 → 57, unchanged** — nothing silently stopped running |
| `check_doc_links.py` | all links in 162 tracked files resolve |
| black + ruff + mypy + bandit + import-direction | clean |
| `git diff --numstat` vs `--ignore-cr-at-eol` | identical |

A source-discovered test asserts the 5-scanner parameterization still matches
every scan job calling `run_all_parallel`, so a sixth scanner cannot silently
skip instrumentation — this bug's shape is *omission*, which no per-scanner
assertion catches.

## Deferred, deliberately

- **`history_db` persistence** (issue marks it optional): needs a schema
  migration. Consequence stated in the skill rather than glossed — per-tool
  outcomes work for **one scan**; cross-scan *rates* still do not. The cheap
  route when picked up is the existing generic `scan_metadata` key/value table,
  which needs no migration.
- **Deleting `scan_utils.py:291 run_cmd()`** (~85 lines, zero callers).

Also reinstates the timeout analysis in `jmo-profile-optimizer` (#718 chunk A
deleted it for want of a data source) and rewords `--profile` help on `report`
and `ci`, whose "Collect per-tool timing" phrasing is what got #722 filed on a
false premise.


---

## Correction: the first verification run used the wrong filter, and CI caught it

The sweep above ran `-m "not smoke and not requires_tools and not docker and not
slow"` over `tests/unit tests/cli`. That is the **Quick coverage check** filter
(`ci.yml:352`), not the **sharded** one (`:312`, `:327`) — the shards do *not*
exclude `slow`. So it was verifying against a strictly smaller suite than gates
the PR, and it omitted `tests/integration/` entirely.

Shard 3 duly failed:

```
AssertionError: Output files exist for names nothing declared: ['scan-timings']
tests/integration/test_scan_accounting.py:264
```

The scan reconciler maps every `*.json` under `individual-*/<target>/` to a tool
by filename stem, so the new metadata artifact read as `stray_output`. **The
reconciler was right** — that check is what catches a tool having written a file
nobody declared, and it is the invariant the scan-core work exists to protect.

Fixed by naming the artifact (`NON_TOOL_ARTIFACTS`), an explicit allowlist rather
than a pattern: anything broad enough to match `scan-timings` is also broad
enough to swallow a real tool.

| Re-verification | Result |
|---|---|
| new unit test, **before** the fix | RED — reproduces CI's exact assertion in 0.75s |
| `tests/unit/test_scan_accounting.py` after | **28 passed** |
| the failing test, **CI's shard filter**, slow included | **1 passed in 111.18s** |

Also corrects `.claude/rules/testing.cross-platform.rules.md`, which is what
produced the bad run: its rule-of-thumb claimed PR-time CI excludes `slow`, while
the table fifteen lines above it correctly showed the shards including it.
