### PR TITLE
docs(skills): #718 chunk D - jmo-ci-debugger (13/13)

### DIFF
--- a/.claude/skills/jmo-ci-debugger/SKILL.md
+++ b/.claude/skills/jmo-ci-debugger/SKILL.md
@@ -82,7 +82,7 @@ jobs:
 | 10 | Lockfile Drift | `uv.lock needs to be updated` | Run `make deps-lock`, commit uv.lock | Easy |
 | 11 | YAML Syntax | `syntax error: expected <block` | Fix indentation, quote special chars, use 2-space indent | Easy-Med |
 | 12 | Branch Protection | `GH013: Repository rule violations` | Use feature branches + PRs (never push directly to main) | Easy |
-| 13 | Rulesets/Commit Status | `waiting for status to be reported` | Add `createCommitStatus` step with `actions/github-script` | Medium |
+| 13 | Ruleset check never reported | `waiting for status to be reported` | Match the ruleset context to a job name; only add `createCommitStatus` if the ruleset really wants a commit status | Medium |
 | 14 | Nightly Cascading | `lint-full: 4+ tool failures` | Fix in order: uv-lock, actionlint, mypy, markdownlint | Medium |
 | 15 | Ruff After Black | `F401`/`F541` after formatting | Run `ruff check --fix` after Black, review auto-fixes | Easy |
 | 16 | Platform Float Precision | `assert 0.X <= Y.YYY` across platforms | Find min/max across ALL platforms, add 5-20% buffer | Medium |
@@ -113,11 +113,12 @@ Use the [error pattern matching reference](references/error-pattern-matching.md)
 - `uv.lock needs to be updated` -> #10 Lockfile Drift
 - `syntax error: expected <block` -> #11 YAML Syntax
 - `GH013: Repository rule violations` -> #12 Branch Protection
-- `waiting for status to be reported` -> #13 Rulesets/Commit Status
+- `waiting for status to be reported` -> #13 Ruleset check never reported
 - `lint-full: 4+ tool failures` -> #14 Nightly Cascading
 - `F401 imported but unused` / `F541 f-string` -> #15 Ruff After Black
 - `assert 0.X <= Y.YYY` (cross-platform) -> #16 Platform Float Precision
 - `FileNotFoundError: React dashboard` -> #17 React Build Check
+- `collected 0 items / 1 skipped` then `make: *** Error 5` -> #18 Bare `pip install` outside the uv venv
 
 ### 3. Apply Proven Fix
 
@@ -189,7 +190,7 @@ gh run rerun <run-id> --failed             # Re-run failed jobs
 
 ## Additional References
 
-- [Complete failure catalog](references/ci-failure-catalog.md) - All 17 failures with full detail
+- [Complete failure catalog](references/ci-failure-catalog.md) - All 18 failures with full detail
 - [Error pattern matching](references/error-pattern-matching.md) - Regex patterns, diagnostic decision tree
 - [Installation and configuration](references/installation-config.md) - Version pinning, Dockerfile patterns
 - [Prevention strategies](references/prevention-strategies-full.md) - Pre-push hooks, local CI simulation

--- a/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
+++ b/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
@@ -1,6 +1,6 @@
 # CI Failure Catalog
 
-Complete reference of all 17 documented CI failure patterns with detailed symptoms, root causes, and proven fixes.
+Complete reference of all 18 documented CI failure patterns with detailed symptoms, root causes, and proven fixes.
 
 ---
 
@@ -148,15 +148,40 @@ Using deprecated or incorrect parameter names from outdated action documentation
 
 ### Alternative: Run actionlint directly
 
+Only when the reviewdog action cannot be used. **Do not pipe an unpinned remote
+script into a shell** — the upstream `scripts/download-actionlint.bash` lives on
+`main`, so `bash <(curl ...)` executes whatever that branch holds at the moment
+the job runs, with no integrity check. Pin a release and verify the checksum,
+the same convention the Dockerfiles use (`.claude/rules/docker.rules.md`,
+"Download Hardening Convention"):
+
 ```yaml
 - name: Run actionlint (Direct)
+  env:
+    ACTIONLINT_VERSION: 1.7.12  # release assets omit the leading 'v'
   run: |
-    # Install actionlint
-    bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+    set -euo pipefail
+    base="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+    archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
 
-    # Run with custom flags
+    # Keep the canonical asset name: sha256sum -c resolves the path written in
+    # the checksums line, so renaming the download makes verification impossible.
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+      --connect-timeout 30 --max-time 600 -o "$archive" "${base}/${archive}"
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+      --connect-timeout 30 --max-time 600 \
+      -o checksums.txt "${base}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+
+    # Verify before extracting -- curl without -f exits 0 on an HTML error page.
+    grep " ${archive}\$" checksums.txt | sha256sum -c -
+    gzip -t "$archive"
+    tar -xzf "$archive" actionlint
+
     ./actionlint -color -verbose
 ```
+
+Bump `ACTIONLINT_VERSION` deliberately; `ci.yml` pins the action side the same
+way (`reviewdog/action-actionlint@v1.73.0`).
 
 **Testing Locally:**
 
@@ -456,10 +481,12 @@ jobs:
 
 ```bash
 # Go to Docker Hub -> Account Settings -> Security -> Access Tokens
-# Create new token with scopes:
-- Read
-- Write
-- Delete (required for README updates)
+# Create new token with the LEAST privilege that works:
+- Read & Write   # sufficient: the sync PATCHes the repository description
+
+# Do NOT grant Delete. Read/Write/Delete are distinct Docker Hub permissions;
+# README sync never removes a repository or an image, so Delete only widens the
+# blast radius of a leaked token.
 
 # Name: github-actions-readme-sync
 # Copy token (shown once)
@@ -482,13 +509,23 @@ DOCKERHUB_ENABLED=true  # Repository variable
 **3. Verify Token Permissions:**
 
 ```bash
-# Test token locally
+# Test token locally. Docker Hub's token endpoint is a POST with a JSON body --
+# it does not accept Basic auth, and it is not the legacy /v2/users/login/ path.
 TOKEN="dckr_pat_xxxxxxxxxxxxxxxxxxxxx"
-curl -u "username:$TOKEN" https://hub.docker.com/v2/users/login/
+curl -sS -X POST https://hub.docker.com/v2/auth/token \
+  -H "Content-Type: application/json" \
+  -d "{\"identifier\": \"username\", \"secret\": \"$TOKEN\"}"
 
-# Should return: {"token": "..."}
-# If error 401: Token expired or wrong permissions
+# Should return: {"access_token": "...", ...}
+# 401 -> token revoked, expired, or the identifier is wrong
+# 400 -> malformed body (the response names the offending field)
+# 415 -> you sent a GET, or omitted the JSON Content-Type
 ```
+
+> `curl -u "username:$TOKEN" https://hub.docker.com/v2/users/login/` cannot work:
+> measured, it returns **415 Unsupported Media Type**, so it fails on the method
+> before the token is ever evaluated. A 401 from it would not mean what the
+> old text claimed.
 
 **Why Use Variable Gate?**
 
@@ -1377,7 +1414,7 @@ actionlint .github/workflows/*.yml
 
 ---
 
-## 13. GitHub Rulesets Requiring Commit Statuses (Not Check Runs)
+## 13. Ruleset Check Never Reported (Required Context Matches No Job)
 
 **Symptoms:**
 
@@ -1390,18 +1427,39 @@ Manual merge attempt: "Required status check was not set by the expected GitHub 
 
 **Root Cause:**
 
-GitHub has **two separate status systems**:
+GitHub has two status systems, and a ruleset's `required_status_checks`
+accepts **either**:
 
-1. **Check Runs API** (modern) - Used by GitHub Actions workflows
-2. **Commit Status API** (legacy) - Required by some GitHub Rulesets
+1. **Check Runs API** (modern) - what GitHub Actions creates automatically
+2. **Commit Status API** (legacy) - what external CI systems typically post
 
-When a **GitHub Ruleset** is configured to require a specific status check by context name, it expects a **commit status** (legacy API), not a **check run**. GitHub Actions creates check runs by default, not commit statuses.
+A required check is satisfied when *either* a check run **or** a commit status
+reports success under the required context name. So the usual cause of this
+symptom is not the API family — it is that **the required context matches
+nothing that ran**:
+
+- The context is spelled differently from the job (`Quick checks` vs `quick-checks`).
+  Rulesets match a check run by its **name**, which is `jobs.<id>.name` when set
+  and the job id otherwise.
+- The job was filtered out by `paths:`/`branches:` and never ran at all. A
+  required check that never starts leaves the PR pending forever.
+- The context is genuinely a commit status posted by an external service that
+  is no longer running.
+
+> **Measured in this repository.** Ruleset `9147592` requires
+> `{"context": "quick-checks", "integration_id": 15368}` (15368 is the GitHub
+> Actions app). `gh api .../commits/<sha>/status` returns
+> `{"state": "pending", "statuses": []}` — **zero commit statuses ever** — while
+> `check-runs` shows `quick-checks` succeeding from app 15368, and PRs merge
+> normally. `createCommitStatus` appears nowhere in `.github/workflows/`. A
+> check run alone satisfies the rule; the older claim that rulesets demand a
+> commit status is false here.
 
 **Where This Occurs:**
 
-- Repositories using GitHub Rulesets instead of branch protection rules
 - Rulesets configured with `required_status_checks` by context name
-- Any workflow where ruleset expects commit status but CI creates check run
+- A required context that no job name produces (renamed job, typo, case drift)
+- A required job gated behind `paths:` or `if:` so it never reports on some PRs
 
 **Diagnosis Commands:**
 
@@ -1412,66 +1470,83 @@ gh api repos/OWNER/REPO/rulesets --jq '.[] | {id, name, enforcement}'
 # 2. Get required status checks from ruleset
 gh api repos/OWNER/REPO/rulesets/RULESET_ID --jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]'
 
-# 3. Check commit status API (different from check runs)
+# 3. Check the commit status API
 gh api repos/OWNER/REPO/commits/COMMIT_SHA/status --jq '{state, statuses: [.statuses[] | {context, state}]}'
-# Returns: {"state":"pending","statuses":[]}  <- No commit statuses!
+# {"state":"pending","statuses":[]} is NORMAL for an Actions-only repo -- it
+# means no commit statuses exist, not that anything is broken.
 
-# 4. Check check runs API (GitHub Actions)
+# 4. Check the check runs API (GitHub Actions)
 gh api repos/OWNER/REPO/commits/COMMIT_SHA/check-runs --jq '.check_runs[] | {name, status, conclusion}'
-# Returns: All checks show "completed" and "success"
 
-# 5. Compare: Ruleset expects commit status, but only check runs exist
+# 5. The real comparison: does the required context from step 2 appear as a
+#    check-run NAME in step 4, or as a status CONTEXT in step 3? If it appears
+#    in neither, nothing is producing it -- that is the bug.
+gh api repos/OWNER/REPO/commits/COMMIT_SHA/check-runs --jq '[.check_runs[].name]'
 ```
 
-**Wrong Approach (Manual Fix):**
+**Fix 1 (usual case): make a job actually produce the required context.**
 
-```bash
-# Manually creating commit status works but isn't sustainable
-gh api repos/OWNER/REPO/statuses/COMMIT_SHA \
-  -X POST \
-  -f state=success \
-  -f context="quick-checks" \
-  -f description="All CI checks passed"
+Rename the job -- or the ruleset entry -- so they agree exactly. Rulesets match a
+check run by `jobs.<id>.name`, falling back to the job id when `name:` is absent:
 
-# This works ONCE but doesn't fix future PRs
+```yaml
+jobs:
+  quick-checks:
+    name: quick-checks   # must equal the ruleset's required context, character for character
 ```
 
-**Correct Approach (Permanent Fix):**
+If instead the job is skipped by `paths:`/`if:` on some PRs, either drop it from
+the required list or give it a always-reporting companion job, because a
+required check that never starts blocks the PR indefinitely.
 
-Add commit status creation to your workflow:
+**Fix 2 (only when a commit status is genuinely required):**
+
+Reach for this **only** when step 5 shows the required context is a commit
+status posted by something outside Actions and you must emulate it. Adding it
+"just in case" creates a second status surface to keep green for no benefit.
 
 ```yaml
 # .github/workflows/ci.yml
 jobs:
   quick-checks:
-    name: Quick checks
+    name: quick-checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write        # REQUIRED: createCommitStatus 403s without it
     steps:
       # ... existing validation steps ...
 
-      # Create commit status for ruleset compatibility
-      # GitHub Rulesets may require commit statuses (legacy API) instead of check runs
       - name: Create commit status
         if: always()
         uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            github.rest.repos.createCommitStatus({
+            const ok = process.env.JOB_STATUS === 'success';
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.sha,
-              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
+              sha: context.payload.pull_request?.head.sha ?? context.sha,
+              state: ok ? 'success' : 'failure',
               context: 'quick-checks',
-              description: 'CI checks ' + ('${{ job.status }}' === 'success' ? 'passed' : 'failed')
+              description: 'CI checks ' + (ok ? 'passed' : 'failed')
             });
 ```
 
 **Why This Works:**
 
-- `if: always()` ensures status is created even if job fails
-- `${{ job.status }}` evaluates to 'success', 'failure', 'cancelled', or 'skipped'
-- `context: 'quick-checks'` matches the ruleset requirement exactly
-- Creates **both** check run (automatic) and commit status (explicit)
+- `statuses: write` is mandatory. Declaring **any** `permissions` block sets
+  every unlisted scope to `none`, so a block without it makes the call 403 —
+  and on repos whose default token is read-only it 403s even with no block.
+- `await` matters: without it the step can finish before the request settles,
+  which reports green while posting nothing.
+- `job.status` is read via `env:` rather than interpolated into the script body,
+  so the value is never spliced into JavaScript source.
+- On `pull_request`, `context.sha` is the **merge** commit; the ruleset checks
+  the PR head, so prefer `pull_request.head.sha` when present.
+- `if: always()` still reports when the job fails.
 
 **Key Differences: Check Runs vs. Commit Statuses:**
 
@@ -1479,62 +1554,56 @@ jobs:
 |--------|-------------------|------------------------|
 | **API Endpoint** | `/repos/{owner}/{repo}/check-runs` | `/repos/{owner}/{repo}/statuses/{sha}` |
 | **Created By** | GitHub Actions (automatic) | Manual API call or external CI |
-| **Identifier** | Name (e.g., "Quick checks") | Context (e.g., "quick-checks") |
-| **Ruleset Support** | Not directly supported | Required by rulesets |
+| **Identifier** | Name (e.g., "quick-checks") | Context (e.g., "quick-checks") |
+| **Ruleset Support** | Supported — matched by check-run name | Supported — matched by context |
 | **UI Display** | Shows in "Checks" tab | Shows as status badge |
 | **Conclusion** | SUCCESS, FAILURE, SKIPPED, etc. | success, failure, error, pending |
 
-**Alternative Solution: Update Ruleset to Use Check Runs:**
+**Alternative: point the ruleset at the context that already reports.**
 
-If you have repository admin access, update the ruleset:
+With repository admin access, edit the required context instead of adding a
+producer for it. `integration_id` pins which app may satisfy the rule — 15368 is
+GitHub Actions; `null` accepts any source:
 
 ```bash
 # Get current ruleset configuration
 gh api repos/OWNER/REPO/rulesets/RULESET_ID > ruleset.json
 
-# Edit ruleset.json to change from commit status to check run
-# Change:
-#   "required_status_checks": [{"context": "quick-checks", "integration_id": 15368}]
-# To:
-#   "required_status_checks": [{"context": "Quick checks", "integration_id": null}]
-# Note: Check runs use the job NAME, not context
+# Edit required_status_checks[].context to match a real check-run name,
+# e.g. "Quick checks" -> "quick-checks" if that is what the job is called.
+# Keep integration_id: 15368 to require that GitHub Actions be the reporter.
 
 # Update ruleset
 gh api repos/OWNER/REPO/rulesets/RULESET_ID -X PUT --input ruleset.json
 ```
 
-**However, updating workflows is preferred** because:
-
-- Works with any ruleset configuration
-- Backwards compatible with branch protection rules
-- Doesn't require admin access
-- Creates both check runs and commit statuses (best of both worlds)
+Prefer whichever side is wrong. If the job name drifted, rename the job; if the
+ruleset was written against a name that never existed, fix the ruleset.
 
 **Verification:**
 
 ```bash
-# After adding commit status step to workflow:
-# 1. Push commit
-git commit -m "test"
-git push
+# 1. Push to a branch and open/refresh a PR, then wait for CI (2-3 min)
 
-# 2. Wait for CI to complete (2-3 min)
+# 2. The required context must appear in ONE of these two lists
+gh api repos/OWNER/REPO/commits/$(git rev-parse HEAD)/check-runs --jq '[.check_runs[].name]'
+gh api repos/OWNER/REPO/commits/$(git rev-parse HEAD)/status --jq '[.statuses[].context]'
 
-# 3. Verify commit status was created
-gh api repos/OWNER/REPO/commits/$(git rev-parse HEAD)/status --jq '.statuses[] | {context, state}'
-# Should show: {"context":"quick-checks","state":"success"}
-
-# 4. Verify PR is mergeable
+# 3. Verify PR is mergeable
 gh pr view PR_NUMBER --json mergeable,mergeStateStatus
 # Should show: {"mergeable":true,"mergeStateStatus":"CLEAN"}
+# UNSTABLE means a non-required check is failing -- that is a different problem.
 ```
 
 **Prevention:**
 
-1. **Always create commit statuses** in GitHub Actions workflows for critical jobs
-2. **Test merge button** in PRs during workflow development
-3. **Document ruleset requirements** in repository documentation
-4. **Use consistent context names** between workflow job names and status contexts
+1. **Keep job names and required contexts identical** — this is the whole failure
+   mode. Renaming a job silently un-satisfies every ruleset naming the old name.
+2. **Do not add commit statuses "just in case."** A check run already satisfies a
+   ruleset; a second surface is one more thing that can go stale or 403.
+3. **Test the merge button** in a real PR when changing job names or rulesets.
+4. **Re-check after adding `paths:`/`if:` filters** — a required job that stops
+   running blocks merges rather than passing them.
 
 ---
 

--- a/.claude/skills/jmo-ci-debugger/references/error-pattern-matching.md
+++ b/.claude/skills/jmo-ci-debugger/references/error-pattern-matching.md
@@ -6,7 +6,17 @@ Error pattern matching regex and log analysis patterns for diagnosing CI failure
 
 ## Quick Pattern Matching Table
 
-When diagnosing CI failures, match error messages to these patterns:
+When diagnosing CI failures, match error messages to these patterns.
+
+**Dialect: POSIX ERE**, as used by the `grep -E` commands below. Write digits as
+`[0-9]`: `\d` is a PCRE construct GNU grep does not implement, so `\d` matches a
+literal `d` and the pattern silently matches nothing.
+
+**The `\|` in this table is Markdown, not regex.** A bare `|` inside a table cell
+is a column separator, so GFM requires it escaped even inside a code span. It
+renders as a plain `|`, which is the ERE alternation you want — copy the
+*rendered* cell, not the raw source. Removing the backslash does not fix a regex;
+it splits the cell in half and drops the last column off the row.
 
 | Error Pattern (regex) | Failure | Section |
 |----------------------|---------|---------|
@@ -18,15 +28,16 @@ When diagnosing CI failures, match error messages to these patterns:
 | `ModuleNotFoundError` (multiple PRs) | Dependabot Cascading Failures | #6 |
 | `MD036/no-emphasis-as-heading` | Markdownlint | #7 |
 | `ruff\.+Failed` | Pre-commit Hooks | #8 |
-| `Coverage of \d+% is below` | Test Coverage | #9 |
+| `Coverage of [0-9]+% is below` | Test Coverage | #9 |
 | `uv\.lock needs to be updated` | Lockfile Drift | #10 |
 | `syntax error: expected <block` | YAML Syntax | #11 |
 | `GH013: Repository rule violations` | Branch Protection | #12 |
-| `waiting for status to be reported` | Rulesets/Commit Status | #13 |
+| `waiting for status to be reported` | Ruleset check never reported | #13 |
 | `lint-full.*Failed` (4+ tools) | Nightly Cascading Failures | #14 |
 | `F401 imported but unused\|F541 f-string` | Ruff After Black | #15 |
-| `assert 0\.\d+ [<>=]+ 0\.\d+` (across platforms) | Platform Float Precision | #16 |
+| `assert 0\.[0-9]+ [<>=]+ 0\.[0-9]+` (across platforms) | Platform Float Precision | #16 |
 | `FileNotFoundError.*React dashboard` | React Build Check | #17 |
+| `collected 0 items` (then `Error 5`) | Bare `pip install` outside the uv venv | #18 |
 
 ---
 
@@ -92,17 +103,22 @@ gh run view <run-id> --log-failed | grep -E "assert|FAILED" | grep -E "test_name
 
 ## Regex Patterns for Common Errors
 
+Same ERE dialect as the table above, so these paste straight into `grep -E`.
+`\s`, `\w` and `\S` are GNU extensions and do work bare, but **not inside a
+bracket expression** — GNU grep reads `[\w.]` as "backslash, w, or dot", so
+write the class out.
+
 ### Python Test Failures
 
 ```regex
 # Float comparison failures
-assert\s+\d+\.\d+\s*[<>=!]+\s*\d+\.\d+
+assert\s+[0-9]+\.[0-9]+\s*[<>=!]+\s*[0-9]+\.[0-9]+
 
 # Module import errors
-ModuleNotFoundError:\s+No module named\s+'[\w.]+'
+ModuleNotFoundError:\s+No module named\s+'[A-Za-z0-9_.]+'
 
 # Coverage threshold
-Coverage of \d+% is below threshold of \d+%
+Coverage of [0-9]+% is below threshold of [0-9]+%
 
 # Test collection errors
 ImportError while importing test module
@@ -115,7 +131,7 @@ ImportError while importing test module
 syntax error: expected <block\s+\w+>.*found.*<block\s+\w+>
 
 # Actionlint
-Unexpected input\(s\) '[\w_]+',\s*valid inputs are
+Unexpected input\(s\) '[A-Za-z0-9_]+',\s*valid inputs are
 
 # Workflow permissions
 Resource not accessible by integration
@@ -126,10 +142,10 @@ refusing to allow.*without.*write permission
 
 ```regex
 # Tag format
-invalid reference format:?\s*v?\d+
+invalid reference format:?\s*v?[0-9]+
 
 # Manifest not found
-manifest.*not found.*for\s+v?\d+
+manifest.*not found.*for\s+v?[0-9]+
 
 # Build failures
 Error:.*docker\s+(build|push|pull)\s+failed
@@ -142,7 +158,7 @@ Error:.*docker\s+(build|push|pull)\s+failed
 \w+\.+Failed
 
 # Ruff violations
-F\d{3}\s+\[\*\]\s+.+
+F[0-9]{3}\s+\[\*\]\s+.+
 
 # Black formatting
 would reformat\s+\S+\.py
@@ -165,6 +181,8 @@ CI Failure
     |
     +-- test-matrix (10-15 min)
     |   |-- ModuleNotFoundError (multiple PRs) -> #6 Dependabot
+    |   |-- ModuleNotFoundError (one job, after a pip install) -> #18 Bare pip install
+    |   |-- collected 0 items, then Error 5 -> #18 Bare pip install
     |   |-- Coverage below 85% -> #9 Test Coverage
     |   |-- Float assertion failures -> #16 Platform Precision
     |   |-- FileNotFoundError: React -> #17 React Build Check
@@ -191,7 +209,7 @@ CI Failure
     |
     +-- Push rejected
         |-- GH013 rule violations -> #12 Branch Protection
-        +-- Waiting for status -> #13 Rulesets/Commit Status
+        +-- Waiting for status -> #13 Ruleset check never reported
 ```
 
 ---

--- a/.claude/skills/jmo-ci-debugger/references/installation-config.md
+++ b/.claude/skills/jmo-ci-debugger/references/installation-config.md
@@ -84,17 +84,44 @@ RUN userdel -r ubuntu && useradd -u 1000 jmo
 
 ### Tool Installation in Docker
 
-```dockerfile
-# Shellcheck: Use GitHub releases binary (not apt)
-RUN set -eux && \
-    SHELLCHECK_VERSION="v0.10.0" && \
-    curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-    | tar -xJf - --strip-components=1 -C /usr/local/bin shellcheck-${SHELLCHECK_VERSION}/shellcheck
+Two rules, both learned the hard way (see `.claude/rules/docker.rules.md`,
+"Download Hardening Convention"):
 
-# Note: fast/slim/balanced Dockerfiles need xz-utils for .tar.xz extraction
-# deep variant has it via build-essential transitive dependency
-RUN apt-get install -y --no-install-recommends xz-utils
+1. **Install the extractor before the extraction.** `tar -xJf` shells out to
+   `xz`; on a slim base that package is absent, so an extraction step placed
+   above the `apt-get install` fails every build.
+2. **Never pipe a download straight into `tar`.** `curl` without `-f` exits 0 on
+   an HTTP error page, and the pipe hands that HTML to `tar` — the
+   "not in gzip format" cycle that broke v1.0.3 nightly smoke tests repeatedly.
+   Download to a file, verify, then extract.
+
+```dockerfile
+# xz-utils goes in the base package layer, well before any .tar.xz download.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Shellcheck: GitHub releases binary (not apt).
+# The version literal is owned by versions.yaml -- never hand-edit it here or in
+# a Dockerfile; run `python scripts/dev/update_versions.py --sync`.
+RUN SHELLCHECK_VERSION="<from versions.yaml>" && \
+    SHELLCHECK_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") && \
+    curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \
+      --connect-timeout 30 --max-time 600 \
+      "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${SHELLCHECK_ARCH}.tar.xz" \
+      -o /tmp/shellcheck.tar.xz && \
+    xz -t /tmp/shellcheck.tar.xz && \
+    tar -xJf /tmp/shellcheck.tar.xz -C /tmp && \
+    mv /tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck && \
+    chmod +x /usr/local/bin/shellcheck
 ```
+
+**All four** `Dockerfile.*` variants install `xz-utils` explicitly in that base
+layer (`Dockerfile.fast:18`, `.slim:18`, `.balanced:18`, `.deep:19`) — including
+`deep`, which does **not** get it transitively from `build-essential`. Read the
+real files rather than copying this snippet; they are the source of truth for
+the pinned versions and the arch handling.
 
 ---
 
@@ -136,6 +163,12 @@ jobs:
 
 ### Permissions Block
 
+**Declaring any `permissions` block sets every scope you do not list to `none`.**
+It is not additive on top of the defaults, so an omission silently removes access
+rather than inheriting it — the usual symptom is a 403 from one API call in an
+otherwise green job. Grant per job, not workflow-wide, and list only what that
+job calls:
+
 ```yaml
 permissions:
   contents: read          # Checkout code
@@ -143,6 +176,7 @@ permissions:
   security-events: write  # Upload SARIF to Security tab
   id-token: write         # OIDC token for Trusted Publishers
   pull-requests: write    # Comment on PRs with results
+  statuses: write         # ONLY if the job calls createCommitStatus (see catalog #13)
 ```
 
 ---

--- a/.claude/skills/jmo-ci-debugger/references/prevention-strategies-full.md
+++ b/.claude/skills/jmo-ci-debugger/references/prevention-strategies-full.md
@@ -136,26 +136,35 @@ if [ -n "$untracked" ]; then
   exit 1
 fi
 
-# Validate critical module imports
-for module in compliance_frameworks exceptions tool_runner constants; do
-  if ! python3 -c "import scripts.core.$module" 2>/dev/null; then
+# Validate critical module imports.
+# Name only modules that exist -- one bad entry makes the hook exit 1 forever,
+# and a hook that always fails gets bypassed with --no-verify, which is worse
+# than no hook. Check with: ls scripts/core/<name>.py
+for module in compliance_frameworks exceptions tool_runner; do
+  if ! python -c "import scripts.core.$module" 2>/dev/null; then
     echo "ERROR: Cannot import scripts.core.$module"
     exit 1
   fi
 done
 
-# Run mypy on staged Python files
+# Run mypy on staged Python files.
+# -z gives NUL-delimited names, so paths containing spaces or glob characters
+# survive; xargs -0 passes them as discrete arguments and -- stops a leading
+# dash being read as an option. An unquoted $STAGED_PY would split on whitespace,
+# glob-expand, and hand "-foo.py" to the tool as a flag.
+# --diff-filter=ACMR drops deletions: linting a removed file always errors.
+# The guard is required -- with empty input, GNU xargs still runs the command once.
 echo "Running mypy on staged Python files..."
-STAGED_PY=$(git diff --cached --name-only | grep '\.py$' || true)
-if [ -n "$STAGED_PY" ]; then
-  mypy $STAGED_PY || exit 1
+if [ -n "$(git diff --cached --name-only --diff-filter=ACMR -- '*.py')" ]; then
+  git diff --cached --name-only -z --diff-filter=ACMR -- '*.py' \
+    | xargs -0 mypy -- || exit 1
 fi
 
 # Run markdownlint on staged Markdown files
 echo "Running markdownlint on staged Markdown files..."
-STAGED_MD=$(git diff --cached --name-only | grep '\.md$' || true)
-if [ -n "$STAGED_MD" ]; then
-  npx markdownlint $STAGED_MD || exit 1
+if [ -n "$(git diff --cached --name-only --diff-filter=ACMR -- '*.md')" ]; then
+  git diff --cached --name-only -z --diff-filter=ACMR -- '*.md' \
+    | xargs -0 npx markdownlint -- || exit 1
 fi
 
 echo "Pre-push checks passed!"

--- a/.claude/skills/jmo-compliance-mapper/references/memory-integration.md
+++ b/.claude/skills/jmo-compliance-mapper/references/memory-integration.md
@@ -6,8 +6,28 @@ Detailed memory query/store patterns and bulk enrichment workflows for complianc
 
 **Purpose:** Check if CWE mapping already stored before performing full research.
 
+> There is no `scripts.core.memory` module. `.jmo/memory/` is a **file
+> convention**, not a Python API — see
+> [memory-integration-pattern.md](../../references/memory-integration-pattern.md).
+> Each skill reads and writes the JSON itself, so these examples use the stdlib.
+
 ```python
-from scripts.core.memory import query_memory
+import json
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+
+MEMORY_ROOT = Path(".jmo/memory/compliance")
+MAX_AGE = timedelta(days=180)  # 6 months
+CWE_RE = re.compile(r"^CWE-[0-9]{1,6}$")
+
+
+def memory_path(cwe_id: str) -> Path:
+    """Resolve a CWE id to its memory file, rejecting traversal (CWE-22)."""
+    if not CWE_RE.match(cwe_id):
+        raise ValueError(f"not a CWE identifier: {cwe_id!r}")
+    return MEMORY_ROOT / f"{cwe_id}.json"
+
 
 def check_compliance_memory(cwe_id: str) -> dict | None:
     """
@@ -17,25 +37,41 @@ def check_compliance_memory(cwe_id: str) -> dict | None:
         cwe_id: CWE identifier (e.g., "CWE-79")
 
     Returns:
-        Compliance mapping dict if found, None otherwise
+        The mapping if a usable, current record exists; None otherwise.
+        None always means "do the full research" -- a caller never has to
+        distinguish absent from unusable.
     """
-    memory_data = query_memory("compliance", cwe_id)
+    path = memory_path(cwe_id)
+    try:
+        memory_data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"[memory] No mapping for {cwe_id}, running full research")
+        return None
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"[memory] Unreadable record for {cwe_id} ({exc}); treating as miss")
+        return None
 
-    if memory_data:
-        print(f"[memory] Found mappings for {cwe_id}")
-        print(f"[memory] Last updated: {memory_data.get('last_updated')}")
+    # A missing key yields None and a hand-edited value can be anything, so
+    # both TypeError and ValueError are expected here -- neither is fatal.
+    try:
+        last_updated = datetime.fromisoformat(memory_data["last_updated"])
+    except (KeyError, TypeError, ValueError):
+        print(f"[memory] {cwe_id} has no usable timestamp; treating as miss")
+        return None
 
-        # Check if mapping is stale (>6 months old)
-        from datetime import datetime, timedelta
-        last_updated = datetime.fromisoformat(memory_data.get("last_updated"))
-        if datetime.now() - last_updated > timedelta(days=180):
-            print(f"[memory] Mapping is stale (>6 months), recommend refresh")
+    age = datetime.now() - last_updated
+    if age > MAX_AGE:
+        print(f"[memory] {cwe_id} is stale ({age.days}d > {MAX_AGE.days}d); re-researching")
+        return None
 
-        return memory_data
-
-    print(f"[memory] No mapping for {cwe_id}, running full research")
-    return None
+    print(f"[memory] Hit: {cwe_id} (updated {memory_data['last_updated']})")
+    return memory_data
 ```
+
+**Stale records are a miss, not a hit.** Returning the record alongside a
+"recommend refresh" message leaves the decision to a caller that has no reason
+to re-check it, so a mapping researched against OWASP 2021 keeps being served
+after the framework moves. Returning `None` makes the refresh happen.
 
 ## Example Memory Hit
 
@@ -73,35 +109,82 @@ def check_compliance_memory(cwe_id: str) -> dict | None:
 **Purpose:** Persist compliance mappings for future reuse.
 
 ```python
-from scripts.core.memory import store_memory
+import json
 from datetime import datetime
 
-def store_compliance_mapping(cwe_id: str, mappings: dict):
-    """Store CWE compliance mappings in memory."""
+# Every framework the mapper is expected to resolve. Anything missing or empty
+# means the record is partial, which is what decides confidence below.
+REQUIRED_FRAMEWORKS = (
+    "owasp_top_10_2021",
+    "cwe_top_25_2024",
+    "cis_controls_v8_1",
+    "nist_csf_2_0",
+    "pci_dss_4_0",
+    "mitre_attack",
+)
+
+
+def store_compliance_mapping(
+    cwe_id: str,
+    mappings: dict,
+    confidence: str | None = None,
+    evidence: list[str] | None = None,
+) -> None:
+    """Store CWE compliance mappings in memory.
+
+    Args:
+        cwe_id: CWE identifier, e.g. "CWE-79".
+        mappings: Per-framework results from the mapping workflow.
+        confidence: "high" only when the workflow verified every framework
+            against its published source. Left unset, it is derived below --
+            never assumed.
+        evidence: Citations backing the mapping; an empty list caps confidence.
+    """
+    frameworks = {
+        "owasp_top_10_2021": mappings.get("owasp", []),
+        "cwe_top_25_2024": mappings.get("cwe_top_25", {}),
+        "cis_controls_v8_1": mappings.get("cis", []),
+        "nist_csf_2_0": mappings.get("nist", []),
+        "pci_dss_4_0": mappings.get("pci", []),
+        "mitre_attack": mappings.get("attack", []),
+    }
+
+    if confidence is None:
+        resolved = sum(1 for key in REQUIRED_FRAMEWORKS if frameworks.get(key))
+        if resolved == len(REQUIRED_FRAMEWORKS) and evidence:
+            confidence = "high"
+        elif resolved:
+            confidence = "partial"
+        else:
+            confidence = "unverified"
+
     memory_data = {
         "cwe": cwe_id,
         "name": mappings.get("name"),
-        "frameworks": {
-            "owasp_top_10_2021": mappings.get("owasp", []),
-            "cwe_top_25_2024": mappings.get("cwe_top_25", {}),
-            "cis_controls_v8_1": mappings.get("cis", []),
-            "nist_csf_2_0": mappings.get("nist", []),
-            "pci_dss_4_0": mappings.get("pci", []),
-            "mitre_attack": mappings.get("attack", [])
-        },
-        "confidence": "high",
+        "frameworks": frameworks,
+        "confidence": confidence,
+        "evidence": evidence or [],
+        "unresolved": [k for k in REQUIRED_FRAMEWORKS if not frameworks.get(k)],
         "last_updated": datetime.now().isoformat(),
         "framework_versions": {
             "owasp": "2021", "cwe_top_25": "2024", "cis": "8.1",
             "nist_csf": "2.0", "pci_dss": "4.0", "mitre_attack": "15.1"
         },
-        "created_by": "jmo-compliance-mapper v2.1.0"
+        "created_by": "jmo-compliance-mapper",
     }
 
-    store_memory("compliance", cwe_id, memory_data)
-    print(f"[memory] Stored mappings for {cwe_id}")
-    print(f"[memory] Location: .jmo/memory/compliance/{cwe_id}.json")
+    path = memory_path(cwe_id)  # validates the id; see Phase 0
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(memory_data, indent=2), encoding="utf-8")
+    print(f"[memory] Stored {cwe_id} (confidence={confidence})")
+    print(f"[memory] Location: {path}")
 ```
+
+**Confidence is derived, never assumed.** Writing `"high"` unconditionally made
+the field meaningless: a record with five empty frameworks and no citation was
+indistinguishable from a fully-researched one, so nothing downstream could
+choose to re-research. `unresolved` records *which* frameworks are missing, so
+a later pass can fill only the gaps.
 
 **Memory File Location:** `.jmo/memory/compliance/{cwe_id}.json`
 
@@ -113,11 +196,20 @@ def store_compliance_mapping(cwe_id: str, mappings: dict):
 
 **Memory-Integrated Approach:**
 
-```python
-from scripts.core.memory import query_memory, store_memory
+> **Do not name this `enrich_findings_with_compliance`.** That name is taken by
+> real production code — `scripts/core/compliance_mapper.py:1278`, called from
+> `normalize_and_report.py:234` during the report phase. It maps from the
+> built-in tables, not from `.jmo/memory/`. This helper is a *research* aid for
+> the skill; giving it the production name invites someone to wire the wrong one
+> into the pipeline.
 
-def enrich_findings_with_compliance(findings: list) -> list:
-    """Enrich findings with compliance mappings from memory."""
+```python
+def preview_memory_coverage(findings: list) -> dict:
+    """Report which findings' CWEs already have researched mappings.
+
+    Read-only: it tells the mapper what is left to research. Report-phase
+    enrichment stays in compliance_mapper.enrich_findings_with_compliance().
+    """
     # Extract unique CWEs
     unique_cwes = set()
     for finding in findings:
@@ -129,7 +221,7 @@ def enrich_findings_with_compliance(findings: list) -> list:
     # Query memory for each CWE
     compliance_cache = {}
     for cwe in unique_cwes:
-        memory_data = query_memory("compliance", cwe)
+        memory_data = check_compliance_memory(cwe)
         if memory_data:
             print(f"[memory] Hit: {cwe}")
             compliance_cache[cwe] = memory_data.get("frameworks")
@@ -137,30 +229,27 @@ def enrich_findings_with_compliance(findings: list) -> list:
             print(f"[memory] Miss: {cwe} - needs mapping")
             compliance_cache[cwe] = None
 
-    # Enrich findings
-    for finding in findings:
-        cwes = finding.get("raw", {}).get("cwe", [])
-        compliance = {}
-        for cwe in cwes:
-            if compliance_cache.get(cwe):
-                compliance[cwe] = compliance_cache[cwe]
-        finding["compliance"] = compliance
-
-    # Report statistics
+    # Report statistics. Plenty of scans produce no CWE-bearing findings at all
+    # (a clean run, or tools that emit only rule ids), so the empty set is a
+    # normal input -- not a reason to raise ZeroDivisionError on the last line.
     hits = sum(1 for v in compliance_cache.values() if v is not None)
-    misses = len(compliance_cache) - hits
-    print(f"[memory] Hits: {hits}/{len(unique_cwes)} ({hits/len(unique_cwes)*100:.0f}%)")
+    total = len(unique_cwes)
+    misses = total - hits
+    pct = (hits / total * 100) if total else 0.0
+    print(f"[memory] Hits: {hits}/{total} ({pct:.0f}%)")
     print(f"[memory] Misses: {misses} (need manual mapping)")
 
-    return findings
-
-# Time: 2-5 min (all memory hits) vs. 300 min (sequential research)
-# Savings: 295 min (98%)
+    return {
+        "unique_cwes": total,
+        "hits": hits,
+        "misses": misses,
+        "needs_research": sorted(c for c, v in compliance_cache.items() if v is None),
+    }
 ```
 
 **Benefits:**
 
 1. **Speed:** Instant retrieval for known CWEs
 2. **Consistency:** Same CWE always mapped identically
-3. **Partial Results:** Use known mappings, defer unknown CWEs
+3. **Partial Results:** Research only what `needs_research` lists
 4. **Incremental Improvement:** Each manual mapping benefits future scans

--- a/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
+++ b/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
@@ -6,19 +6,19 @@
 
 ## Progress
 
-**44 / 103 resolved.**
+**57 / 103 resolved.**
 
 | Chunk | Scope | Findings | Done | Status |
 |---|---|---:|---:|---|
 | **A** | jmo-profile-optimizer | 13 | 13 | **complete** |
 | **B** | dashboard-builder + documentation-updater | 13 | 13 | **complete** |
 | **C** | adapter-generator + test-fabricator | 15 | 15 | **complete** |
-| **D** | jmo-ci-debugger | 13 | 0 | not started |
+| **D** | jmo-ci-debugger | 13 | 13 | **complete** |
 | **E** | target-type-expander + security-hardening | 19 | 0 | not started |
 | **F** | the 7 agents | 13 | 0 | not started |
 | **G** | tail: refactoring, compliance, systematic-debugging, references | 11 | 0 | not started |
 | **H** | repo config authored by PR #717 | 6 | 3 | in progress |
-| | **total** | **103** | **44** | |
+| | **total** | **103** | **57** | |
 
 ## How to mark a finding off
 
@@ -348,39 +348,146 @@ three findings were one stale snippet. Deleted and replaced with a citation.
       column said 15 while the ranges summed to 10. Ranges are now
       18-22, 35-39, 45-49 = 15, with 27/42 giving the stated 64%.
 
-## Chunk D - jmo-ci-debugger  (0/13)
+## Chunk D - jmo-ci-debugger  (13/13)
 
+**Two root causes, plus a review-tool defect worth knowing about.**
+
+1. **Speculative content presented as battle-tested.** The skill opens "Every fix
+   has been battle-tested in production CI/CD workflows." Pattern #13 was not:
+   `createCommitStatus` appears **nowhere** in `.github/workflows/`, in any
+   commit (`git log -S`), and its central claim is measurably false against this
+   repo's own ruleset.
+2. **Staleness against hardened originals** - chunk B's shape. The Dockerfile
+   snippet reproduces a prototype from before the v1.0.3 download hardening, so
+   it carries the exact `curl | tar` pipe that `.claude/rules/docker.rules.md`
+   now forbids.
+
+**Review-tool defect: 4 of the 13 were anchored to the wrong file.** The API
+`path` for the four `memory-integration.md` findings is *jmo-ci-debugger*, and
+the `diff_hunk` confirms the anchor really sits in that file - but the finding
+bodies analyse Python (`datetime.fromisoformat`, `store_compliance_mapping`,
+`unique_cwes`) that exists only in **`jmo-compliance-mapper/references/memory-integration.md`**,
+at those exact line numbers. Two files, same basename, similar length. The
+claims are all real *there*, so they were fixed there and are counted here.
+Grep the cited symbol before trusting a path.
+
+**Verification.** Markdown is not executed by any test, so the examples were
+extracted and run. Pre-fix code reproduced every claimed failure
+(`TypeError: fromisoformat: argument must be str`, `ValueError: Invalid
+isoformat string`, a 200-day-old record returned as fresh, `confidence='high'`
+on an empty mapping, `ZeroDivisionError`); rewritten code passes 17 checks
+including traversal payloads and a store/reload cycle. The regex table was run
+through `grep -E` against sample log lines, and the actionlint recipe was
+downloaded, checksummed and extracted for real.
 
 **`.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md`**
 
-- [ ] **Major** L158: (claim nested; read from the PR conversation)
-- [ ] **Major** L463: (claim nested; read from the PR conversation)
-- [ ] **Major** L1405: (claim nested; read from the PR conversation)
-- [ ] **Major** L1466: (claim nested; read from the PR conversation)
+- [x] **Major** L158: Do not execute an unpinned remote script (CWE-494)
+      -> FIXED: `bash <(curl .../actionlint/main/scripts/download-actionlint.bash)`
+      runs whatever `main` holds at job time. Replaced with a pinned release,
+      `sha256sum -c`, and `gzip -t`, per the repo's own Download Hardening
+      Convention - which the old line also violated (no `-f`, no `--retry`).
+      **Executed end-to-end**; the first draft was wrong and the run caught it:
+      `sha256sum -c` resolves the filename *inside* the checksums line, so
+      saving as `actionlint.tar.gz` could never verify. Keeps the canonical
+      asset name now. Verified 2353908 bytes, checksum OK, valid x86-64 ELF.
+- [x] **Major** L463: Use the least-privileged Docker Hub token
+      -> FIXED: README sync PATCHes the repository description, which needs
+      Read & Write. `Delete (required for README updates)` was false and only
+      widened a leaked token's blast radius.
+- [x] **Major** L1405: Do not assume rulesets require commit statuses
+      -> FIXED, and the claim was wrong in four places, not one (heading,
+      root-cause paragraph, comparison-table row, prevention list).
+      **Measured against this repo:** ruleset `9147592` requires
+      `{"context":"quick-checks","integration_id":15368}`;
+      `commits/<sha>/status` returns `{"state":"pending","statuses":[]}` -
+      zero commit statuses have ever existed - while `check-runs` shows
+      `quick-checks` succeeding from app 15368, and PRs merge normally. A check
+      run alone satisfies the rule. Section re-rooted on the real cause: a
+      required context that matches no job name, or a job filtered out by
+      `paths:`/`if:` so it never reports.
+- [x] **Major** L1466: Grant `statuses: write` for the commit-status step
+      -> FIXED at both sites, plus two defects the finding missed. The call was
+      **not awaited**, so the step could finish green having posted nothing; and
+      it used `context.sha`, which on `pull_request` is the merge commit rather
+      than the head the ruleset checks. `job.status` now arrives via `env:`
+      instead of being interpolated into JavaScript source.
+- [x] **Minor** L3: Index failure pattern 18 everywhere
+      -> FIXED: pattern 18 exists at L1921 while the header said "all 17".
+      Corrected at 4 real sites - catalog L3, `SKILL.md` "All 17 failures",
+      the SKILL.md quick-lookup list, and the error-pattern table - plus the
+      decision tree, which the finding did not mention. The cited `SKILL.md:92`
+      needed **no** change: it carries no count.
+- [x] **Minor** L490: Update the Docker Hub authentication example
+      -> FIXED, and understated: `curl -u ... GET /v2/users/login/` returns
+      **HTTP 415** (measured, no credentials needed), so it fails on method
+      before the token is evaluated - meaning the old "If error 401: token
+      expired" guidance was also unreachable. Now `POST /v2/auth/token` with a
+      JSON body, whose 400 response names `identifier`/`secret`.
 
 **`.claude/skills/jmo-ci-debugger/references/installation-config.md`**
 
-- [ ] **Major** L96: (claim nested; read from the PR conversation)
+- [x] **Major** L96: Install `xz-utils` before extracting the archive
+      -> FIXED, and the surrounding snippet was stale in three further ways.
+      All four real Dockerfiles already install `xz-utils` in the base layer
+      (`fast:18`, `slim:18`, `balanced:18`, `deep:19`), so the trailing comment
+      "deep variant has it via build-essential transitive dependency" is false.
+      The real files download to a file and run `xz -t` before `tar`; the
+      snippet piped `curl` straight into `tar`, the exact "not in gzip format"
+      failure the hardening convention exists to prevent. Version literal now
+      defers to `versions.yaml` rather than pinning a stale `0.10.0` (real:
+      `0.11.0`).
 
-**`.claude/skills/jmo-ci-debugger/references/memory-integration.md`**
+**`.claude/skills/jmo-compliance-mapper/references/memory-integration.md`** *(the four mis-anchored findings)*
 
-- [ ] **Major** L30: Handle invalid memory timestamps as cache misses
-- [ ] **Major** L34: Do not return stale mappings as fresh results
-- [ ] **Major** L99: Do not assign `high` confidence unconditionally
-- [ ] **Major** L153: Handle reports with no CWE identifiers
-
-**`.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md`**
-
-- [ ] **Minor** L3: Index failure pattern 18 everywhere
-- [ ] **Minor** L490: (claim nested; read from the PR conversation)
+- [x] **Major** L30: Handle invalid memory timestamps as cache misses
+      -> FIXED: reproduced both `TypeError` (key absent -> `.get()` returns
+      `None`) and `ValueError` (hand-edited value). Both, plus `KeyError`, now
+      resolve to a miss. Corrupt JSON and unreadable files too.
+- [x] **Major** L34: Do not return stale mappings as fresh results
+      -> FIXED: reproduced - a 200-day-old record printed "recommend refresh"
+      and then returned itself, so nothing ever refreshed. Stale now returns
+      `None`. Verified at 200d (miss), 5d (hit) and 179d23h (hit).
+- [x] **Major** L99: Do not assign `high` confidence unconditionally
+      -> FIXED: reproduced `confidence='high'` on a mapping with **zero**
+      frameworks and no evidence, which made the field meaningless. Now derived
+      - `high` only when all six frameworks resolve *and* evidence is cited,
+      else `partial`/`unverified` - with an `unresolved` list naming the gaps.
+- [x] **Major** L153: Handle reports with no CWE identifiers
+      -> FIXED: reproduced `ZeroDivisionError` on an empty finding list, which
+      is a normal input (a clean scan, or tools emitting only rule ids).
+      **Root cause behind all four:** the enclosing examples begin
+      `from scripts.core.memory import query_memory` - no such module, so every
+      one was dead on line 1 and fixing the four bugs alone would have repaired
+      fiction. Rewritten against the real file convention per chunk A's policy.
+      Also renamed the helper: it was called `enrich_findings_with_compliance`,
+      colliding with **production code** at `compliance_mapper.py:1278` that
+      does something entirely different.
 
 **`.claude/skills/jmo-ci-debugger/references/error-pattern-matching.md`**
 
-- [ ] **Minor** L29: Use one regex dialect consistently
+- [x] **Minor** L29: Use one regex dialect consistently
+      -> **FIXED in part, DISMISSED in part - the review's remedy corrupts the
+      file.** Measured: rows 21 and 28 (`\d`) match **nothing** under `grep -E`,
+      because GNU grep reads `\d` as a literal `d`; fixed to `[0-9]`, and the
+      standalone regex blocks fixed likewise (`[\w.]` also fails - GNU
+      extensions do not work inside a bracket expression). But rows 17 and 27
+      are **correct as written**: `\|` there is the mandatory *GFM table* escape,
+      not regex. Verified via `gh api markdown` that it renders as a bare `|`;
+      verified that applying the remedy splits the code span across two cells
+      and pushes the `#5` column out of the row. All 18 table patterns now
+      re-verified as valid ERE matching a real log line.
 
 **`.claude/skills/jmo-ci-debugger/references/prevention-strategies-full.md`**
 
-- [ ] **Minor** L158: Pass staged paths as discrete arguments
+- [x] **Minor** L158: Pass staged paths as discrete arguments
+      -> FIXED: measured, `mypy $STAGED_PY` turned 4 staged files into 5 wrong
+      arguments (`has space.py` -> `has` + `space.py`). Now `-z` +
+      `xargs -0` + `--`, with `--diff-filter=ACMR` so deleted files are not
+      linted, and a guard because GNU `xargs` still runs once on empty input.
+      **Sibling the review missed:** the same hook loops over
+      `scripts.core.constants`, which does not exist - so it hit `exit 1` on
+      every run, and a hook that always fails gets bypassed with `--no-verify`.
 
 ## Chunk E - target-type-expander + security-hardening  (0/19)
 
@@ -515,6 +622,10 @@ three findings were one stale snippet. Deleted and replaced with a citation.
 - [ ] **Minor** L69: (claim nested; read from the PR conversation)
 
 **`.claude/skills/jmo-compliance-mapper/references/memory-integration.md`**
+
+> Chunk D already rewrote the Python in this file (the four mis-anchored
+> findings). The JSON example below was **deliberately left alone** so the chunk
+> tallies stay honest - it belongs to G, not D.
 
 - [ ] **Minor** L67: Keep the framework-version schema complete
 


### PR DESCRIPTION
Resolves the 13 chunk-D findings from the PR #717 review. Tracker moves **44 -> 57 / 103**.

Part of #718.

## Two root causes, plus a review-tool defect

**1. Speculative content presented as battle-tested.** The skill opens with "every fix has been battle-tested in production CI/CD workflows." Pattern #13 was not. `createCommitStatus` appears **nowhere** in `.github/workflows/`, in any commit (`git log -S`), and its central claim is measurably false against this repo:

| | measured |
|---|---|
| ruleset `9147592` requires | `{"context":"quick-checks","integration_id":15368}` |
| `commits/<sha>/status` | `{"state":"pending","statuses":[]}` — zero commit statuses, ever |
| `commits/<sha>/check-runs` | `quick-checks`, `success`, app `15368` |
| PRs | merge normally |

A check run alone satisfies the rule. The section is re-rooted on the real cause: a required context matching no job name, or a job filtered out by `paths:`/`if:` so it never reports.

**2. Staleness against hardened originals** — chunk B's shape. The Dockerfile snippet predates the v1.0.3 download hardening and still pipes `curl` straight into `tar`, the exact "not in gzip format" failure `.claude/rules/docker.rules.md` exists to prevent. Its comment claiming `deep` gets `xz-utils` transitively from `build-essential` is false — all four variants install it explicitly (`fast:18`, `slim:18`, `balanced:18`, `deep:19`).

**Review-tool defect: 4 of 13 were anchored to the wrong file.** The API `path` and `diff_hunk` both say `jmo-ci-debugger/references/memory-integration.md`, but the finding bodies analyse Python (`datetime.fromisoformat`, `store_compliance_mapping`, `unique_cwes`) that exists only in **`jmo-compliance-mapper/references/memory-integration.md`** — at those exact line numbers. Two files, same basename, similar length. All four claims are real *there*, so they were fixed there. Their shared root cause is `from scripts.core.memory import query_memory`: no such module, so every example was dead on line 1 and fixing the four bugs alone would have repaired fiction.

## Verification — executed, not asserted

Markdown runs in no test, so the examples were extracted and run. **Pre-fix code reproduced every claimed failure:**

```
D9  missing last_updated : TypeError: fromisoformat: argument must be str
D9  malformed            : ValueError: Invalid isoformat string: 'not-a-date'
D10 stale 200d           : returned THE RECORD  <- served as fresh
D11 empty mapping        : confidence='high'
D12 no findings          : ZeroDivisionError: division by zero
```

The rewrite passes **17/17** checks including traversal payloads, the 180-day boundary, and a store/reload cycle. All **18** regex patterns re-verified through `grep -E` against real log lines. The actionlint recipe was downloaded, checksummed and extracted for real — which **caught a bug in my own first draft**: `sha256sum -c` resolves the filename written inside the checksums line, so saving as `actionlint.tar.gz` could never verify.

`GET /v2/users/login/` was measured at **HTTP 415** (no credentials needed), so the old example fails on method before the token is evaluated — meaning its "If error 401: token expired" advice was unreachable too.

## One finding dismissed in part

The `\|` in the pattern table is the mandatory **GFM table escape**, not regex — verified via `gh api markdown` that it renders as a bare `|`. Applying the suggested fix splits the code span across two cells and pushes the `#5` column out of the row. The `\d` half of that finding was real and is fixed (`\d` matches a literal `d` under `grep -E`, so rows 21 and 28 matched nothing).

## Siblings the review missed

- Pattern 18 was unindexed in **4** places, not the 1 cited — and the cited `SKILL.md:92` needed no change at all.
- The commit-status snippet was **not awaited** (green while posting nothing) and used `context.sha`, the merge commit, where the ruleset checks the PR head.
- The pre-push hook imports `scripts.core.constants`, which **does not exist** — so it hit `exit 1` on every run, and a hook that always fails gets bypassed with `--no-verify`.

## Checks

Docs-only, so CI is genuinely sufficient — there is no runtime behaviour here for a gate to exercise. Locally: `pre-commit` passes on every changed file (`markdownlint-cli2`, `mixed line ending`, `doc-links`), `check_doc_links.py` resolves across all 162 tracked files, and `git diff --numstat` equals `--ignore-cr-at-eol --numstat` (the compliance-mapper file is CRLF and stayed fully CRLF).
