### PR TITLE
docs: correct tool counts that no profile has had for some time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -784,11 +784,11 @@ jobs:
 
           {
             echo ""
-            echo "**v1.0.0 Target Sizes (Phase 1 Optimizations):**"
-            echo "- Deep: ~1.97 GB (26 Docker-ready tools, 155 MB savings)"
-            echo "- Balanced: ~1.41 GB (21 tools, production CI/CD)"
-            echo "- Slim: ~557 MB (15 tools, cloud-focused)"
-            echo "- Fast: ~502 MB (8 tools, CI/CD gate)"
+            echo "**Target Sizes:**"
+            echo "- Deep: ~1.97 GB (28 tools, 4 of them manual-install)"
+            echo "- Balanced: ~1.41 GB (17 tools, production CI/CD)"
+            echo "- Slim: ~557 MB (13 tools, cloud-focused)"
+            echo "- Fast: ~502 MB (9 tools, CI/CD gate)"
             echo ""
             echo "**Phase 1 Optimizations Applied (155 MB savings):**"
             echo "- Nuclei template filtering (65 MB)"
@@ -876,7 +876,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ env.IMAGE_NAME_DOCKERHUB }}
-          short-description: "Security audit toolkit with 12 tools - scan repos, images, IaC, URLs, K8s in one unified CLI"
+          short-description: "Security audit toolkit with 29 tools - scan repos, images, IaC, URLs, K8s in one unified CLI"
           readme-filepath: ./DOCKER_HUB_README.md
 
       - name: Docker Hub update skipped

--- a/docs/PROFILES_AND_TOOLS.md
+++ b/docs/PROFILES_AND_TOOLS.md
@@ -191,12 +191,12 @@ deep:
   - yara            # Malware pattern detection
   - noseyparker     # Deep secrets scanning
   - bandit          # Python security linter
-  # Tool variants (4)
+  # Tool variants (4) - 1 requires manual installation
   - semgrep-secrets # Semgrep with secrets rules
   - trivy-rbac      # Trivy RBAC scanning
   - checkov-cicd    # Checkov CI/CD config scanning
-  - falco           # Runtime security
-  # Specialized (4) - 3 require manual installation
+  - falco           # Runtime security [MANUAL]
+  # Specialized (5) - 3 require manual installation
   - akto            # API security (OWASP API Top 10) [MANUAL]
   - afl++           # Coverage-guided fuzzing [MANUAL]
   - mobsf           # Mobile security (Android/iOS) [MANUAL]
@@ -684,7 +684,7 @@ apt-get install -y git curl jq shellcheck ca-certificates
 docker run -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:fast scan
 docker run -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:slim scan
 docker run -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:balanced scan
-docker run -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:deep scan  # 25 tools, 3 manual
+docker run -v $(pwd):/scan ghcr.io/jimmy058910/jmo-security:deep scan  # 28 tools, 4 need manual install
 ```
 
 **Registries:**


### PR DESCRIPTION
Closes #731.

Found by the verification checklist rewritten in #730. The previous checklist
could not have found them: its first step grepped `jmo.yml` for a `tools:` key
under `deep:` that does not exist, so it returned `0` on every run and every
later comparison "passed" against nothing.

Live counts, from `scripts/core/tool_registry.py:PROFILE_TOOLS`:
**fast 9, slim 13, balanced 17, deep 28, unique catalogue 29.**

| File | Was | Now |
|---|---|---|
| `docs/PROFILES_AND_TOOLS.md:687` | `25 tools, 3 manual` | `28 tools, 4 need manual install` |
| `release.yml:788` | Deep `26 Docker-ready tools` | `28 tools, 4 of them manual-install` |
| `release.yml:789` | Balanced `21 tools` | `17 tools` |
| `release.yml:790` | Slim `15 tools` | `13 tools` |
| `release.yml:791` | Fast `8 tools` | `9 tools` |
| `release.yml:879` | Docker Hub `12 tools` | `29 tools` |

`release.yml:879` matters most — it is the **published Docker Hub
short-description**, and 12 was never a tool count at all. It is the number of
tool *categories*.

**`README.md:83` is deliberately untouched.** Its "29 tools across 12
categories" cites the catalogue and is correct. An earlier draft of the checker
flagged it; acting on that would have made a right file wrong.

## Two annotation defects in the same doc

`docs/PROFILES_AND_TOOLS.md` calls itself the authoritative reference, so its
deep-profile block was diffed against the registry entry by entry. **The tool
list is exact** — 28 documented, 28 in the registry, no duplicates, no drift.
Two annotations had rotted:

- **`falco` was missing its `[MANUAL]` marker.** It is in
  `MANUAL_INSTALL_TOOLS`, so a reader would expect the Docker image to ship it.
  The doc's `[MANUAL]` entries now equal the registry's four exactly.
- **`# Specialized (4)` labelled a group of five.** Corrected, and
  `# Tool variants (4)` now notes one of its four is manual. Group labels sum
  to 28.

## One thing worth reviewing in the diff

My first pass wrote the deep line as *"24 Docker-ready tools of 28"* — accurate,
but **invisible** to the checker, whose `[0-9]+ tools` pattern cannot match a
number separated from the word. That would have fixed the value while silently
removing the guard. Both deep lines now keep the count adjacent to "tools" so
they stay checkable.

## Evidence gate

The checklist is the gate, and it must now pass where it previously failed:

```
legitimate tool counts: 9 13 17 28 29
exit=0
```

across `DOCKER_HUB_README.md`, `README.md`, `docs/PROFILES_AND_TOOLS.md` and
`release.yml`. Registry cross-check: doc `[MANUAL]` markers == registry
`MANUAL_INSTALL_TOOLS ∩ deep` exactly. `check_doc_links.py`, yamllint,
actionlint and markdownlint all clean.