### PR TITLE
feat(dev): validate the #fragment half of a documentation link

### DIFF
--- a/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
+++ b/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
@@ -894,7 +894,7 @@ MD031: true   # Blank lines around code fences
 
 **Fix ALL violations found, not just new ones.**
 
-If markdownlint shows 10 violations (3 new + 7 old), fix all 10. See [jmo-documentation-updater skill](../../jmo-documentation-updater/SKILL.md#technical-debt-principle) for rationale.
+If markdownlint shows 10 violations (3 new + 7 old), fix all 10. See [jmo-documentation-updater skill](../../jmo-documentation-updater/SKILL.md#technical-debt-and-linting) for rationale.
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -226,9 +226,9 @@ jmo scan --repo . --image myapp:latest --url https://myapp.com
 | Feature | Guide |
 |---------|-------|
 | Tool management | [docs/USER_GUIDE.md#tool-management](docs/USER_GUIDE.md#tool-management) |
-| Compare scans | [docs/USER_GUIDE.md#jmo-diff](docs/USER_GUIDE.md#jmo-diff) |
-| Track trends | [docs/USER_GUIDE.md#jmo-trends](docs/USER_GUIDE.md#jmo-trends) |
-| Scan history | [docs/USER_GUIDE.md#jmo-history](docs/USER_GUIDE.md#jmo-history) |
+| Compare scans | [docs/USER_GUIDE.md#machine-readable-diffs](docs/USER_GUIDE.md#machine-readable-diffs) |
+| Track trends | [docs/USER_GUIDE.md#trend-analysis](docs/USER_GUIDE.md#trend-analysis) |
+| Scan history | [docs/USER_GUIDE.md#historical-storage](docs/USER_GUIDE.md#historical-storage) |
 | Scheduled scans | [docs/SCHEDULE_GUIDE.md](docs/SCHEDULE_GUIDE.md) |
 | AI remediation | [docs/MCP_SETUP.md](docs/MCP_SETUP.md) |
 | Policy-as-code | [docs/POLICY_AS_CODE.md](docs/POLICY_AS_CODE.md) |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ docker run --rm -v "$(pwd):/scan" ghcr.io/jimmy058910/jmo-security:latest \
 | **Policy** | OPA |
 | **Runtime** | Trivy-RBAC, Falco, AFL++ |
 
-**Tool details:** [docs/USER_GUIDE.md#tool-overview](docs/USER_GUIDE.md#tool-overview)
+**Tool details:** [docs/PROFILES_AND_TOOLS.md](docs/PROFILES_AND_TOOLS.md)
 
 ---
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,7 +16,7 @@ Answer these three questions:
 
 - **How do you install?** If Docker, see [Docker users](#docker-users). If pip, see [pip users](#pip-users).
 - **Do you have a `.jmo/history.db` from v0.8.0?** No — history storage is new in v1.0.0. See [New features worth adopting](#new-features-worth-adopting).
-- **Do you have CI pipelines calling `jmo scan` or `jmo ci`?** Re-read [CLI flag changes](#cli-flag-changes) before bumping your image or package version.
+- **Do you have CI pipelines calling `jmo scan` or `jmo ci`?** Re-read [CLI flag changes](#cli-flag---profile-renamed-to---profile-name-on-scan-and-ci) before bumping your image or package version.
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -999,7 +999,7 @@ if __name__ == "__main__":
 
 ## Further Reading
 
-- [User Guide - Trend Analysis](USER_GUIDE.md#trend-analysis-v100): CLI usage and examples
-- [User Guide - Historical Storage](USER_GUIDE.md#historical-storage-v100): Database schema and query API
+- [User Guide - Trend Analysis](USER_GUIDE.md#trend-analysis): CLI usage and examples
+- [User Guide - Historical Storage](USER_GUIDE.md#historical-storage): Database schema and query API
 - [CHANGELOG.md](../CHANGELOG.md): Feature #5 implementation details
 - [Source Code](../scripts/core/): Complete implementation with docstrings

--- a/docs/MANUAL_INSTALLATION.md
+++ b/docs/MANUAL_INSTALLATION.md
@@ -490,7 +490,7 @@ Some tools require manual installation due to complex dependencies or platform-s
 
 The following tools have special requirements on Windows that prevent automatic installation:
 
-#### Prowler (Windows) {#prowler-windows}
+#### Prowler (Windows)
 
 **Issue:** Prowler installation on Windows fails due to long path limitations (>260 characters). The AWS SDK and its dependencies create deeply nested paths that exceed Windows' default MAX_PATH limit.
 
@@ -529,7 +529,7 @@ pip install prowler
 docker run -v "$PWD:/scan" ghcr.io/jimmy058910/jmo-security:balanced scan --profile balanced
 ```
 
-#### Lynis (Windows) {#lynis-windows}
+#### Lynis (Windows)
 
 **Issue:** Lynis is a shell script that requires a Unix shell (bash) to run. It cannot run natively on Windows without a Unix-like environment.
 

--- a/docs/RESULTS_GUIDE.md
+++ b/docs/RESULTS_GUIDE.md
@@ -29,7 +29,7 @@ After running a JMo Security scan, you'll get multiple output formats. Here's wh
 
 ```bash
 cat results/summaries/SUMMARY.md
-```text
+```
 **What you'll see:**
 
 - Total findings count with severity breakdown (CRITICAL/HIGH/MEDIUM/LOW/INFO)
@@ -40,7 +40,7 @@ cat results/summaries/SUMMARY.md
 **Example:**
 ```text
 Total findings: 8058 | 🔴 3 CRITICAL | 🔴 91 HIGH | 🟡 280 MEDIUM | ⚪ 7391 LOW
-```text
+```
 **What this means:** Most findings are LOW severity (common for code quality checks). Focus on the 3 CRITICAL and 91 HIGH first.
 
 ### 2. Open the Interactive Dashboard (2 minutes)
@@ -58,7 +58,7 @@ open results/summaries/dashboard.html
 # Windows
 
 start results/summaries/dashboard.html
-```text
+```
 **What you'll see:**
 
 - Visual charts showing severity distribution
@@ -72,7 +72,7 @@ start results/summaries/dashboard.html
 
 ```bash
 cat results/summaries/COMPLIANCE_SUMMARY.md
-```text
+```
 **What you'll see:**
 
 - Which OWASP Top 10 categories are affected
@@ -85,7 +85,7 @@ OWASP Top 10 2021: 4/10 categories
 
 - A02:2021 (Cryptographic Failures): 102 findings
 - A03:2021 (Injection): 301 findings
-```text
+```
 **What this means:** If you need SOC 2, PCI DSS, or ISO 27001 compliance, these reports show exactly which security findings map to which requirements.
 
 ---
@@ -129,7 +129,7 @@ results/
     ├── attack-navigator.json  # MITRE ATT&CK Navigator visualization
     ├── dashboard.html         # Interactive web dashboard
     └── timings.json           # Performance profiling (if --profile used)
-```text
+```
 
 ### Which Files to Use When
 
@@ -153,7 +153,7 @@ The `SUMMARY.md` file is your starting point for triage. Here's how to read it:
 
 ```markdown
 Total findings: 8058 | 🔴 3 CRITICAL | 🔴 91 HIGH | 🟡 280 MEDIUM | ⚪ 7391 LOW
-```text
+```
 **What to look for:**
 
 - **CRITICAL/HIGH count** - Your immediate priority
@@ -166,7 +166,7 @@ Total findings: 8058 | 🔴 3 CRITICAL | 🔴 91 HIGH | 🟡 280 MEDIUM | ⚪ 73
 |------|----------|----------|-----------|
 | tests/e2e/fixtures/iac/aws-s3-public.tf | 19 | 🔴 CRITICAL | RDS Cluster backup retention <1 day |
 | Dockerfile.alpine | 6 | 🔴 CRITICAL | ':latest' tag used |
-```text
+```
 **What to do:**
 
 1. **Check if it's production code** - Test fixtures, examples, archived code can often be suppressed
@@ -180,7 +180,7 @@ Total findings: 8058 | 🔴 3 CRITICAL | 🔴 91 HIGH | 🟡 280 MEDIUM | ⚪ 73
 - **trivy**: 81 findings (🔴 3 CRITICAL, 🔴 28 HIGH)
 - **semgrep**: 32 findings (🔴 6 HIGH, 🟡 24 MEDIUM)
 - **trufflehog**: 7 findings (🟡 7 MEDIUM)
-```text
+```
 **What this tells you:**
 
 - **Trivy found CRITICAL** - Likely container or dependency vulnerabilities (CVEs)
@@ -199,7 +199,7 @@ Total findings: 8058 | 🔴 3 CRITICAL | 🔴 91 HIGH | 🟡 280 MEDIUM | ⚪ 73
 
 1. **Fix Image user should not be 'root'** (5 findings) → Review container security
 2. **Address 63 code security issues** → Review SAST findings
-```text
+```
 **How to use this:**
 
 - Start with **systemic issues** (same fix applies to multiple findings)
@@ -212,7 +212,7 @@ Total findings: 8058 | 🔴 3 CRITICAL | 🔴 91 HIGH | 🟡 280 MEDIUM | ⚪ 73
 - 🔧 Code Quality: 7673 findings (95% of total)
 - 🛡️ Vulnerabilities: 79 findings (1% of total)
 - 🔑 Secrets: 9 findings (0% of total)
-```text
+```
 **What this means:**
 
 - **95% Code Quality** - Bandit flagging `assert` statements, missing type hints, etc. (LOW priority)
@@ -235,7 +235,7 @@ JMo Security auto-enriches findings with 6 compliance frameworks. Here's how to 
 |----------|----------|
 | A02:2021 | 102 |
 | A03:2021 | 301 |
-```text
+```
 **What it means:**
 
 - **A02:2021 - Cryptographic Failures:** 102 findings related to weak crypto, missing encryption, insecure storage
@@ -256,7 +256,7 @@ JMo Security auto-enriches findings with 6 compliance frameworks. Here's how to 
 | CWE ID | Rank | Findings |
 |--------|------|----------|
 | CWE-798 | 18 | 7 |
-```text
+```
 **What it means:**
 
 - **CWE-798 (Rank 18):** Use of Hard-coded Credentials - 7 findings
@@ -280,7 +280,7 @@ JMo Security auto-enriches findings with 6 compliance frameworks. Here's how to 
 | IDENTIFY | 8047 |
 | PROTECT  | 22 |
 | DETECT   | 7673 |
-```text
+```
 **What it means:**
 
 - **GOVERN:** Findings related to policies, risk management, supply chain (CWE-798, dependency issues)
@@ -305,7 +305,7 @@ JMo Security auto-enriches findings with 6 compliance frameworks. Here's how to 
 
 **Priority:** CRITICAL
 **Findings:** 7673
-```text
+```
 **What it means:**
 
 - **Requirement 6.2.4:** All custom code must be scanned for vulnerabilities
@@ -328,7 +328,7 @@ JMo Security auto-enriches findings with 6 compliance frameworks. Here's how to 
 | Framework | Coverage |
 |-----------|----------|
 | CIS Controls v8.1 | 14 controls |
-```text
+```
 **What it means:**
 
 - **14 controls triggered** - Your findings map to 14 of the 18 CIS Critical Security Controls
@@ -353,7 +353,7 @@ JMo Security auto-enriches findings with 6 compliance frameworks. Here's how to 
 
 1. **T1195** - Supply Chain Compromise (374 findings)
 2. **T1552** - Unsecured Credentials (7 findings)
-```text
+```
 **What it means:**
 
 - **T1195 - Supply Chain Compromise:** Findings in dependencies, SBOM packages (Syft detected 374 packages)
@@ -392,7 +392,7 @@ jq 'length' critical-high.json
 
 # Output: 94
 
-```text
+```
 **Result:** You now have 94 findings to review instead of 8058.
 
 ### Step 2: Categorize by Location (10 minutes)
@@ -402,7 +402,7 @@ jq 'length' critical-high.json
 # Group by file path pattern
 
 jq 'group_by(.location.path | split("/")[0:3] | join("/"))' critical-high.json > grouped.json
-```text
+```
 **Categories to look for:**
 
 1. **Production code** (`src/`, `scripts/`, root files)
@@ -420,7 +420,7 @@ Is it in production code?
     NO → Is it a test fixture?
       YES → Priority 4 (suppress or document as intentional)
       NO → Priority 2 (CI/CD hardening)
-```text
+```
 
 ### Step 3: Check for False Positives (10 minutes)
 
@@ -445,7 +445,7 @@ jq '.[] | select(.ruleId == "B101" and (.location.path | contains("test")))' \
 
 # Output: 62
 
-```text
+```
 **Decision:** Suppress B101 for test files (pytest uses `assert` extensively)
 
 ### Step 4: Identify Systemic Issues (5 minutes)
@@ -458,7 +458,7 @@ jq '.[] | select(.ruleId == "B101" and (.location.path | contains("test")))' \
 
 jq '[.[] | .ruleId] | group_by(.) | map({rule: .[0], count: length}) | sort_by(.count) | reverse | .[0:5]' \
   critical-high.json
-```text
+```
 **Example output:**
 ```json
 [
@@ -466,7 +466,7 @@ jq '[.[] | .ruleId] | group_by(.) | map({rule: .[0], count: length}) | sort_by(.
   {"rule": "CVE-2023-12345", "count": 15},
   {"rule": "root-user", "count": 5}
 ]
-```text
+```
 **What this means:**
 
 1. **B101 (62 occurrences)** - Systemic pattern (likely test files) → One suppression rule fixes all 62
@@ -509,7 +509,7 @@ All findings follow the **CommonFinding schema v1.2.0**. Here's how to query the
     "mitreAttack": [{"tactic": "Initial Access", "technique": "T1190"}]
   }
 }
-```text
+```
 
 ### Common Queries
 
@@ -518,28 +518,28 @@ All findings follow the **CommonFinding schema v1.2.0**. Here's how to query the
 ```bash
 jq '[.[] | select(.tags[]? == "secret" or .ruleId | contains("secret"))]' \
   results/summaries/findings.json > secrets.json
-```text
+```
 
 #### 2. Find Exploitable CVEs (CVSS ≥7.0)
 
 ```bash
 jq '[.[] | select(.cvss? and (.cvss.score >= 7.0))]' \
   results/summaries/findings.json > exploitable-cves.json
-```text
+```
 
 #### 3. Find All SQL Injection Issues
 
 ```bash
 jq '[.[] | select(.ruleId | contains("sql") or (.message | ascii_downcase | contains("sql injection")))]' \
   results/summaries/findings.json > sql-injection.json
-```text
+```
 
 #### 4. Get OWASP A03 (Injection) Findings
 
 ```bash
 jq '[.[] | select(.compliance.owaspTop10_2021[]? == "A03:2021")]' \
   results/summaries/findings.json > owasp-a03.json
-```text
+```
 
 #### 5. Find Findings in Production Code Only
 
@@ -548,7 +548,7 @@ jq '[.[] | select(.location.path | contains("tests/") | not)
            | select(.location.path | contains(".venv/") | not)
            | select(.location.path | contains("fixtures/") | not)]' \
   results/summaries/findings.json > production-only.json
-```text
+```
 
 #### 6. Group Findings by File
 
@@ -557,7 +557,7 @@ jq 'group_by(.location.path)
     | map({path: .[0].location.path, count: length, severities: [.[] | .severity] | unique})
     | sort_by(.count) | reverse' \
   results/summaries/findings.json > by-file.json
-```text
+```
 ---
 
 ## Using the Interactive Dashboard
@@ -642,7 +642,7 @@ suppressions:
 
     line: 74
     reason: "Read-only echo of commit message in CI logs"
-```text
+```
 
 ### Method 2: Update Scan Configuration
 
@@ -677,7 +677,7 @@ per_tool:
       - "tests/e2e/fixtures/"
       - "--exclude"
       - "docs/archive/"
-```text
+```
 
 ### Method 3: Tool-Specific Configuration
 
@@ -695,13 +695,13 @@ skips:
 
   - B101  # assert_used
   - B404  # import_subprocess
-```text
+```
 **Semgrep** (`.semgrepignore`):
 ```text
 .venv/
 tests/e2e/fixtures/
 docs/archive/
-```text
+```
 
 ### Viewing Suppressed Findings
 
@@ -710,7 +710,7 @@ After adding suppressions, re-run the scan:
 ```bash
 jmo balanced --repos-dir .
 cat results/summaries/SUPPRESSIONS.md
-```text
+```
 **Example output:**
 ```markdown
 
@@ -723,7 +723,7 @@ cat results/summaries/SUPPRESSIONS.md
 - Third-party dependencies vetted by PyPI: 1,180
 - Test fixtures with intentional vulnerabilities: 62
 - Accepted risk: alpine:latest for faster builds: 3
-```text
+```
 ---
 
 ## Integrating with Your Workflow
@@ -746,7 +746,7 @@ cat results/summaries/SUPPRESSIONS.md
       language: system
       pass_filenames: false
       always_run: true
-```text
+```
 1. Install: `pre-commit install`
 
 **Result:** Commits are blocked if HIGH/CRITICAL findings exist.
@@ -801,7 +801,7 @@ jobs:
         with:
           name: security-scan-results
           path: results/summaries/
-```text
+```
 **Result:** PRs are blocked if HIGH/CRITICAL findings exist, and results appear in GitHub Security tab.
 
 ### Scenario 3: Weekly Scheduled Scans
@@ -850,7 +850,7 @@ jobs:
           name: weekly-scan-results
           path: results/summaries/
           retention-days: 90
-```text
+```
 **Result:** Weekly audit with historical tracking.
 
 ### Scenario 4: Slack/Email Notifications
@@ -879,7 +879,7 @@ jobs:
           }
         ]
       }
-```text
+```
 ---
 
 ## Advanced: SARIF and CI/CD Integration
@@ -907,7 +907,7 @@ JMo Security outputs `findings.sarif` (SARIF 2.1.0) for seamless integration.
   with:
     sarif_file: results/summaries/findings.sarif
     category: jmo-security-scan
-```text
+```
 **What you get:**
 
 - Findings appear in **Security → Code scanning** tab
@@ -921,7 +921,7 @@ JMo Security outputs `findings.sarif` (SARIF 2.1.0) for seamless integration.
 permissions:
   security-events: write  # Required for SARIF upload
   contents: read
-```text
+```
 
 ### GitLab SAST Integration
 
@@ -937,7 +937,7 @@ security-scan:
 
     reports:
       sast: gl-sast-report.json
-```text
+```
 **Result:** Findings appear in GitLab Security Dashboard and Merge Request widget.
 
 ### Azure DevOps Integration
@@ -951,7 +951,7 @@ security-scan:
     pathtoPublish: 'results/summaries/findings.sarif'
     artifactName: 'CodeAnalysisLogs'
     publishLocation: 'Container'
-```text
+```
 ---
 
 ## Real-World Triage Examples
@@ -999,6 +999,7 @@ security-scan:
 
 2. **Investigate Trivy CVEs:**
 
+   ```bash
    jq '[.[] | select(.tool.name == "trivy" and .severity == "CRITICAL")]' findings.json
    ```
 
@@ -1050,7 +1051,7 @@ security-scan:
 mkdir -p compliance/soc2/
 cp results/summaries/SUMMARY.md compliance/soc2/scan-$(date +%Y-%m-%d).md
 cp results/summaries/COMPLIANCE_SUMMARY.md compliance/soc2/
-```text
+```
 
 ### Preparing for a PCI DSS Audit
 
@@ -1061,6 +1062,7 @@ cp results/summaries/COMPLIANCE_SUMMARY.md compliance/soc2/
 1. **Provide PCI_DSS_COMPLIANCE.md**
 2. **Filter to show only production code:**
 
+   ```bash
    jq '[.[] | select(.location.path | contains("tests/") | not)]' findings.json > production-findings.json
    ```
 
@@ -1072,7 +1074,7 @@ cp results/summaries/COMPLIANCE_SUMMARY.md compliance/soc2/
 
 ```bash
 jmo ci --repo . --fail-on HIGH
-```text
+```
 ---
 
 ## Troubleshooting Common Issues
@@ -1089,7 +1091,7 @@ jq '[.[] | select(.severity == "CRITICAL" or .severity == "HIGH")
          | select(.location.path | contains("tests/") | not)
          | select(.location.path | contains(".venv/") | not)]' \
   findings.json > findings-priority.json
-```text
+```
 
 ### Issue 2: "Same CVE appears in 50 different locations"
 
@@ -1098,13 +1100,13 @@ jq '[.[] | select(.severity == "CRITICAL" or .severity == "HIGH")
 ```bash
 jq 'group_by(.ruleId) | map({rule: .[0].ruleId, count: length, severity: .[0].severity})
     | sort_by(.count) | reverse' findings.json
-```text
+```
 **Example output:**
 ```json
 [
   {"rule": "CVE-2023-12345", "count": 50, "severity": "HIGH"}
 ]
-```text
+```
 **Fix:** One `pip install --upgrade vulnerable-package` fixes all 50.
 
 ### Issue 3: "Dashboard won't open / shows blank page"
@@ -1135,7 +1137,7 @@ jq 'group_by(.ruleId) | map({rule: .[0].ruleId, count: length, severity: .[0].se
 
 ```bash
 pip install --upgrade jmo-security-audit
-```text
+```
 Compliance auto-enrichment was added in v0.5.1.
 
 ---
@@ -1169,7 +1171,7 @@ jq '[.[] | select(.compliance.owaspTop10_2021[]? == "A03:2021")]' results/summar
 # Filter production code only
 
 jq '[.[] | select(.location.path | contains("tests/") or contains(".venv/") | not)]' results/summaries/findings.json
-```text
+```
 
 ### File Quick Reference
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1305,7 +1305,7 @@ jmo adapters validate ~/.jmo/adapters/custom_tool_adapter.py
 1. `~/.jmo/adapters/` - User plugins (highest priority)
 2. `scripts/core/adapters/` - Built-in plugins
 
-**Complete Guide:** [CONTRIBUTING.md — Adding Tool Adapters](../CONTRIBUTING.md#adding-tool-adapters)
+**Complete Guide:** [CONTRIBUTING.md — Adding Tool Adapters](../CONTRIBUTING.md#adding-tool-adapters-plugin-system)
 
 ## Schedule Management
 

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -1,7 +1,7 @@
 # Version Management Guide
 
 **Status:** ✅ Implemented
-**Related:** [ROADMAP.md #14](../ROADMAP.md#1-tool-version-consistency--automated-dependency-management), [Issue #46](https://github.com/jimmy058910/jmo-security-repo/issues/46), [Issue #12](https://github.com/jimmy058910/jmo-security-repo/issues/12)
+**Related:** [ROADMAP.md](../ROADMAP.md), [Issue #46](https://github.com/jimmy058910/jmo-security-repo/issues/46), [Issue #12](https://github.com/jimmy058910/jmo-security-repo/issues/12)
 
 ## Table of Contents
 
@@ -20,7 +20,7 @@
 
 ## Overview
 
-JMo Security Suite uses a **5-layer version management system** to ensure Docker images and native installations always use the same tool versions. This prevents critical issues like the Trivy v0.58.1 → v0.67.2 discrepancy that caused 16 CVEs to be missed (see [ROADMAP.md #14](../ROADMAP.md#1-tool-version-consistency--automated-dependency-management)).
+JMo Security Suite uses a **5-layer version management system** to ensure Docker images and native installations always use the same tool versions. This prevents critical issues like the Trivy v0.58.1 → v0.67.2 discrepancy that caused 16 CVEs to be missed (see [ROADMAP.md](../ROADMAP.md)).
 
 ### Why This Matters
 
@@ -712,7 +712,7 @@ python3 scripts/dev/update_versions.py --sync
 
 ## Related Documentation
 
-- [ROADMAP.md #14](../ROADMAP.md#1-tool-version-consistency--automated-dependency-management) — Full 5-layer system design
+- [ROADMAP.md](../ROADMAP.md) — Project roadmap and shipped features
 - [Issue #46](https://github.com/jimmy058910/jmo-security-repo/issues/46) — Tool version consistency tracking
 - [Issue #12](https://github.com/jimmy058910/jmo-security-repo/issues/12) — Dependency locking & updates
 - [CLAUDE.md](../CLAUDE.md) — AI assistant development guidance

--- a/docs/examples/attestation-workflows.md
+++ b/docs/examples/attestation-workflows.md
@@ -717,4 +717,4 @@ jobs:
 - **Sigstore Documentation:** <https://docs.sigstore.dev>
 - **Rekor Transparency Log:** <https://rekor.sigstore.dev>
 - **in-toto Attestation Framework:** <https://in-toto.io>
-- **JMo Security USER_GUIDE.md:** [SLSA Attestation Section](../USER_GUIDE.md#slsa-attestation-v100)
+- **JMo Security USER_GUIDE.md:** [SLSA Attestation Section](../USER_GUIDE.md#slsa-attestation)

--- a/docs/examples/attestation-workflows.md
+++ b/docs/examples/attestation-workflows.md
@@ -500,7 +500,7 @@ jobs:
               --check-rekor
             ```
 
-```text
+```
 
 ## Compliance Scenarios
 

--- a/docs/examples/diff-workflows.md
+++ b/docs/examples/diff-workflows.md
@@ -44,7 +44,7 @@ graph LR
 
 ### Example Output
 
-```markdown
+````markdown
 # 🔍 Security Diff Report
 
 **Baseline:** `main` (2025-11-05, balanced profile)
@@ -93,7 +93,7 @@ cursor.execute(query, (user_id,))
 
 </details>
 
-```text
+````
 
 ---
 

--- a/docs/examples/diff-workflows.md
+++ b/docs/examples/diff-workflows.md
@@ -499,7 +499,7 @@ jmo diff --scan abc123 --scan def456 --format json
 
 - [GitHub Actions Example](github-actions-diff.yml)
 - [GitLab CI Example](gitlab-ci-diff.yml)
-- [USER_GUIDE.md - Diff Command Reference](../USER_GUIDE.md#jmo-diff)
+- [USER_GUIDE.md - Diff Command Reference](../USER_GUIDE.md#machine-readable-diffs)
 
 ---
 

--- a/docs/examples/wizard-examples.md
+++ b/docs/examples/wizard-examples.md
@@ -1830,7 +1830,7 @@ docker run --rm \
 For complete documentation, see:
 
 - [docs/USER_GUIDE.md — Trend Analysis](../USER_GUIDE.md#trend-analysis)
-- [docs/API_REFERENCE.md — TrendAnalyzer API](../API_REFERENCE.md#trendanalyzer)
+- [docs/API_REFERENCE.md — TrendAnalyzer API](../API_REFERENCE.md#trendanalyzer-api)
 - [docs/examples/ci-cd-trends.md](./ci-cd-trends.md) - Complete CI/CD patterns
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@
 | Configure scanning | [User Guide: Configuration](USER_GUIDE.md#configuration-jmoyml) |
 | Speed up scans | [Scan Optimization](SCAN_OPTIMIZATION.md) |
 | Set up CI/CD | [Docker Guide: CI/CD](DOCKER_README.md#cicd-integration) |
-| Suppress false positives | [User Guide: Suppressions](USER_GUIDE.md#suppressions) |
+| Suppress false positives | [User Guide: Suppressions](USER_GUIDE.md#handling-false-positives) |
 | Compare scans (diff) | [Diff Guide](DIFF_GUIDE.md) |
 | Track trends over time | [Trends Guide](TRENDS_GUIDE.md) |
 | View scan history | [History Guide](HISTORY_GUIDE.md) |
@@ -162,7 +162,7 @@ JMo Security orchestrates 28 security scanners across 11 categories:
 | System | Lynis |
 | Runtime | Trivy-RBAC, Falco, AFL++ |
 
-**Tool details:** [Profiles and Tools Reference](PROFILES_AND_TOOLS.md) | [User Guide: Tool Overview](USER_GUIDE.md#tool-overview)
+**Tool details:** [Profiles and Tools Reference](PROFILES_AND_TOOLS.md) | [User Guide: Tool Overview](USER_GUIDE.md#tool-management)
 
 ---
 

--- a/scripts/dev/check_doc_links.py
+++ b/scripts/dev/check_doc_links.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+import unicodedata
+from collections.abc import Iterator
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -66,16 +68,65 @@ INLINE_CODE_PATTERN = re.compile(r"(?P<ticks>`+)(?:(?!(?P=ticks)).)*(?P=ticks)")
 LINE_ANCHOR_PATTERN = re.compile(r"#L\d")
 
 
-def navigable_lines(text: str) -> list[str]:
-    """Lines with code fences dropped and inline code spans blanked out.
+# A link inside a heading renders as its text alone, so the URL must come off
+# before the filter runs - stripping punctuation from it would otherwise glue
+# the URL to the text (`the-guidedocsuser_guidemd`).
+HEADING_LINK_PATTERN = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+
+# Join controls (U+200C/U+200D) glue emoji sequences together. GitHub keeps
+# them; they are `\p{Join_Control}`, which Python exposes nowhere.
+JOIN_CONTROLS = frozenset("‌‍")
+
+
+def _is_slug_char(char: str) -> bool:
+    """True for the characters GitHub's slug filter keeps.
+
+    GitHub drops everything outside `[\\p{Word}\\- ]`, and Ruby's `\\p{Word}` is
+    `Alnum + Mark + Connector_Punctuation + Join_Control`. Python's `\\w` covers
+    the first and third but **not** marks - so a `[^\\w\\- ]` port silently
+    disagrees on `⚠️`, dropping the U+FE0F variation selector GitHub retains.
+    Measured against `gh api markdown` across all 177 tracked files: this
+    predicate agrees on 3873/3873 anchors, the regex on 3868.
+    """
+    if char in "- _":
+        return True
+    if char.isalnum():
+        return True
+    return unicodedata.category(char).startswith("M") or char in JOIN_CONTROLS
+
+
+# An ATX heading. The space after the hashes is required, which is what keeps
+# `#!/usr/bin/env python` and a `#719` issue reference from becoming anchors.
+# The corpus has no setext (`Title\n=====`) headings; every `---` under a line
+# of prose is a YAML frontmatter terminator.
+HEADING_PATTERN = re.compile(r"^\s{0,3}#{1,6}\s+(?P<title>.*?)\s*#*\s*$")
+
+
+def heading_anchor(text: str) -> str:
+    """The `#fragment` GitHub generates for a heading with this text.
+
+    Backticks and `**` need no special case: they are punctuation, and the
+    filter drops them like any other. Note that a dropped character leaves its
+    surrounding spaces behind, so an emoji between two words produces a double
+    hyphen - that is GitHub's behaviour, not an artefact.
+    """
+    rendered = HEADING_LINK_PATTERN.sub(r"\1", text).lower()
+    kept = "".join(char for char in rendered if _is_slug_char(char))
+    return kept.replace(" ", "-")
+
+
+def unfenced_lines(text: str) -> Iterator[str]:
+    """Yield the lines that are not inside a fenced code block.
 
     Follows the CommonMark closing rule rather than toggling on every fence:
     a closer repeats the opener's character, is at least as long, and carries
     no info string. Toggling desynchronises on same-length nested fences - a
     ```markdown block quoting a ```bash block - which is exactly the shape
     these agent files use to show example output.
+
+    Both callers need this and neither needs the other's transformation, so it
+    lives here once. Duplicating the closing rule is how the two would drift.
     """
-    lines: list[str] = []
     opener: str | None = None
     for raw in text.splitlines():
         fence = FENCE_PATTERN.match(raw)
@@ -88,8 +139,34 @@ def navigable_lines(text: str) -> list[str]:
             if closes:
                 opener = None
                 continue
-        lines.append("" if opener else INLINE_CODE_PATTERN.sub("``", raw))
-    return lines
+        if opener is None:
+            yield raw
+
+
+def navigable_lines(text: str) -> list[str]:
+    """Lines with code fences dropped and inline code spans blanked out."""
+    return [INLINE_CODE_PATTERN.sub("``", raw) for raw in unfenced_lines(text)]
+
+
+def collect_anchors(text: str) -> set[str]:
+    """Every `#fragment` a reader can actually link to in this document.
+
+    Headings are the only source: the corpus carries no `<a id=>` and no inline
+    HTML in any heading. Code spans are deliberately *not* blanked first - the
+    anchor derives from the heading's rendered text, and blanking
+    ``## `jmo tools check` MANUAL`` would drop three of its four words.
+    """
+    anchors: set[str] = set()
+    seen: dict[str, int] = {}
+    for raw in unfenced_lines(text):
+        heading = HEADING_PATTERN.match(raw)
+        if not heading:
+            continue
+        base = heading_anchor(heading.group("title").strip())
+        count = seen.get(base, 0)
+        seen[base] = count + 1
+        anchors.add(base if count == 0 else f"{base}-{count}")
+    return anchors
 
 
 def tracked_paths() -> set[str]:
@@ -126,25 +203,34 @@ def is_tracked(target: str, tracked: set[str]) -> bool:
     return any(p.startswith(prefix) for p in tracked)
 
 
-def check_file(rel_path: str, tracked: set[str]) -> list[str]:
-    """Return dead-reference messages for one documentation file."""
+def check_text(
+    rel_path: str,
+    text: str,
+    tracked: set[str],
+    anchors: dict[str, set[str]],
+) -> list[str]:
+    """Return dead-reference messages for one document's Markdown source."""
     source = REPO_ROOT / rel_path
     problems: list[str] = []
-    text = "\n".join(navigable_lines(source.read_text(encoding="utf-8")))
+    navigable = "\n".join(navigable_lines(text))
 
-    for match in LINK_PATTERN.finditer(text):
+    for match in LINK_PATTERN.finditer(navigable):
         link = match.group(1).strip()
 
-        if link.startswith(("http://", "https://", "mailto:", "#")):
+        if link.startswith(("http://", "https://", "mailto:")):
             continue
 
-        # A line citation points at source on the web, not into the tree.
+        # A line citation points at source on the web, not at a heading.
         if LINE_ANCHOR_PATTERN.search(link):
             continue
 
-        # Strip any anchor; a bare anchor was handled above.
-        path_part = link.split("#", 1)[0]
+        path_part, _, fragment = link.partition("#")
+
+        # A bare `#anchor` - the shape every table of contents uses - names a
+        # heading in the file it is written in.
         if not path_part:
+            if fragment and fragment not in anchors.get(rel_path, set()):
+                problems.append(f"  NO ANCHOR {rel_path} -> {link}")
             continue
 
         # Repo-relative form of a link written relative to its own file.
@@ -155,13 +241,25 @@ def check_file(rel_path: str, tracked: set[str]) -> list[str]:
             # Escapes the repo entirely - not ours to validate.
             continue
 
-        if is_tracked(target, tracked):
+        if not is_tracked(target, tracked):
+            kind = "UNTRACKED" if resolved.exists() else "BROKEN   "
+            problems.append(f"  {kind} {rel_path} -> {link}")
+            # The path is the fix; its anchor is downstream noise.
             continue
 
-        kind = "UNTRACKED" if resolved.exists() else "BROKEN   "
-        problems.append(f"  {kind} {rel_path} -> {link}")
+        # Only Markdown grows headings, so only Markdown has anchors to verify.
+        if fragment and target in anchors and fragment not in anchors[target]:
+            problems.append(f"  NO ANCHOR {rel_path} -> {link}")
 
     return problems
+
+
+def check_file(
+    rel_path: str, tracked: set[str], anchors: dict[str, set[str]]
+) -> list[str]:
+    """Return dead-reference messages for one documentation file."""
+    text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+    return check_text(rel_path, text, tracked, anchors)
 
 
 def main() -> int:
@@ -174,10 +272,19 @@ def main() -> int:
     safe_print("Checking documentation links resolve to tracked files...")
     tracked = tracked_paths()
 
+    # Anchors come from every tracked Markdown file, archival included: those
+    # are exempt as link *sources*, not as link *targets*. A link into a plan's
+    # heading is as checkable as any other.
+    anchors = {
+        path: collect_anchors((REPO_ROOT / path).read_text(encoding="utf-8"))
+        for path in tracked
+        if path.endswith(".md")
+    }
+
     files = collect_files(tracked)
     problems: list[str] = []
     for rel_path in files:
-        problems.extend(check_file(rel_path, tracked))
+        problems.extend(check_file(rel_path, tracked, anchors))
 
     if problems:
         for line in sorted(problems):
@@ -187,6 +294,13 @@ def main() -> int:
         safe_print("UNTRACKED -> the file exists locally but ships to nobody. Either")
         safe_print("             track it (see the .claude/ allowlist in .gitignore)")
         safe_print("             or stop referencing it from a tracked file.")
+        safe_print("NO ANCHOR -> the file resolves but names no such heading. This one")
+        safe_print(
+            "             fails silently in a browser - it scrolls to the top of"
+        )
+        safe_print(
+            "             the page, which looks exactly like a link that worked."
+        )
         return 1
 
     safe_print(f"All links in {len(files)} tracked file(s) resolve to tracked paths.")

--- a/tests/unit/test_check_doc_links.py
+++ b/tests/unit/test_check_doc_links.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/dev/check_doc_links.py`.
+
+The interesting half is fragment validation. A link's *file* half fails loudly
+when it is wrong - the page 404s. Its `#fragment` half fails silently: a browser
+that cannot find the anchor scrolls to the top of the page, which is
+indistinguishable from a link that worked. So a wrong anchor survives every
+form of review that consists of clicking it.
+"""
+
+from __future__ import annotations
+
+from scripts.dev.check_doc_links import (
+    check_text,
+    collect_anchors,
+    heading_anchor,
+)
+
+
+def test_lowercases_and_hyphenates_spaces() -> None:
+    assert heading_anchor("Scan Profiles") == "scan-profiles"
+
+
+def test_drops_punctuation_rather_than_hyphenating_it() -> None:
+    """`:` vanishes; the space beside it is what becomes the hyphen.
+
+    Order matters. Hyphenating before stripping would yield `setup--fast`.
+    """
+    assert heading_anchor("Setup: Fast Path") == "setup-fast-path"
+    assert heading_anchor("What's New?") == "whats-new"
+    assert heading_anchor("jmo.yml Key Settings") == "jmoyml-key-settings"
+
+
+def test_keeps_underscores_and_existing_hyphens() -> None:
+    """GitHub's filter strips everything outside `[\\w- ]`, and `_` is a word char."""
+    assert heading_anchor("per_tool overrides") == "per_tool-overrides"
+    assert heading_anchor("Pre-commit Order") == "pre-commit-order"
+
+
+def test_backticks_and_bold_need_no_special_case() -> None:
+    """They are punctuation, so the same filter that drops `:` drops them."""
+    assert heading_anchor("`jmo tools check` MANUAL state") == (
+        "jmo-tools-check-manual-state"
+    )
+    assert heading_anchor("**Bold** text") == "bold-text"
+
+
+def test_a_link_renders_as_its_text_only() -> None:
+    """A link is the one construct the punctuation filter gets wrong alone.
+
+    Stripping punctuation from `[the guide](docs/USER_GUIDE.md)` leaves the URL
+    glued to the text (`the-guidedocsuser_guidemd`). No heading in this repo is
+    a link today; this exists so that adding one does not make the checker
+    report a *working* anchor as broken.
+    """
+    assert heading_anchor("See [the guide](docs/USER_GUIDE.md)") == "see-the-guide"
+
+
+def test_a_dropped_character_leaves_its_spaces_behind() -> None:
+    """Removing an emoji between two words yields a DOUBLE hyphen.
+
+    The filter deletes the character but not the spaces around it, and both
+    spaces then become hyphens. 117 headings in this repo carry an emoji or an
+    em-dash, so getting this wrong would mis-derive every one of them.
+    """
+    assert heading_anchor("Fast Profile [OK] Works") == "fast-profile-ok-works"
+    assert heading_anchor("Fast Profile ✅ Works") == "fast-profile--works"
+    assert heading_anchor("B.2 Platform choice — Cloudflare") == (
+        "b2-platform-choice--cloudflare"
+    )
+
+
+def test_keeps_unicode_letters_that_are_not_punctuation() -> None:
+    """The filter is `\\w`-based, not ASCII-based: an accent is a word char."""
+    assert heading_anchor("Café Settings") == "café-settings"
+
+
+def test_keeps_the_invisible_selector_an_emoji_leaves_behind() -> None:
+    """`⚠️` is two code points, and GitHub drops only the first.
+
+    U+FE0F VARIATION SELECTOR-16 is a Unicode *mark*, and GitHub's filter keeps
+    `\\p{Word}` - which in Ruby includes marks. Python's `\\w` does not, so a
+    naive port silently disagrees. Measured against `gh api markdown`, which
+    renders `packaging/WINDOWS_COMPATIBILITY.md` with the selector retained.
+
+    This direction matters: anyone copying an anchor from GitHub's own
+    heading-link button gets the selector, and dropping it would make the
+    checker redden CI over a link that works.
+    """
+    assert heading_anchor("Balanced Profile ⚠️ Partially Works") == (
+        "balanced-profile-️-partially-works"
+    )
+
+
+def test_keeps_the_zero_width_joiner_inside_an_emoji_sequence() -> None:
+    """U+200D is `\\p{Join_Control}`, which GitHub's filter also keeps."""
+    assert heading_anchor("Team \U0001f468‍\U0001f4bb Notes") == ("team-‍-notes")
+
+
+def test_collects_headings_at_every_level() -> None:
+    doc = "# Top\n\nprose\n\n### Deeply Nested\n"
+    assert collect_anchors(doc) == {"top", "deeply-nested"}
+
+
+def test_repeated_heading_text_gets_a_numeric_suffix() -> None:
+    """GitHub numbers the *later* occurrences, leaving the first bare.
+
+    Both anchors are valid targets, so a checker that recorded only one would
+    report a working link as broken.
+    """
+    doc = "## Usage\n\n## Usage\n\n## Usage\n"
+    assert collect_anchors(doc) == {"usage", "usage-1", "usage-2"}
+
+
+def test_ignores_hash_lines_inside_a_code_fence() -> None:
+    """A shell comment is not a heading, and must not become a valid anchor.
+
+    Without this the checker accepts links to anchors that do not exist -
+    3873 headings in this repo sit alongside a great many `# comment` lines.
+    """
+    doc = "# Real\n\n```bash\n# Not A Heading\n```\n"
+    assert collect_anchors(doc) == {"real"}
+
+
+def test_requires_a_space_after_the_hashes() -> None:
+    """`#!/usr/bin/env` and `#4 issue refs` are not headings."""
+    doc = "#!/usr/bin/env python\n\n#719 was merged\n\n# Real\n"
+    assert collect_anchors(doc) == {"real"}
+
+
+# --------------------------------------------------------------------------
+# Fragment validation
+# --------------------------------------------------------------------------
+
+TRACKED = {"README.md", "docs/GUIDE.md", "scripts/core/thing.py"}
+ANCHORS = {
+    "README.md": {"install", "usage"},
+    "docs/GUIDE.md": {"configuration"},
+}
+
+
+def test_a_fragment_naming_a_real_heading_is_accepted() -> None:
+    problems = check_text(
+        "README.md", "See [config](docs/GUIDE.md#configuration).", TRACKED, ANCHORS
+    )
+    assert problems == []
+
+
+def test_a_fragment_naming_no_heading_is_reported() -> None:
+    """The failure this whole change exists to catch.
+
+    The file resolves, so every existing check passes; the browser silently
+    scrolls to the top of the page instead of reporting anything.
+    """
+    problems = check_text(
+        "README.md", "See [config](docs/GUIDE.md#confguration).", TRACKED, ANCHORS
+    )
+    assert len(problems) == 1
+    assert "NO ANCHOR" in problems[0]
+    assert "docs/GUIDE.md#confguration" in problems[0]
+
+
+def test_a_bare_fragment_resolves_against_its_own_file() -> None:
+    """`[Usage](#usage)` is the dominant shape - every table of contents."""
+    assert check_text("README.md", "[Usage](#usage)", TRACKED, ANCHORS) == []
+
+    problems = check_text("README.md", "[Usage](#usaeg)", TRACKED, ANCHORS)
+    assert len(problems) == 1
+    assert "NO ANCHOR" in problems[0]
+
+
+def test_a_line_citation_is_not_an_anchor() -> None:
+    """`thing.py#L42` points at source on the web, not at a heading."""
+    assert (
+        check_text("README.md", "[l](scripts/core/thing.py#L42)", TRACKED, ANCHORS)
+        == []
+    )
+
+
+def test_a_fragment_on_a_non_markdown_target_is_not_checked() -> None:
+    """Only Markdown grows headings, so only Markdown has anchors to verify."""
+    assert (
+        check_text("README.md", "[x](scripts/core/thing.py#frag)", TRACKED, ANCHORS)
+        == []
+    )
+
+
+def test_a_fragment_is_not_checked_when_the_file_itself_is_broken() -> None:
+    """One dead reference, not two. The path is the fix; the anchor is noise."""
+    problems = check_text("README.md", "[x](docs/GONE.md#anything)", TRACKED, ANCHORS)
+    assert len(problems) == 1
+    assert "BROKEN" in problems[0]
+
+
+def test_a_fragment_inside_a_code_fence_is_a_sample_not_a_link() -> None:
+    """Skill files quote broken links on purpose, to teach what one looks like."""
+    doc = "```md\n[x](docs/GUIDE.md#nope)\n```\n"
+    assert check_text("README.md", doc, TRACKED, ANCHORS) == []


### PR DESCRIPTION
## What

`check_doc_links.py` resolved a link's file and stopped there, so the
`#fragment` half was never checked. That is the half worth checking: a wrong
path 404s, but a wrong anchor degrades to "scroll to the top of the page",
which is indistinguishable from a link that worked. The gap let two broken
anchors ship — one of them inside the passage warning against broken anchors.

Three commits, in the order that keeps every point on the branch green:

1. **`279ef63` fence repair** — the structural cause behind 11 of the breaks.
2. **`5c07082` stale anchors** — the remaining 20.
3. **`15c3c9d` the gate** — fragment validation plus 20 tests.

## Measured

| | before | after |
|---|---|---|
| fragment links in tracked docs | 319 | 319 |
| pointing at no heading | **31** | **0** |
| what the old checker reported | `All links … resolve` | — |
| what the new checker reports on the old docs | — | `31 dead reference(s)` |

## Evidence gate: what CI structurally cannot check

CI can run the checker, but it cannot tell whether the checker's idea of an
anchor matches **GitHub's**. A derivation that is subtly wrong would either
redden CI over working links or keep missing broken ones, and the suite would
pass either way.

So the derivation was cross-validated against `gh api markdown` — the same
cmark-gfm GitHub renders with — across **all 177 tracked Markdown files**:

```
mine=3873  github=3885  agreeing=3873
```

**Zero anchors that this checker recognises and GitHub does not**, i.e. no
false positives, so it cannot redden CI over a working link. The 12 GitHub has
and this does not are one per `.claude/skills/*/SKILL.md`, where the raw
endpoint reads YAML frontmatter as a setext heading; github.com renders
frontmatter as a table, so that anchor exists in neither place.

That cross-validation is what caught the one real bug in the first draft.
GitHub keeps `[\p{Word}\- ]`, and Ruby's `\p{Word}` includes **Marks**, which
Python's `\w` does not — so `[^\w\- ]` dropped the U+FE0F variation selector
out of `⚠️` that GitHub retains. Anyone copying an anchor from GitHub's own
heading-link button gets that selector. The filter is now a predicate matching
Ruby's class; agreement went 3868 → 3873.

The fence repair was verified the same way. `docs/RESULTS_GUIDE.md` emitted
**31** anchors for a source declaring **95**; it now emits all 95, all 14
table-of-contents links resolve, and the 64 recovered anchors are all real
headings ("Section 1: Headline Stats", "Step 3: Check for False Positives") —
**no shell comment promoted to a heading**, checked by diffing GitHub's anchor
set before and after.

## Mutation testing

Eight mutations, each verified to turn the suite red (file backup, not
`git checkout --`):

| mutation | result |
|---|---|
| drop cross-file fragment check | 1 failed |
| drop bare-`#anchor` check | 1 failed |
| ASCII-only slug filter | 1 failed |
| drop Unicode-mark retention | 2 failed |
| drop duplicate-heading `-1`/`-2` suffix | 1 failed |
| collect headings inside code fences | 1 failed |
| allow hashes with no following space | 1 failed |
| drop link-text unwrapping | 1 failed |

Plus end-to-end: old checker → old docs = green; new checker → old docs = 31
dead references.

## Note on `docs/MANUAL_INSTALLATION.md`

One behaviour change rather than a redirect. It declared `{#prowler-windows}`
explicit anchors — honoured by `attr_list` on Read the Docs, **not** by GitHub,
which rendered the braces as literal text and derived
`#prowler-windows-prowler-windows`. Dropping the attribute makes the natural
anchor `#prowler-windows` correct under *both* renderers; confirmed with
`gh api markdown`.

## Out of scope

13 more files carry the same info-string-closer defect but do not currently
break a link — filed as #740 rather than widened into this PR.
