### PR TITLE
fix(trufflehog): stop reporting pytest function names as verified secrets

### DIFF
--- a/scripts/core/adapters/trufflehog_adapter.py
+++ b/scripts/core/adapters/trufflehog_adapter.py
@@ -68,6 +68,37 @@ from scripts.core.plugin_api import (
     adapter_plugin,
 )
 
+# Lob test-mode API keys are `test_` followed by 35 hex-ish characters.
+# TruffleHog's detector for them accepts underscores in that run, and pytest
+# names every test function `test_<words_with_underscores>` - so the two
+# collide by construction, and any Python project whose test names happen to be
+# 35 characters long produces Lob "secrets".
+#
+# They come back **Verified: true**, because Lob's API accepts test-mode keys,
+# so nothing downstream can tell them apart: the adapter graded them HIGH and
+# `zero-secrets.rego` ("blocks all verified secrets") failed the build. That was
+# #724, and it reached users as well as CI - `jmo scan` runs the same detector.
+#
+# The separator is the underscore. A real key has none; a Python identifier
+# always does. Measured over this repository's `tests/` tree: 2318 Lob findings,
+# 412 distinct, **412/412 containing an underscore and 0/412 matching
+# `[0-9a-f]{35}`**. Filtering on it costs no real detection.
+LOB_KEY_PREFIX = "test_"
+
+
+def _is_pytest_name_matched_as_lob_key(detector: str, secret: object) -> bool:
+    """True when a Lob "secret" is really a pytest function name.
+
+    Deliberately narrow: only the Lob detector, only a `test_` prefix, and only
+    when the remainder contains an underscore. Anything else - including a
+    genuine Lob key, and every other detector - is left alone.
+    """
+    if detector != "Lob" or not isinstance(secret, str):
+        return False
+    if not secret.startswith(LOB_KEY_PREFIX):
+        return False
+    return "_" in secret[len(LOB_KEY_PREFIX) :]
+
 
 @adapter_plugin(
     PluginMetadata(
@@ -103,6 +134,10 @@ class TruffleHogAdapter(AdapterPlugin):
         for f in safe_load_ndjson_file(output_path):
             detector = str(f.get("DetectorName") or f.get("Detector") or "Unknown")
             verified = bool(f.get("Verified") or f.get("verified") or False)
+
+            secret = f.get("Raw")
+            if _is_pytest_name_matched_as_lob_key(detector, secret):
+                continue
 
             # Try to extract file path from SourceMetadata.Data.Filesystem.file or similar
             file_path = ""

--- a/tests/adapters/test_trufflehog_adapter.py
+++ b/tests/adapters/test_trufflehog_adapter.py
@@ -445,3 +445,94 @@ class TestTruffleHogUnicode:
         adapter = TruffleHogAdapter()
         findings = adapter.parse(path)
         assert "密码" in findings[0].message
+
+
+class TestLobDetectorCollidesWithPytestNames:
+    """TruffleHog's Lob detector matches `test_[A-Za-z0-9_]{35}`.
+
+    pytest names test functions `test_<words_with_underscores>`, so the two
+    collide by construction: any Python project whose test names happen to be
+    35 characters long produces "verified" Lob findings. Measured on this
+    repository, `tests/` alone yielded 2318 of them, 412 distinct, and every
+    single one contained an underscore. A real Lob key is hex-ish and has
+    none, which is what makes them separable.
+
+    They arrive `Verified: true` because Lob's API accepts test-mode keys, so
+    the adapter graded them HIGH and `zero-secrets.rego` - "blocks all
+    verified secrets" - failed the build. See #724.
+    """
+
+    def test_pytest_function_name_is_not_reported_as_a_secret(self, tmp_path: Path):
+        """Verbatim TruffleHog output for a real false positive."""
+        payload = {
+            "SourceMetadata": {
+                "Data": {"Filesystem": {"file": "tests/adapters/t.py", "line": 142}}
+            },
+            "DetectorName": "Lob",
+            "Verified": True,
+            "Raw": "test_akto_adapter_non_vulnerable_skipped",
+            "ExtraData": {"environment": "test"},
+        }
+        path = write_tmp(tmp_path, "trufflehog.json", json.dumps(payload))
+        assert TruffleHogAdapter().parse(path) == []
+
+    def test_a_real_lob_key_is_still_reported(self, tmp_path: Path):
+        """The filter must not cost real detection - no underscores here.
+
+        The body below is **34 characters on purpose**. Lob's detector matches
+        exactly 35, so a fully realistic fixture would be flagged as a live
+        secret in this very file - it was, on the first draft, and it is the
+        only finding that survived the fix. The predicate under test does not
+        look at length, so 34 exercises precisely the same path.
+
+        Do not "correct" this to 35.
+        """
+        payload = {
+            "SourceMetadata": {
+                "Data": {"Filesystem": {"file": "src/app.py", "line": 3}}
+            },
+            "DetectorName": "Lob",
+            "Verified": True,
+            "Raw": "test_0dc8d51e0acffcb1880e0f19c79b2f5b0c",
+        }
+        path = write_tmp(tmp_path, "trufflehog.json", json.dumps(payload))
+        findings = TruffleHogAdapter().parse(path)
+        assert len(findings) == 1
+        assert findings[0].severity == "HIGH"
+
+    def test_other_detectors_are_never_filtered(self, tmp_path: Path):
+        """The collision is specific to Lob; nothing else may be suppressed."""
+        payload = {
+            "SourceMetadata": {
+                "Data": {"Filesystem": {"file": "src/app.py", "line": 3}}
+            },
+            "DetectorName": "AWS",
+            "Verified": True,
+            "Raw": "test_akto_adapter_non_vulnerable_skipped",
+        }
+        path = write_tmp(tmp_path, "trufflehog.json", json.dumps(payload))
+        assert len(TruffleHogAdapter().parse(path)) == 1
+
+    def test_a_lob_secret_without_the_test_prefix_is_never_filtered(
+        self, tmp_path: Path
+    ):
+        """The prefix is load-bearing, not decoration.
+
+        Lob issues live keys too. Without the `test_` check the predicate
+        would slice the first five characters off *any* Lob secret and filter
+        it whenever the remainder held an underscore - discarding a live key.
+        Mutation testing found this: removing the prefix check left every
+        other test in this class passing.
+        """
+        payload = {
+            "SourceMetadata": {
+                "Data": {"Filesystem": {"file": "src/app.py", "line": 3}}
+            },
+            "DetectorName": "Lob",
+            "Verified": True,
+            "Raw": "live_0dc8_d51e0acffcb1880e0f19c79b2f5b0cc",
+        }
+        path = write_tmp(tmp_path, "trufflehog.json", json.dumps(payload))
+        findings = TruffleHogAdapter().parse(path)
+        assert len(findings) == 1
+        assert findings[0].severity == "HIGH"

--- a/tests/security/test_secrets_management.py
+++ b/tests/security/test_secrets_management.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 import pytest
 
+from scripts.core.adapters.trufflehog_adapter import (
+    _is_pytest_name_matched_as_lob_key,
+)
+
 # Vendored trees are pruned during traversal, never filtered afterwards.
 # `rglob` descends into them regardless of any later check and stats every entry
 # it yields, which fails differently on each platform and so reads as a platform
@@ -188,7 +192,11 @@ class TestSecretsManagement:
                 ["trufflehog", "filesystem"] + scan_dirs + ["--json", "--no-update"],
                 capture_output=True,
                 text=True,
-                timeout=60,
+                # Measured at 3m46s on a Windows dev box. `Verified` means
+                # TruffleHog made a live API call per candidate, so the wall
+                # time is dominated by network round-trips, not scanning. The
+                # previous 60s budget was under a quarter of the real cost.
+                timeout=600,
             )
 
             # Parse findings
@@ -211,6 +219,14 @@ class TestSecretsManagement:
                         "node_modules" in file_path
                         or ".git/" in file_path
                         or not file_path.endswith(".py")
+                    ):
+                        continue
+
+                    # TruffleHog's Lob detector matches pytest function names
+                    # (#724). Reuse the adapter's predicate rather than a second
+                    # copy of the rule - it is the same collision.
+                    if _is_pytest_name_matched_as_lob_key(
+                        finding.get("DetectorName", ""), finding.get("Raw")
                     ):
                         continue
 


### PR DESCRIPTION
## What

TruffleHog's Lob detector matches `test_` followed by 35 characters, accepting
underscores. pytest names every test function `test_<words_with_underscores>`.
They collide **by construction** — any Python project whose test names happen to
be 35 characters long produces Lob "secrets", and they arrive
**`Verified: true`** because Lob's API accepts test-mode keys.

```json
{"DetectorName":"Lob", "Verified":true,
 "Raw":"test_akto_adapter_non_vulnerable_skipped",
 "ExtraData":{"environment":"test"}}
```

That is a pytest function name. TruffleHog even scrapes two characters off the
following token to reach 40: `test_trufflehog_handles_malformed_json` + `rG`.

## This is a product bug, not just a red build

`repository_scanner.py:257` runs the same detector for users, and
`trufflehog_adapter.py` grades `Verified` as **HIGH**. So
`policies/builtin/zero-secrets.rego` — *"blocks all verified secrets, zero
tolerance"* — failed `jmo ci` for **anyone scanning a Python repo with tests**.
`production-hardening.rego` blocks on HIGH trufflehog findings too.

Fixing only the test would have left that shipping.

## Measured

Over this repository's `tests/` tree:

| | |
|---|---|
| Lob findings | **2318**, all `Verified: true` |
| distinct | 412 |
| every one is | `test_` + exactly **35** chars |
| **contain an underscore** | **412 / 412** |
| **match `[0-9a-f]{35}`** (a real key) | **0 / 412** |
| Lob integration in this repo | none |

The underscore is the separator: a real Lob key is hex-ish and has none, a
Python identifier always does. Filtering on it costs no real detection, which
is why this is a filter and not `--exclude-detectors=Lob`.

The predicate is deliberately narrow — Lob only, `test_` prefix only, underscore
in the remainder only.

## Verification

Against the **captured live TruffleHog output**, not fixtures:

```
raw trufflehog findings : 2408
after the adapter filter:   90
by severity             : {'MEDIUM': 90}
HIGH (what zero-secrets.rego blocks on): 0
```

And end to end, the previously-failing test against real TruffleHog:

```
163 verified secrets  ->  1 passed in 241.33s (0:04:01)
```

## Mutation testing

Four mutations, each verified to turn the suite red:

| mutation | result |
|---|---|
| drop the underscore discriminator (filters *all* Lob) | 1 failed |
| drop the Lob-only restriction | 1 failed |
| disable the filter entirely | 1 failed |
| drop the `test_` prefix check | **37 passed — did not redden** |

That fourth one exposed a real gap: without the prefix check the predicate
would slice five characters off *any* Lob secret and discard it when the
remainder held an underscore — throwing away a `live_` key. The missing test
now exists, and the mutation reddens.

## Two things found while fixing it

**The test's `timeout=60` was under a quarter of the real cost.** `Verified`
means a live API call per candidate, so wall time is network-bound, not
scan-bound — measured **3m46s**. Raised to 600s. This also explains the drifting
failure count: CI reported 163 where a local run finds 2318, because the number
is however many verification calls happened to succeed. The test was
nondeterministic.

**My own fixture was detected.** The first draft's "a real Lob key is still
reported" case used a realistic 35-character key — which is a live finding in a
scanned file, and was the single survivor of the fix. It is now 34 characters,
exercising the same path (the predicate does not look at length) without being
detectable. Commented, because the obvious "correction" reintroduces it.

## Note

`tests/security/test_input_validation.py::test_integer_overflow_in_scan_parameters`
fails under full-directory load with `TimeoutExpired`. **Pre-existing and not
from this change** — verified passing in isolation on this branch (29s) and on
clean `dev` (22s). Same family as #742.

Fixes #724
