### PR TITLE
test(perf): measure latency with perf_counter and a median, not one time.time()

### DIFF
--- a/tests/performance/test_prioritization_performance.py
+++ b/tests/performance/test_prioritization_performance.py
@@ -4,6 +4,7 @@ Performance tests for EPSS/KEV prioritization.
 Tests API latency, cache performance, and bulk operations.
 """
 
+import statistics
 import time
 from unittest.mock import Mock, patch
 
@@ -12,6 +13,37 @@ import pytest
 from scripts.core.epss_integration import EPSSClient, EPSSScore
 from scripts.core.kev_integration import KEVClient, KEVEntry
 from scripts.core.priority_calculator import PriorityCalculator
+
+# Windows clock granularity, measured on a dev box:
+#
+#     time.monotonic()       15.0000 ms
+#     time.time()             0.5021 ms
+#     time.perf_counter()     0.0001 ms
+#
+# So a single sub-10ms sample timed with time.time() has ~20 usable ticks, and
+# one scheduler slice fails it -- which is exactly how #733 flaked a PR that
+# touched only the Makefile. perf_counter is the clock this repository
+# standardised on after a "just use monotonic" change made a different flake
+# 26.7% worse (see tests/unit/test_tool_runner.py).
+#
+# Granularity is necessary but not sufficient: one sample on a shared CI runner
+# measures the runner as much as the code. Sub-10ms budgets therefore take the
+# median of several runs.
+LATENCY_SAMPLES = 21
+
+
+def median_ms(operation, samples: int = LATENCY_SAMPLES) -> float:
+    """Median wall time of `operation` in milliseconds, over `samples` runs.
+
+    Median rather than mean: a single descheduled run should not move the
+    result, and that is the failure mode being defended against.
+    """
+    timings = []
+    for _ in range(samples):
+        start = time.perf_counter()
+        operation()
+        timings.append((time.perf_counter() - start) * 1000)
+    return statistics.median(timings)
 
 
 @pytest.fixture
@@ -36,9 +68,9 @@ class TestEPSSPerformance:
         client._cache_score(score)
 
         # Measure retrieval time
-        start = time.time()
+        start = time.perf_counter()
         cached_score = client.get_score("CVE-2024-1234")
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.perf_counter() - start) * 1000
 
         assert cached_score is not None
         assert (
@@ -67,9 +99,9 @@ class TestEPSSPerformance:
         client = EPSSClient(cache_dir=temp_cache_dir)
 
         # Measure API call time
-        start = time.time()
+        start = time.perf_counter()
         score = client.get_score("CVE-2024-5678")
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.perf_counter() - start) * 1000
 
         assert score is not None
         assert elapsed_ms < 500, f"API call took {elapsed_ms:.2f}ms (expected <500ms)"
@@ -99,9 +131,9 @@ class TestEPSSPerformance:
         cves = [f"CVE-2024-{i:04d}" for i in range(100)]
 
         # Measure bulk API call time
-        start = time.time()
+        start = time.perf_counter()
         scores = client.get_scores_bulk(cves)
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.perf_counter() - start) * 1000
 
         assert len(scores) == 100
         assert (
@@ -177,9 +209,9 @@ class TestKEVPerformance:
         mock_get.return_value = mock_response
 
         # Measure download + parse time
-        start = time.time()
+        start = time.perf_counter()
         client = KEVClient(cache_dir=temp_cache_dir)
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.perf_counter() - start) * 1000
 
         assert len(client.catalog) == 1000
         assert (
@@ -219,10 +251,10 @@ class TestKEVPerformance:
         cache_path.write_text(json.dumps(catalog_data))
 
         # Measure cached load time
-        start = time.time()
+        start = time.perf_counter()
         with patch("requests.get"):  # Prevent download
             client = KEVClient(cache_dir=temp_cache_dir)
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.perf_counter() - start) * 1000
 
         assert len(client.catalog) == 1000
         # Threshold: 200ms accommodates Windows disk I/O variance (observed: 100-150ms)
@@ -256,13 +288,18 @@ class TestKEVPerformance:
         with patch("requests.get"):
             client = KEVClient(cache_dir=temp_cache_dir)
 
-        # Measure lookup time
-        start = time.time()
-        is_kev = client.is_kev("CVE-2024-1234")
-        elapsed_ms = (time.time() - start) * 1000
+        # A 1ms budget is BELOW time.time()'s 0.5ms Windows tick, so the old
+        # single-sample timing could only ever read ~0 or ~0.5 -- it was not
+        # measuring this lookup. Median of N with perf_counter is.
+        assert client.is_kev("CVE-2024-1234") is True
 
-        assert is_kev is True
-        assert elapsed_ms < 1, f"KEV lookup took {elapsed_ms:.2f}ms (expected <1ms)"
+        elapsed_ms = median_ms(lambda: client.is_kev("CVE-2024-1234"))
+
+        assert elapsed_ms < 1, (
+            f"KEV lookup median took {elapsed_ms:.4f}ms over {LATENCY_SAMPLES} "
+            f"runs (expected <1ms). This is an in-memory set lookup; a real "
+            f"regression here means the catalog is being re-read or re-parsed."
+        )
 
 
 class TestPriorityCalculatorPerformance:
@@ -306,15 +343,20 @@ class TestPriorityCalculatorPerformance:
             "tool": {"name": "trivy", "version": "0.50.0"},
         }
 
-        # Measure calculation time
-        start = time.time()
+        # This is the assertion that flaked CI at 15.65ms on a PR touching only
+        # the Makefile (#733). One sample on a shared runner measures the runner;
+        # the median over N measures the code.
         priority = calculator.calculate_priority(finding)
-        elapsed_ms = (time.time() - start) * 1000
-
         assert priority is not None
-        assert (
-            elapsed_ms < 10
-        ), f"Priority calculation took {elapsed_ms:.2f}ms (expected <10ms)"
+
+        elapsed_ms = median_ms(lambda: calculator.calculate_priority(finding))
+
+        assert elapsed_ms < 10, (
+            f"Priority calculation median took {elapsed_ms:.4f}ms over "
+            f"{LATENCY_SAMPLES} runs (expected <10ms). Both clients are mocked "
+            f"here, so this measures scoring arithmetic only -- a regression "
+            f"means real work crept into the calculation path."
+        )
 
     @patch("scripts.core.priority_calculator.EPSSClient")
     @patch("scripts.core.priority_calculator.KEVClient")
@@ -360,9 +402,9 @@ class TestPriorityCalculatorPerformance:
         ]
 
         # Measure bulk calculation time
-        start = time.time()
+        start = time.perf_counter()
         priorities = calculator.calculate_priorities_bulk(findings)
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.perf_counter() - start) * 1000
 
         assert len(priorities) == 1000
         assert (
@@ -399,9 +441,9 @@ class TestPriorityCalculatorPerformance:
         }
 
         # Measure extraction time
-        start = time.time()
+        start = time.perf_counter()
         cves = calculator._extract_cves(finding)
-        elapsed_ms = (time.time() - start) * 1000
+        elapsed_ms = (time.perf_counter() - start) * 1000
 
         # Should find all unique CVEs
         assert len(cves) >= 5


### PR DESCRIPTION
Closes #733.

`test_prioritization_performance.py` timed single sub-10ms operations with
`time.time()` and asserted hardcoded millisecond ceilings. On Windows that is
near the clock's own resolution, so the assertions measured scheduler noise as
much as the code — flaking the `Windows native console encoding` job on **#728**,
a PR that changes only `Makefile` and `CLAUDE.md`:

```
AssertionError: Priority calculation took 15.65ms (expected <10ms)
```

## Why raising the ceiling would have been the wrong fix

Measured: the operation takes **0.023 ms**. The budget is **10 ms** — a 430×
margin — and it still read 15.65 ms in CI. That is a ~680× outlier, so the
assertion was not measuring the code at all. Raising the ceiling buys quiet, not
signal.

## Clock granularity, measured on this box

| Clock | Minimum tick |
|---|---:|
| `time.monotonic()` | 15.0000 ms |
| `time.time()` | 0.5021 ms |
| `time.perf_counter()` | 0.0001 ms |

`time.time()` leaves ~20 usable ticks across a 10 ms budget. The `<1 ms` KEV
assertion was **below the tick entirely** — it could only ever read ~0 or ~0.5,
never a true value.

Note `monotonic` is *worse* than either; this repo already learned that when a
"just use monotonic" change made a different flake 26.7% worse
(`tests/unit/test_tool_runner.py` guards it at source level).

## Change

- All 18 `time.time()` sites → `time.perf_counter()`.
- The two sub-10 ms budgets take `median_ms()` over 21 runs. **Median, not
  mean** — one descheduled run should not move the result, and that is precisely
  the failure mode being defended against.
- Assertion messages now say what a real regression would mean, so a future
  failure is diagnosable rather than just a number.

## Evidence gate

The claim is "this is no longer flaky", which a single green run cannot support.
So: 300 single samples vs 60 medians on the site that actually flaked.

| | min | median | max | ≥10 ms |
|---|---:|---:|---:|---:|
| single sample | 0.0204 | 0.0229 | **0.3075** | 0/300 |
| median of 21 | 0.0223 | 0.0230 | **0.0240** | 0/60 |

Spread collapses from **15×** to **1.08×**; the worst single sample is 13× the
worst median. Suite: **10 passed**.

The six larger ceilings (50 / 500 / 2000 / 5000 / 200 / 1000 ms) keep single
samples — granularity is not a factor at that scale — but use `perf_counter`
for consistency.