### PR TITLE
fix(tool_runner): make a timeout structurally detectable

### DIFF
--- a/.claude/skills/jmo-profile-optimizer/SKILL.md
+++ b/.claude/skills/jmo-profile-optimizer/SKILL.md
@@ -36,7 +36,7 @@ them is how this skill drifted in the first place.
 | Is the report worker count right? | yes | `recommended_threads` vs `meta.max_workers` |
 | How long did the whole scan take? | yes | `jmo history list` / `jmo history show` |
 | How long did **one tool** take to run? | yes | `scan-timings.json` `tools[].duration` |
-| Did a tool time out **on this scan**? | yes | `scan-timings.json` `tools[].error_message` starts `"Timeout after "` — **not** `status`, which never takes the `"timeout"` value its docstring claims |
+| Did a tool time out **on this scan**? | yes | `scan-timings.json` `tools[].timed_out` — a boolean, **not** a `status` value |
 | What is a tool's timeout **rate across scans**? | **no** | `scan-timings.json` is per-scan; nothing aggregates it yet (#722) |
 
 So "why is the scan slow" is now answerable per tool, from the scan's own

--- a/.claude/skills/jmo-profile-optimizer/references/optimization-patterns.md
+++ b/.claude/skills/jmo-profile-optimizer/references/optimization-patterns.md
@@ -221,19 +221,24 @@ guards it:
 | `schema_version` | `1`. Refuse a shape you do not recognise rather than misreading it. |
 | `target` / `target_type` | Which target, and one of `repo` / `image` / `iac` / `url` / `k8s`. |
 | `wall_seconds` | Elapsed time of the whole parallel tool batch. |
-| `tools[]` | One entry per invocation: `tool`, `status`, `returncode`, `attempts`, `duration`, `output_file`, `error_message`. |
+| `tools[]` | One entry per invocation: `tool`, `status`, `timed_out`, `returncode`, `attempts`, `duration`, `output_file`, `error_message`. |
 
 `tools[].status` carries **four** values, not a coarse pass/fail:
 `success`, `no_output`, `error`, `retry_exhausted`. Read `no_output`
 carefully — it means an *accepted* return code with an empty artifact, which
 is a tool that appeared to work and did not.
 
-> **Do not test `status == "timeout"`.** `ToolResult`'s docstring claims that
-> value but `scripts/core/tool_runner.py` never assigns it (measured: the only
-> `"timeout"` literal is a progress-callback UI signal). A timed-out tool
-> reports `error` or `retry_exhausted` with
-> `error_message` beginning `"Timeout after "` — which is how all five scan
-> jobs detect it. Match on `error_message` until #727 resolves the producer.
+> **A timeout is `tools[].timed_out`, not a `status` value.** `status` has no
+> `"timeout"` member — its docstring claimed one for months while `run_tool`
+> never assigned it, which is how #722 came to be filed on a false premise.
+> #727 added a separate boolean instead of a fifth status, so that
+> `retry_exhausted` keeps its own meaning: *this failure burned the whole retry
+> budget*. A timed-out tool therefore reports **both**
+> `status: "error" | "retry_exhausted"` **and** `timed_out: true`.
+>
+> Read them together. `timed_out` with `retry_exhausted` and `attempts: 4` is a
+> tool that is reliably too slow for its budget; `timed_out` with `error` and
+> `attempts: 1` timed out once and was not retried.
 
 ### The denominator trap
 
@@ -414,6 +419,6 @@ budget scan time by image count rather than by repository count.
 > Whether any of these settings actually helps is not measurable from
 > `timings.json` — it records report-phase parsing only. Verify a timeout change
 > against `scan-timings.json`: re-run the scan and compare that tool's
-> `duration` and `status`. A cap that "fixed" a slow tool by killing it shows up
-> as `status: "timeout"`, which a whole-scan duration from `jmo history list`
+> `duration` and `timed_out`. A cap that "fixed" a slow tool by killing it shows
+> up as `timed_out: true`, which a whole-scan duration from `jmo history list`
 > would have reported as an improvement.

--- a/.claude/skills/jmo-profile-optimizer/references/output-report-format.md
+++ b/.claude/skills/jmo-profile-optimizer/references/output-report-format.md
@@ -109,10 +109,10 @@ optimizing the adapter.
 4. Store the updated baseline (automatic, final phase)
 
 **Verifying a timeout change:** `timings.json` cannot confirm it — it records
-report-phase parsing only. Read that tool's `duration` and `status` in
+report-phase parsing only. Read that tool's `duration` and `timed_out` in
 `scan-timings.json` before and after. Do not judge it by whole-scan duration
 alone: a cap tight enough to kill a healthy tool makes the scan *faster* while
-producing `status: "timeout"` and no findings.
+producing `timed_out: true` and no findings.
 
 ---
 

--- a/scripts/cli/scan_jobs/iac_scanner.py
+++ b/scripts/cli/scan_jobs/iac_scanner.py
@@ -179,11 +179,35 @@ def scan_iac_file(
             # FileNotFoundError at exec, and was recorded as a clean scan.
             statuses[result.tool] = False
             report_tool_failure(result, "its executable was not found at run time")
-        else:
-            # Other errors (timeout, non-zero exit, etc.)
+        elif result.timed_out:
+            # A timeout gets a stub so the report phase sees a consistent file
+            # tree -- but the stub must never be the only signal. Once read, an
+            # empty stub is indistinguishable from a tool that ran and found
+            # nothing, so the timeout has to be stated on the log or it is lost.
+            tool_out = out_dir / f"{result.tool}.json"
+            if not tool_out.exists():
+                _write_stub(result.tool, tool_out)
             statuses[result.tool] = False
             if result.attempts > 0:
                 attempts_map[result.tool] = result.attempts
+            report_tool_failure(result, "it timed out")
+        else:
+            # Other errors (non-zero exit, no output, etc.). This used to record
+            # False and return without logging anything at all, so a tool that
+            # failed contributed nothing to the scan and said so on no stream
+            # (#727). A non-TTY run renders no progress display, which makes the
+            # log the only durable record.
+            statuses[result.tool] = False
+            if result.attempts > 0:
+                attempts_map[result.tool] = result.attempts
+            report_tool_failure(
+                result,
+                (
+                    "it exited with an accepted code but wrote no output"
+                    if result.status == "no_output"
+                    else "it failed"
+                ),
+            )
 
     # Include attempts metadata if any retries occurred
     if attempts_map:

--- a/scripts/cli/scan_jobs/image_scanner.py
+++ b/scripts/cli/scan_jobs/image_scanner.py
@@ -178,11 +178,35 @@ def scan_image(
             # FileNotFoundError at exec, and was recorded as a clean scan.
             statuses[result.tool] = False
             report_tool_failure(result, "its executable was not found at run time")
-        else:
-            # Other errors (timeout, non-zero exit, etc.)
+        elif result.timed_out:
+            # A timeout gets a stub so the report phase sees a consistent file
+            # tree -- but the stub must never be the only signal. Once read, an
+            # empty stub is indistinguishable from a tool that ran and found
+            # nothing, so the timeout has to be stated on the log or it is lost.
+            tool_out = out_dir / f"{result.tool}.json"
+            if not tool_out.exists():
+                _write_stub(result.tool, tool_out)
             statuses[result.tool] = False
             if result.attempts > 0:
                 attempts_map[result.tool] = result.attempts
+            report_tool_failure(result, "it timed out")
+        else:
+            # Other errors (non-zero exit, no output, etc.). This used to record
+            # False and return without logging anything at all, so a tool that
+            # failed contributed nothing to the scan and said so on no stream
+            # (#727). A non-TTY run renders no progress display, which makes the
+            # log the only durable record.
+            statuses[result.tool] = False
+            if result.attempts > 0:
+                attempts_map[result.tool] = result.attempts
+            report_tool_failure(
+                result,
+                (
+                    "it exited with an accepted code but wrote no output"
+                    if result.status == "no_output"
+                    else "it failed"
+                ),
+            )
 
     # Include attempts metadata if any retries occurred
     if attempts_map:

--- a/scripts/cli/scan_jobs/k8s_scanner.py
+++ b/scripts/cli/scan_jobs/k8s_scanner.py
@@ -160,11 +160,35 @@ def scan_k8s_resource(
             # FileNotFoundError at exec, and was recorded as a clean scan.
             statuses[result.tool] = False
             report_tool_failure(result, "its executable was not found at run time")
-        else:
-            # Other errors (timeout, non-zero exit, etc.)
+        elif result.timed_out:
+            # A timeout gets a stub so the report phase sees a consistent file
+            # tree -- but the stub must never be the only signal. Once read, an
+            # empty stub is indistinguishable from a tool that ran and found
+            # nothing, so the timeout has to be stated on the log or it is lost.
+            tool_out = out_dir / f"{result.tool}.json"
+            if not tool_out.exists():
+                _write_stub(result.tool, tool_out)
             statuses[result.tool] = False
             if result.attempts > 0:
                 attempts_map[result.tool] = result.attempts
+            report_tool_failure(result, "it timed out")
+        else:
+            # Other errors (non-zero exit, no output, etc.). This used to record
+            # False and return without logging anything at all, so a tool that
+            # failed contributed nothing to the scan and said so on no stream
+            # (#727). A non-TTY run renders no progress display, which makes the
+            # log the only durable record.
+            statuses[result.tool] = False
+            if result.attempts > 0:
+                attempts_map[result.tool] = result.attempts
+            report_tool_failure(
+                result,
+                (
+                    "it exited with an accepted code but wrote no output"
+                    if result.status == "no_output"
+                    else "it failed"
+                ),
+            )
 
     # Include attempts metadata if any retries occurred
     if attempts_map:

--- a/scripts/cli/scan_jobs/repository_scanner.py
+++ b/scripts/cli/scan_jobs/repository_scanner.py
@@ -1485,9 +1485,15 @@ def scan_repository(
             # lie being removed.
             statuses[result.tool] = False
             report_tool_failure(result, "its executable was not found at run time")
-        elif "Timeout" in result.error_message:
+        elif result.timed_out:
             # Tool timed out - write stub so report phase has consistent files
             # and mark as failed (timeout is a failure state)
+            #
+            # `result.timed_out`, not `"Timeout" in result.error_message` (#727).
+            # That match made a human-readable message load-bearing: rewording
+            # "Timeout after 600s" would have silently routed every timeout to
+            # the generic branch below, dropping the stub and the "it timed out"
+            # log line, with nothing going red.
             #
             # The stub must not be the only signal: once the report phase reads
             # it, an empty stub is indistinguishable from a tool that genuinely

--- a/scripts/cli/scan_jobs/url_scanner.py
+++ b/scripts/cli/scan_jobs/url_scanner.py
@@ -232,11 +232,35 @@ def scan_url(
             # FileNotFoundError at exec, and was recorded as a clean scan.
             statuses[result.tool] = False
             report_tool_failure(result, "its executable was not found at run time")
-        else:
-            # Other errors (timeout, non-zero exit, etc.)
+        elif result.timed_out:
+            # A timeout gets a stub so the report phase sees a consistent file
+            # tree -- but the stub must never be the only signal. Once read, an
+            # empty stub is indistinguishable from a tool that ran and found
+            # nothing, so the timeout has to be stated on the log or it is lost.
+            tool_out = out_dir / f"{result.tool}.json"
+            if not tool_out.exists():
+                _write_stub(result.tool, tool_out)
             statuses[result.tool] = False
             if result.attempts > 0:
                 attempts_map[result.tool] = result.attempts
+            report_tool_failure(result, "it timed out")
+        else:
+            # Other errors (non-zero exit, no output, etc.). This used to record
+            # False and return without logging anything at all, so a tool that
+            # failed contributed nothing to the scan and said so on no stream
+            # (#727). A non-TTY run renders no progress display, which makes the
+            # log the only durable record.
+            statuses[result.tool] = False
+            if result.attempts > 0:
+                attempts_map[result.tool] = result.attempts
+            report_tool_failure(
+                result,
+                (
+                    "it exited with an accepted code but wrote no output"
+                    if result.status == "no_output"
+                    else "it failed"
+                ),
+            )
 
     # Include attempts metadata if any retries occurred
     if attempts_map:

--- a/scripts/core/tool_runner.py
+++ b/scripts/core/tool_runner.py
@@ -205,9 +205,22 @@ class ToolResult:
 
     Attributes:
         tool: Tool name
-        status: Execution status ("success", "no_output", "timeout", "error",
-            "retry_exhausted"). "no_output" means the return code was acceptable
-            but the tool wrote nothing to its declared output_file.
+        status: Execution status. Exactly four values are ever assigned:
+            "success", "no_output", "error", "retry_exhausted". "no_output"
+            means the return code was acceptable but the tool wrote nothing to
+            its declared output_file.
+
+            There is deliberately no "timeout" status -- see ``timed_out``.
+            This docstring claimed one until #727, while ``run_tool`` never
+            assigned it; the only "timeout" literal in this module is a
+            progress-callback UI signal. Reading the docstring instead of the
+            code is how #722 came to be filed on a false premise.
+        timed_out: Whether the terminal failure was a timeout. Separate from
+            ``status`` on purpose: "retry_exhausted" carries its own signal --
+            *this failure burned the whole retry budget* -- and folding a
+            timeout into ``status`` would discard it. A timed-out tool
+            therefore reports ``status="error"`` or ``"retry_exhausted"`` **and**
+            ``timed_out=True``.
         returncode: Process return code (or -1 if timeout/error)
         stdout: Standard output (empty if not captured)
         stderr: Standard error output
@@ -228,6 +241,7 @@ class ToolResult:
     output_file: Path | None = None
     capture_stdout: bool = False
     error_message: str = ""
+    timed_out: bool = False
 
     def is_success(self) -> bool:
         """Check if tool execution was successful."""
@@ -243,6 +257,7 @@ class ToolResult:
             "duration": self.duration,
             "output_file": str(self.output_file) if self.output_file else None,
             "error_message": self.error_message,
+            "timed_out": self.timed_out,
         }
 
 
@@ -387,6 +402,10 @@ class ToolRunner:
         rc = tool.retry_config
         attempt = 0
         last_error = ""
+        # Paired with last_error: whichever failure ends the loop is the one
+        # the returned ToolResult describes, so this must be reassigned at
+        # every site that sets last_error -- not only at the timeout one.
+        last_failure_was_timeout = False
 
         # Track attempts per failure type
         attempts_by_type: dict[str, int] = {}
@@ -517,6 +536,7 @@ class ToolRunner:
                 last_error = (
                     f"Return code {result.returncode} not in {tool.ok_return_codes}"
                 )
+                last_failure_was_timeout = False
                 attempts_by_type["crash"] = attempts_by_type.get("crash", 0) + 1
                 budget = rc.attempts_for_failure("crash")
                 if attempts_by_type["crash"] < budget:
@@ -528,6 +548,7 @@ class ToolRunner:
 
             except subprocess.TimeoutExpired:
                 last_error = f"Timeout after {tool.timeout}s"
+                last_failure_was_timeout = True
                 attempts_by_type["timeout"] = attempts_by_type.get("timeout", 0) + 1
                 budget = rc.attempts_for_failure("timeout")
 
@@ -571,6 +592,7 @@ class ToolRunner:
 
             except (OSError, PermissionError) as e:
                 last_error = str(e)
+                last_failure_was_timeout = False
                 attempts_by_type["system_error"] = (
                     attempts_by_type.get("system_error", 0) + 1
                 )
@@ -587,6 +609,7 @@ class ToolRunner:
                 Exception
             ) as e:  # Acceptable: tool invocation may fail unexpectedly — retry with budget
                 last_error = str(e)
+                last_failure_was_timeout = False
                 attempts_by_type["unknown"] = attempts_by_type.get("unknown", 0) + 1
                 budget = rc.attempts_for_failure("unknown")
                 logger.error(
@@ -608,6 +631,7 @@ class ToolRunner:
             attempts=attempt,
             duration=duration,
             error_message=last_error,
+            timed_out=last_failure_was_timeout,
         )
 
     def run_all_parallel(self) -> list[ToolResult]:

--- a/tests/cli/test_repository_scanner.py
+++ b/tests/cli/test_repository_scanner.py
@@ -926,6 +926,7 @@ class TestRepositoryScanner:
                     tool="semgrep-secrets",
                     status="error",
                     attempts=2,
+                    timed_out=True,
                     error_message="Timeout after 900s",
                 ),
             ]
@@ -976,6 +977,7 @@ class TestRepositoryScanner:
                     tool="semgrep-secrets",
                     status="retry_exhausted",
                     attempts=3,
+                    timed_out=True,
                     error_message="Timeout after 900s",
                 ),
             ]
@@ -1288,7 +1290,8 @@ class TestFailedToolsAreReported:
                 [
                     ToolResult(
                         tool="dependency-check",
-                        status="timeout",
+                        status="error",
+                        timed_out=True,
                         error_message="Timeout after 1200s",
                         attempts=1,
                     )

--- a/tests/cli/test_scanner_failure_accounting.py
+++ b/tests/cli/test_scanner_failure_accounting.py
@@ -283,3 +283,85 @@ def test_timeout_handling_does_not_depend_on_the_message_wording(tmp_path, caplo
     assert (
         "timed out" in caplog.text
     ), f"the timeout was not announced as a timeout. caplog was: {caplog.text!r}"
+
+
+def _run_timeout(
+    module: str, scan_func, target_kwargs: dict, tool: str, tmp_path: Path
+):
+    """Run a scan job whose only tool times out, with ToolRunner mocked."""
+    stubbed: list[str] = []
+    with patch(f"scripts.cli.scan_jobs.{module}.ToolRunner") as MockRunner:
+        mock_runner = MagicMock()
+        MockRunner.return_value = mock_runner
+        mock_runner.run_all_parallel.return_value = [
+            ToolResult(
+                tool=tool,
+                status="retry_exhausted",
+                returncode=-1,
+                attempts=3,
+                timed_out=True,
+                error_message="Timeout after 600s",
+            )
+        ]
+        _, statuses = scan_func(
+            **target_kwargs,
+            results_dir=tmp_path,
+            tools=[tool],
+            timeout=600,
+            retries=0,
+            per_tool_config={},
+            allow_missing_tools=True,
+            find_tool_func=lambda t: f"/usr/bin/{t}",
+            write_stub_func=lambda name, path: stubbed.append(name),
+        )
+    return statuses, stubbed
+
+
+@pytest.mark.parametrize("module,scan_func,target,tool", SCANNERS)
+def test_a_timeout_names_itself_on_a_durable_stream(
+    module, scan_func, target, tool, tmp_path, caplog
+):
+    """Every scan job must say a tool timed out, not just record False.
+
+    `repository_scanner` writes a stub and logs "it timed out"; the other four
+    dropped a timeout into an `else` branch that recorded `False` and returned
+    -- no stub, and **no log call at all**. Measured: `report_tool_failure` was
+    called once per scanner (the tool-not-found path) against three times in
+    `repository_scanner`.
+
+    So a `deep` scan where checkov timed out on an IaC target produced a scan
+    that exited 0 with no output for checkov and nothing anywhere saying why.
+    That is the silent-failure class this suite exists to close.
+    """
+    with caplog.at_level(logging.ERROR):
+        statuses, _ = _run_timeout(module, scan_func, target(tmp_path), tool, tmp_path)
+
+    assert statuses[tool] is False
+    assert tool in caplog.text, (
+        f"{module}: {tool} timed out and said so on no stream. A non-TTY run "
+        f"renders no progress display, so this is the only durable record. "
+        f"caplog was: {caplog.text!r}"
+    )
+    assert "timed out" in caplog.text, (
+        f"{module}: the failure was logged but not identified as a timeout, so "
+        f"an operator cannot tell it from a crash. caplog was: {caplog.text!r}"
+    )
+
+
+@pytest.mark.parametrize("module,scan_func,target,tool", SCANNERS)
+def test_a_timeout_leaves_a_stub_so_the_report_phase_has_a_file(
+    module, scan_func, target, tool, tmp_path
+):
+    """A timed-out tool gets a stub, so the report phase sees a consistent tree.
+
+    Paired with the log assertion above, never alone: an empty stub on its own
+    is indistinguishable from a tool that ran and found nothing, which is the
+    lie #7 in the scan-core work removed. The stub is for file-shape
+    consistency; the log is what carries the meaning.
+    """
+    _, stubbed = _run_timeout(module, scan_func, target(tmp_path), tool, tmp_path)
+
+    assert tool in stubbed, (
+        f"{module}: no stub written for a timed-out {tool}, so the report phase "
+        f"has no file for it at all. stubbed={stubbed}"
+    )

--- a/tests/cli/test_scanner_failure_accounting.py
+++ b/tests/cli/test_scanner_failure_accounting.py
@@ -236,3 +236,50 @@ def test_resolve_then_vanish_writes_no_stub(tmp_path, caplog):
         f"the report phase reads it."
     )
     assert statuses["yara"] is False
+
+
+def test_timeout_handling_does_not_depend_on_the_message_wording(tmp_path, caplog):
+    """A timeout is routed by `result.timed_out`, not by prose (#727).
+
+    This branch writes a stub and logs "it timed out". It used to be selected by
+    `"Timeout" in result.error_message`, which made a human-readable string
+    load-bearing: rewording it would silently route every timeout to the generic
+    failure branch, dropping both signals, with no test going red.
+
+    So this passes a deliberately reworded message. The branch must still fire.
+    """
+    stubbed: list[str] = []
+    with patch("scripts.cli.scan_jobs.repository_scanner.ToolRunner") as MockRunner:
+        mock_runner = MagicMock()
+        MockRunner.return_value = mock_runner
+        mock_runner.run_all_parallel.return_value = [
+            ToolResult(
+                tool="semgrep",
+                status="retry_exhausted",
+                returncode=-1,
+                attempts=3,
+                timed_out=True,
+                error_message="exceeded its 600s budget",  # deliberately NOT "Timeout"
+            )
+        ]
+        with caplog.at_level(logging.ERROR):
+            _, statuses = scan_repository(
+                repo=_repo_target(tmp_path)["repo"],
+                results_dir=tmp_path,
+                tools=["semgrep"],
+                timeout=600,
+                retries=0,
+                per_tool_config={},
+                allow_missing_tools=True,
+                find_tool_func=lambda t: f"/usr/bin/{t}",
+                write_stub_func=lambda name, path: stubbed.append(name),
+            )
+
+    assert statuses["semgrep"] is False
+    assert stubbed == ["semgrep"], (
+        "no stub was written for a timed-out tool, so the report phase will "
+        f"have no file for it at all. stubbed={stubbed}"
+    )
+    assert (
+        "timed out" in caplog.text
+    ), f"the timeout was not announced as a timeout. caplog was: {caplog.text!r}"

--- a/tests/unit/test_scan_timings.py
+++ b/tests/unit/test_scan_timings.py
@@ -155,13 +155,15 @@ def test_never_serializes_tool_stdout_or_stderr(tmp_path: Path) -> None:
 
 # The four values `tool_runner.py` actually assigns to `ToolResult.status`.
 #
-# Deliberately NOT five. `ToolResult`'s own docstring claims a `"timeout"`
-# status, and #722's rescoping read that claim off the docstring rather than the
-# code -- but `run_tool` never assigns it. A timed-out tool gets `error` or
-# `retry_exhausted` with `error_message="Timeout after Ns"`, which is why all
-# five scan jobs detect timeouts by string-matching that message. Listing
-# `"timeout"` here would make this file assert against fiction, which is the
-# exact defect class the #718 remediation exists to remove.
+# Deliberately NOT five. `ToolResult`'s docstring claimed a `"timeout"` status
+# that `run_tool` never assigned, and #722's rescoping read that claim off the
+# docstring rather than the code. Listing it here would make this file assert
+# against fiction -- the exact defect class the #718 remediation exists to
+# remove.
+#
+# A timed-out tool reports `error` or `retry_exhausted` **and** `timed_out=True`
+# (#727). The flag is what carries the timeout; `status` carries whether the
+# retry budget was exhausted. Both are in `to_dict()`, so both reach this file.
 TOOL_RUNNER_STATUSES = ["success", "no_output", "error", "retry_exhausted"]
 
 

--- a/tests/unit/test_tool_runner.py
+++ b/tests/unit/test_tool_runner.py
@@ -161,16 +161,25 @@ class TestToolResult:
         assert result.duration == 5.2
 
     def test_failed_result(self):
-        """Test creating a failed result"""
+        """Test creating a failed result.
+
+        Uses the shape `run_tool` actually produces for a timeout:
+        `status="retry_exhausted"` plus `timed_out=True`. This test previously
+        constructed `status="timeout"` — a value nothing assigns — which made
+        the docstring's false claim look validated by a passing test, and is
+        part of how #722 came to be filed on a false premise (#727).
+        """
         result = ToolResult(
             tool="semgrep",
-            status="timeout",
+            status="retry_exhausted",
             returncode=-1,
+            timed_out=True,
             error_message="Timeout after 600s",
         )
 
         assert result.is_success() is False
-        assert result.status == "timeout"
+        assert result.status == "retry_exhausted"
+        assert result.timed_out is True
         assert result.error_message == "Timeout after 600s"
 
     def test_to_dict_conversion(self):
@@ -1612,3 +1621,159 @@ class TestTimeoutKillsTheProcessTree:
         )
         # Belt and braces: it must also not still be blocking the runner.
         assert _sp is not None
+
+
+class TestTimedOutFlag:
+    """A timeout must be structurally detectable, not inferred from prose.
+
+    `ToolResult.status` does not distinguish a timeout: `run_tool` assigns only
+    `success`, `no_output`, `error` and `retry_exhausted`, so a timed-out tool
+    is indistinguishable from a crash except by the wording of
+    `error_message` ("Timeout after Ns"). `repository_scanner` branches on that
+    string to decide whether to write a stub and what to log — so rewording a
+    human-readable message silently reclassifies every timeout (#727).
+
+    `timed_out` is a separate field rather than a fifth `status` value on
+    purpose: `retry_exhausted` carries its own signal (this failure burned the
+    whole retry budget), and folding it into `timeout` would lose it.
+    """
+
+    @staticmethod
+    def _timing_out_tool(**kwargs):
+        from scripts.core.config import RetryConfig
+
+        return ToolDefinition(
+            name="slowpoke",
+            command=["sleep", "999"],
+            output_file=None,
+            timeout=1,
+            retries=RetryConfig(
+                max_attempts=1, timeout_retries=0, backoff_base=0, backoff_max=0
+            ),
+            **kwargs,
+        )
+
+    def test_timeout_sets_the_flag(self):
+        """The terminal failure was a timeout, so say so in a field."""
+        tool = self._timing_out_tool()
+        runner = ToolRunner([tool])
+
+        with patch(
+            "scripts.core.tool_runner._run_bounded",
+            side_effect=subprocess.TimeoutExpired("cmd", 1),
+        ):
+            result = runner.run_tool(tool)
+
+        assert result.timed_out is True, (
+            "a timed-out tool must be identifiable without parsing "
+            "error_message, which is human-readable prose"
+        )
+
+    def test_timeout_still_reports_its_retry_status(self):
+        """`timed_out` supplements `status`; it does not replace it.
+
+        Collapsing a timeout into a `status` value would discard whether it
+        exhausted its retry budget, which is what distinguishes a flaky tool
+        from a hopelessly slow one.
+        """
+        from scripts.core.config import RetryConfig
+
+        tool = ToolDefinition(
+            name="slowpoke",
+            command=["sleep", "999"],
+            output_file=None,
+            timeout=1,
+            retries=RetryConfig(
+                max_attempts=2, timeout_retries=2, backoff_base=0, backoff_max=0
+            ),
+        )
+        runner = ToolRunner([tool])
+
+        with patch(
+            "scripts.core.tool_runner._run_bounded",
+            side_effect=subprocess.TimeoutExpired("cmd", 1),
+        ):
+            result = runner.run_tool(tool)
+
+        assert result.timed_out is True
+        assert result.status == "retry_exhausted"
+        assert result.attempts == 4  # 2 base + 2 timeout
+
+    def test_a_crash_does_not_set_the_flag(self):
+        """A non-zero exit is not a timeout. The flag must discriminate."""
+        tool = ToolDefinition(
+            name="crashy", command=["false"], output_file=None, retries=0
+        )
+        runner = ToolRunner([tool])
+
+        with patch(
+            "scripts.core.tool_runner._run_bounded",
+            return_value=subprocess.CompletedProcess(["false"], 3, "", "boom"),
+        ):
+            result = runner.run_tool(tool)
+
+        assert result.timed_out is False
+        assert result.status in ("error", "retry_exhausted")
+
+    def test_missing_tool_does_not_set_the_flag(self):
+        """A tool that never launched cannot have timed out."""
+        tool = ToolDefinition(
+            name="ghost", command=["no-such-binary-12345"], output_file=None, retries=0
+        )
+        runner = ToolRunner([tool])
+
+        with patch(
+            "scripts.core.tool_runner._run_bounded", side_effect=FileNotFoundError()
+        ):
+            result = runner.run_tool(tool)
+
+        assert result.timed_out is False
+
+    def test_flag_survives_serialization(self):
+        """`scan-timings.json` is where this becomes user-visible (#722)."""
+        assert (
+            ToolResult(tool="t", status="error", timed_out=True).to_dict()["timed_out"]
+            is True
+        )
+        assert ToolResult(tool="t", status="success").to_dict()["timed_out"] is False
+
+    def test_a_crash_after_a_timeout_is_not_reported_as_a_timeout(self):
+        """The flag describes the *terminal* failure, not any failure seen.
+
+        `last_error` and `timed_out` are a pair: whichever failure ends the
+        retry loop is the one the returned ToolResult describes. If only the
+        timeout branch assigns the flag, a tool that times out once and then
+        crashes reports `timed_out=True` alongside a crash's `error_message` --
+        so the scan writes a timeout stub and logs "it timed out" for a tool
+        that actually exited non-zero.
+
+        Every other test in this class exercises a single failure kind, and so
+        cannot see the missing reset. Found by mutation: deleting the crash
+        path's reset left all five of them green.
+        """
+        from scripts.core.config import RetryConfig
+
+        tool = ToolDefinition(
+            name="flaky",
+            command=["flaky"],
+            output_file=None,
+            timeout=1,
+            ok_return_codes=(0,),
+            retries=RetryConfig(
+                max_attempts=2, timeout_retries=1, backoff_base=0, backoff_max=0
+            ),
+        )
+        runner = ToolRunner([tool])
+
+        crash = subprocess.CompletedProcess(["flaky"], 3, "", "boom")
+        with patch(
+            "scripts.core.tool_runner._run_bounded",
+            side_effect=[subprocess.TimeoutExpired("cmd", 1), crash, crash],
+        ):
+            result = runner.run_tool(tool)
+
+        assert result.timed_out is False, (
+            "the run ended on a crash, but it was reported as a timeout -- the "
+            "crash path is not resetting the flag a previous timeout set"
+        )
+        assert "Return code 3" in result.error_message


### PR DESCRIPTION
Closes #727. Implements **option 2** from the issue.

## The problem

`ToolResult.status` never took the `"timeout"` value its docstring advertised —
`run_tool` assigns only `success`, `no_output`, `error` and `retry_exhausted`,
and the module's one `"timeout"` literal is a progress-callback UI signal.

So `repository_scanner` decided whether a tool had timed out by matching
`"Timeout" in result.error_message`. That made a **human-readable message
load-bearing**: rewording `"Timeout after 600s"` would route every timeout to
the generic failure branch, dropping the stub *and* the "it timed out" log line,
with nothing going red.

## Why a field rather than a fifth status

`retry_exhausted` carries its own signal — *this failure burned the whole retry
budget* — and folding a timeout into `status` discards it. Keeping them
independent makes the pair readable:

| status | timed_out | attempts | reading |
|---|---|---:|---|
| `retry_exhausted` | true | 4 | reliably too slow for its budget |
| `error` | true | 1 | timed out once, not retried |
| `retry_exhausted` | false | 3 | crashing, not slow |

`timed_out` is in `to_dict()`, so it reaches `scan-timings.json` (#722) — where
it is what makes timeout analysis possible at all.

## Correction to the issue as I filed it

#727 says all five scan jobs string-match the message. **Measured, only
`repository_scanner` does.** The other four never distinguished a timeout from
any other failure — no stub, no "it timed out" log, just the generic branch.
That inconsistency is real and is *not* addressed here; it is a behaviour change
to four scanners, not a refactor.

## Also corrected: two things that made the fiction look verified

- The `ToolResult` docstring, which claimed five status values.
- `test_failed_result`, which hand-constructed `status="timeout"` and asserted
  it round-tripped. It proved nothing about the producer while making the
  docstring look validated by a passing test.

## Evidence gate

CI cannot catch a mislabelled timeout — the scan still exits, the file still
gets written, and the only difference is *which branch* ran. So the gate is
mutation: break each guard, confirm it reddens.

| Mutation | Result |
|---|---|
| Delete the crash path's `last_failure_was_timeout = False` | **all five original tests stayed green** |
| Revert the scanner to `"Timeout" in error_message` | `test_timeout_handling_does_not_depend_on_the_message_wording` **red** |

The first mutation surviving was a genuine hole in my own tests — every test
exercised a *single* failure kind, so none could see a missing reset. Closed by
`test_a_crash_after_a_timeout_is_not_reported_as_a_timeout`, which now fails on
that mutation showing `error_message='Return code 3 not in (0,)'` alongside
`timed_out=True` — the exact mislabelling.

The second mutation's failure log is the regression in words:
`semgrep: it failed` instead of `it timed out`, and no stub written.

Both restored from file backups (not `git checkout --`), then **101 passed**
across `test_tool_runner`, `test_scanner_failure_accounting`, `test_scan_timings`
and `test_scan_timings_persistence`.

`jmo-profile-optimizer` updated to read the flag instead of the string match.