### PR TITLE
docs(skills): fix two broken anchors, one of them inside the warning about them

### DIFF
--- a/.claude/skills/jmo-documentation-updater/SKILL.md
+++ b/.claude/skills/jmo-documentation-updater/SKILL.md
@@ -128,16 +128,34 @@ Anchors are derived from the heading text: lowercased, spaces to hyphens,
 punctuation dropped. Derive them from the **actual** heading — a plausible
 guess is how you get a link that resolves to the top of the page instead:
 
+Both examples below were checked against the real headings before being written
+here, which is the whole point:
+
 ```markdown
-# docs/DOCKER_README.md's heading is "## Quick Start (Absolute Beginners)"
+# docs/DOCKER_README.md heading: "## Quick Start (Absolute Beginners)"
+# -> parentheses dropped, spaces become hyphens
 [Docker quick start](../../../docs/DOCKER_README.md#quick-start-absolute-beginners)
 
-# "AWS Account Scanning (v0.7.0)" -> #aws-account-scanning-v070
-[AWS Scanning](../../../docs/USER_GUIDE.md#aws-account-scanning-v070)
+# docs/USER_GUIDE.md heading: "## Tool Management"
+[Tool management](../../../docs/USER_GUIDE.md#tool-management)
 ```
 
-> `check_doc_links.py` validates that the **file** exists; it does not verify
-> the fragment. A wrong anchor is silent, so check the heading yourself.
+Confirm the heading exists before writing the link:
+
+```bash
+grep -nE '^#{1,6} ' docs/USER_GUIDE.md | grep -i 'tool management'
+```
+
+> **`check_doc_links.py` validates the file, not the `#fragment`.** A wrong
+> anchor is silent — it degrades to "jump to the top of the page", which looks
+> like a working link.
+>
+> This is not hypothetical. The previous version of this very section cited
+> `docs/USER_GUIDE.md#aws-account-scanning-v070`; that file has **no AWS heading
+> at all**. A fabricated anchor sat inside the passage warning against
+> fabricated anchors, and CI was green. Repo-wide there are **28** such links
+> across 328 fragment links — so treat a `#fragment` as unverified until you
+> have grepped for its heading.
 
 ### Bi-Directional Links
 

--- a/.claude/skills/jmo-profile-optimizer/SKILL.md
+++ b/.claude/skills/jmo-profile-optimizer/SKILL.md
@@ -135,9 +135,10 @@ that produced it:
 
 > Recommendation engine: [references/optimization-patterns.md](references/optimization-patterns.md#phase-5-generate-optimization-recommendations)
 
-**Timeout and failure-rate analysis is not part of this skill** — JMo records
-neither. See [the Phase 4 note](references/optimization-patterns.md#phase-4-timeout-and-failure-analysis--no-data-source)
-before adding recommendations about timeouts.
+**Per-tool timeout and failure analysis is available for a single scan, but
+*rates* are not** — nothing aggregates `scan-timings.json` across runs. See
+[Phase 4](references/optimization-patterns.md#phase-4-timeout-and-failure-analysis)
+before making any recommendation about timeouts.
 
 ---
 


### PR DESCRIPTION
Both anchors were introduced earlier in the **same session** as the work that
documented this exact failure mode. That is the part worth reading.

## 1. `jmo-profile-optimizer/SKILL.md:139`

Pointed at `#phase-4-timeout-and-failure-analysis--no-data-source`. #722 renamed
that heading to `## Phase 4: Timeout and Failure Analysis` and updated **three of
the four** references. This was the fourth.

Its surrounding prose was stale too — *"Timeout and failure-rate analysis is not
part of this skill, JMo records neither"* — which #722 made false by adding
`scan-timings.json`. Now states the real limitation: per-tool outcomes exist for
a single scan, *rates* do not.

## 2. `jmo-documentation-updater/SKILL.md`

Cited `docs/USER_GUIDE.md#aws-account-scanning-v070` as its worked example of
deriving an anchor. **That file has no AWS heading at all.**

So a fabricated anchor sat inside the passage warning against fabricated
anchors. The example predates this work; the chunk-B rewrite (#730) corrected
its *path* and left the *fragment* invented — a half-fix that made the file
resolve while the link still went nowhere.

Replaced with two anchors verified against their real headings before being
written, plus the `grep` that verifies one.

## Why CI was green through all of this

`check_doc_links.py` resolves the **file**; it never looks at the `#fragment`.
A wrong anchor degrades to "jump to the top of the page", which is
indistinguishable from a working link unless you follow it.

Measured across tracked Markdown: **28 of 328 fragment links point at no
heading**, including entries in `README.md`, `QUICKSTART.md`, `CHANGELOG.md` and
`docs/USER_GUIDE.md`.

## Scope

Only the two anchors this session introduced are fixed here. The other 26 — and
teaching `check_doc_links.py` to validate fragments so the class cannot regrow —
are a change to a CI gate plus a repo-wide cleanup, and belong in their own PR.
Happy to do that next if wanted.

## Evidence gate

The gate is not "CI is green" — CI was green *with* the broken anchors. It is
resolving each anchor against the target file's real headings:

| Anchor | Target heading | Result |
|---|---|---|
| `#quick-start-absolute-beginners` | `## Quick Start (Absolute Beginners)` | OK |
| `#tool-management` | `## Tool Management` | OK |
| `#phase-4-timeout-and-failure-analysis` | `## Phase 4: Timeout and Failure Analysis` | OK |

Stale-anchor occurrences remaining in `jmo-profile-optimizer`: **0**.
`check_doc_links.py` and markdownlint clean.