### PR TITLE
docs: correct tool-count claims across the repository

### DIFF
--- a/.claude/agents/doc-sync-checker.md
+++ b/.claude/agents/doc-sync-checker.md
@@ -129,13 +129,13 @@ You have access to all documentation analysis tools:
 
 #### 1. README.md
 
-**Current:** "Orchestrates 27+ security scanners"
+**Current:** "Orchestrates 29 security scanners"
 **Update to:** "Orchestrates 28+ security scanners"
 
 **Location:** Line 15
 **Change:**
 ```diff
-- Orchestrates 27+ security scanners (Trivy, Semgrep, TruffleHog, etc.)
+- Orchestrates 29 security scanners (Trivy, Semgrep, TruffleHog, etc.)
 + Orchestrates 28+ security scanners (Trivy, Semgrep, TruffleHog, Snyk, etc.)
 ```
 

--- a/.claude/skills/jmo-documentation-updater/templates/doc-update-templates.md
+++ b/.claude/skills/jmo-documentation-updater/templates/doc-update-templates.md
@@ -339,9 +339,10 @@ jmo report ./results --outputs csv
 
 | Variant | Size | Tools Included | Use Case |
 |---------|------|----------------|----------|
-| `full` | ~2.5 GB | All 14 tools | Complete scanning |
-| `slim` | ~800 MB | 8 core tools | CI/CD |
-| `alpine` | ~400 MB | 6 essential tools | Minimal footprint |
+| `deep` | ~1.97 GB | 28 tools (4 manual-install) | Compliance audits, pentests |
+| `balanced` | ~1.41 GB | 17 tools | Production scans, CI/CD |
+| `slim` | ~557 MB | 13 tools | Cloud/IaC |
+| `fast` | ~502 MB | 9 tools | Pre-commit, PR validation |
 ```
 
 ## 9. Tool Count Changes (Critical for Docker Hub)

--- a/.claude/skills/jmo-refactoring-assistant/SKILL.md
+++ b/.claude/skills/jmo-refactoring-assistant/SKILL.md
@@ -20,7 +20,7 @@ Systematically decompose monolithic functions, migrate to design patterns (BaseA
 This skill helps you refactor the JMo Security codebase by:
 
 1. **Decomposing monolithic functions** (e.g., cmd_scan: 1,553 lines, CC 252)
-2. **Migrating to design patterns** (e.g., BaseAdapter for 14 tool adapters)
+2. **Migrating to design patterns** (e.g., BaseAdapter for 29 tool adapters)
 3. **Splitting oversized files** (e.g., jmo.py: 2,456 lines -> 600 lines)
 4. **Preserving test coverage** and preventing regressions
 5. **Avoiding circular dependencies** with proven patterns

--- a/.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md
+++ b/.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md
@@ -248,7 +248,7 @@ grep -A 10 "individual-images" scripts/core/normalize_and_report.py
 
 - **Adapter pattern:** `scripts/core/adapters/trivy_adapter.py` (most comprehensive)
 - **Test pattern:** `tests/adapters/test_trivy_adapter.py` (5 categories)
-- **Scan job pattern:** `scripts/cli/scan_jobs/repository_scanner.py` (12 tools)
+- **Scan job pattern:** `scripts/cli/scan_jobs/repository_scanner.py` (28 tools)
 - **Exit code handling:** Check CLAUDE.md "Tool Invocation" section
 - **CommonFinding schema:** `docs/schemas/common_finding.v1.json`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code when working with the JMo Security Audit Tool Suite rep
 
 ## Project Overview
 
-JMo Security is a terminal-first security audit toolkit orchestrating 27+ scanners with unified CLI, normalized outputs, and HTML dashboard.
+JMo Security is a terminal-first security audit toolkit orchestrating 29 scanners with unified CLI, normalized outputs, and HTML dashboard.
 
 **Version:** v1.0.5 (latest released — see CHANGELOG.md for full history)
 **Philosophy:** Two-phase architecture: scan (invoke tools) → report (normalize, dedupe, output)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,7 +245,7 @@ These checks run automatically on commit and are also enforced in CI (note: the 
 # Quick scan with fast profile (9 tools, 5-10 min)
 jmo scan --repo . --profile fast --human-logs
 
-# Production scan with balanced profile (18 tools, 18-25 min)
+# Production scan with balanced profile (17 tools, 18-25 min)
 jmo scan --repo . --profile balanced --human-logs
 
 # Generate reports from existing scan

--- a/docs/DOCKER_README.md
+++ b/docs/DOCKER_README.md
@@ -301,12 +301,12 @@ START: What is your primary use case?
 
 ├─ Production CI/CD (daily/weekly scans)
 │  → Use BALANCED variant (:balanced)
-│     - 18 tools, 18-25 min scans
+│     - 17 tools, 18-25 min scans
 │     - Best for: DevOps, regular audits, balanced coverage
 
 ├─ Cloud/K8s/IaC focused (containers, infrastructure)
 │  → Use SLIM variant (:slim)
-│     - 14 tools, 12-18 min scans
+│     - 13 tools, 12-18 min scans
 │     - Best for: Cloud-native, IaC, container security
 
 └─ Fast feedback (pre-commit, PR checks)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -120,9 +120,9 @@ No. JMo Security collects no telemetry and phones home to nothing — all scanni
 Pick the smallest variant that covers your needs:
 
 ```bash
-docker pull ghcr.io/jimmy058910/jmo-security:fast        # ~800 MB, 8 scanners
-docker pull ghcr.io/jimmy058910/jmo-security:slim        # ~1.4 GB, 14 scanners
-docker pull ghcr.io/jimmy058910/jmo-security:balanced    # ~1.6 GB, 18 scanners
+docker pull ghcr.io/jimmy058910/jmo-security:fast        # ~800 MB, 9 scanners
+docker pull ghcr.io/jimmy058910/jmo-security:slim        # ~1.4 GB, 13 scanners
+docker pull ghcr.io/jimmy058910/jmo-security:balanced    # ~1.6 GB, 17 scanners
 docker pull ghcr.io/jimmy058910/jmo-security:latest      # ~2.0 GB, 28 scanners (default)
 ```
 

--- a/docs/PROFILES_AND_TOOLS.md
+++ b/docs/PROFILES_AND_TOOLS.md
@@ -535,7 +535,7 @@ Different target types invoke different subsets of tools. This matrix shows the 
 
 ## Complete Tool Reference
 
-### All 27 Tools (Alphabetical)
+### All 29 Tools (Alphabetical)
 
 | # | Tool | Version | Profiles | Installation | Critical |
 |---|------|---------|----------|--------------|----------|

--- a/docs/SCAN_OPTIMIZATION.md
+++ b/docs/SCAN_OPTIMIZATION.md
@@ -4,7 +4,7 @@ Comprehensive guide for optimizing JMo Security scan performance without sacrifi
 
 ## Overview
 
-A typical balanced profile scan (18 tools) takes 18-25 minutes. This guide covers strategies to reduce scan times by 30-60% while maintaining thorough security coverage.
+A typical balanced profile scan (17 tools) takes 18-25 minutes. This guide covers strategies to reduce scan times by 30-60% while maintaining thorough security coverage.
 
 **Key Metrics:**
 


### PR DESCRIPTION
Repo-wide follow-on to #737, which fixed the six counts a targeted checklist
found. Requested as "fix to whatever is accurate, globally."

Live numbers from `scripts/core/tool_registry.py:PROFILE_TOOLS`:
fast **9**, slim **13**, balanced **17**, deep **28** (24 in the Docker image,
4 manual-install), unique catalogue **29**, adapters **29**.

| File | Was | Now |
|---|---|---|
| `CLAUDE.md:9` | `27+ scanners` | `29 scanners` |
| `CONTRIBUTING.md:248` | balanced `18 tools` | `17 tools` |
| `docs/DOCKER_README.md:304,309` | `18` / `14 tools` | `17` / `13 tools` |
| `docs/FAQ.md:123-125` | `8` / `14` / `18 scanners` | `9` / `13` / `17 scanners` |
| `docs/PROFILES_AND_TOOLS.md:538` | `All 27 Tools` | `All 29 Tools` |
| `docs/SCAN_OPTIMIZATION.md:7` | balanced `18 tools` | `17 tools` |
| `.claude/agents/doc-sync-checker.md:132,138` | `27+ security scanners` | `29` |
| `jmo-refactoring-assistant/SKILL.md:23` | `14 tool adapters` | `29` |
| `jmo-systematic-debugging/.../detailed-phase-guide.md:251` | `(12 tools)` | `(28 tools)` |

`doc-update-templates.md`'s Docker variant table was fiction in **every row**:
`full` was renamed to `deep` in v1.0.2 and its alias removed in v1.0.5, and
`alpine` has never existed. Replaced with the four real variants.

## The interesting half: what was deliberately NOT changed

The audit found **151** numeric "N tools/scanners" claims. Most are correct in
context, and a blanket replace — the obvious approach — would have broken them:

| Category | Example | Why left alone |
|---|---|---|
| `CHANGELOG.md` (19 hits) | "21 tools for production CI/CD" | Historical record; it was true at that release |
| Test-internal comments | `# 5 tools, shows 3 + "+2"` | Describes that test's fixture, not the product |
| Sample output | `NOT INSTALLED (3 tools)` | Illustrative transcript |
| Dedup confidence | "Detected by 3 tools \| HIGH CONFIDENCE" | A different quantity entirely |
| `test_tool_registry.py:43` | "27 security tools + OPA = 28 tools" | Arithmetic, and correct |

**`docs/MANUAL_INSTALLATION.md:376` — "5/12 tools require WSL2 or Docker" — is
left stale on purpose.** It is a *compatibility* claim, not a profile count.
Establishing which tools genuinely need WSL2 requires real Windows testing;
substituting a plausible number would replace a stale fact with a fabricated
one, which is strictly worse. Flagged rather than guessed.

## Website

`jmotools.com` (`C:\Projects\jmotools\index.html`) had 7 stale claims — five
"28 scanners" and two "11+ scanners" — now all **29**, matching README's "29
tools across 12 categories". 28 is the *deep profile* size, a different quantity
close enough to be mistaken for the total.

Two things about that file worth knowing, neither touched here:
- **It is not under version control** — no repo, no remote, no revert. A backup
  was taken before editing.
- It still advertises **v1.0.1** (repo is at v1.0.8) and "87% test coverage".
  Out of scope for a tool-count fix, but it is stale.

## Evidence gate

Not "CI is green" — no test reads prose. The gate is that each replacement
matched **exactly once** (asserted in the edit script, so a moved or duplicated
string fails loudly rather than silently editing the wrong site), plus:

| Check | Result |
|---|---|
| `check_doc_links.py` | all links in 162 tracked files resolve |
| markdownlint | clean |
| `git diff --numstat` vs `--ignore-cr-at-eol` | identical on all 10 files |

**Line-ending note for review.** The first pass used `read_text()` +
`write_bytes()` — which looks like it follows the repo's rule but does not:
`read_text` applies universal newlines, so four CRLF files came back as LF and
writing the bytes rewrote every line (763 changed lines for a 2-line edit).
Caught by the numstat comparison, reverted, redone with `read_bytes()`. Worth
recording that `write_bytes` is only safe when paired with `read_bytes`.