### PR TITLE
docs(config): #718 chunk H - close the 3 repo-config stragglers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,6 +803,10 @@ jobs:
           pre-commit run --all-files mixed-line-ending
           pre-commit run --all-files detect-private-key
           pre-commit run --all-files check-added-large-files
+          # CLAUDE.md and .gitignore both promise this "fails CI and pre-commit".
+          # Until it ran here, only the nightly all-hooks job enforced it, so a
+          # broken documentation link could merge and sit until the next night.
+          pre-commit run --all-files doc-links
 
       - name: Check Python formatting (black --check)
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,9 +121,14 @@ repos:
       - id: doc-links
         name: doc-links (links resolve to tracked files)
         language: system
+        # Every Markdown file, not a hand-listed subset: the checker already
+        # scans all tracked Markdown on each run (pass_filenames: false), so
+        # `files` only decides WHEN it fires. The old list omitted 28 tracked
+        # files -- CHANGELOG.md, SECURITY.md, UPGRADE.md, CONTRIBUTORS.md and
+        # 14 READMEs -- letting a broken link in any of them skip the hook.
         # .gitignore is in scope on purpose: changing the .claude/ allowlist can
         # orphan a link without touching a single markdown file.
-        files: ^(CLAUDE\.md|AGENTS\.md|README\.md|CONTRIBUTING\.md|QUICKSTART\.md|ROADMAP\.md|TEST\.md|\.gitignore|docs/|\.claude/)
+        files: (\.md$|\.markdown$|^\.gitignore$)
         entry: python3 scripts/dev/check_doc_links.py
         pass_filenames: false
       - id: yaml-env-tilde

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Guidance for Claude Code when working with the JMo Security Audit Tool Suite rep
 
 JMo Security is a terminal-first security audit toolkit orchestrating 29 scanners with unified CLI, normalized outputs, and HTML dashboard.
 
-**Version:** v1.0.5 (latest released — see CHANGELOG.md for full history)
+**Version:** v1.0.8 (latest released — see CHANGELOG.md for full history)
 **Philosophy:** Two-phase architecture: scan (invoke tools) → report (normalize, dedupe, output)
 **Test Coverage:** 8,000+ tests, 87% coverage, CI requires ≥85% (sharded across 4 parallel jobs); CI quick threshold 70% (excludes slow/docker/requires_tools/smoke)
 

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -52,6 +52,18 @@ exactly one client. This is the transport's design, not a JMo restriction.
 
 **What to do:** run one server instance per client.
 
+### Memory use over long sessions is unmeasured
+
+The server starts, serves and shuts down cleanly, and that path is tested — but
+no extended profiling has been run, so there is no measured figure for growth
+over a session lasting hours. Because stdio is single-client and sessions are
+normally short, this has not mattered in practice; it is untested rather than
+known-good.
+
+**What to do:** if you keep a server alive for a long-running client, watch its
+RSS and restart it between large batches. Report anything that grows without
+bound — that would be a defect, not this limitation.
+
 ---
 
 ## Scanning
@@ -104,6 +116,21 @@ nothing on a Linux runner.
 
 **What to do:** edit the exported workflow's paths for the CI environment before
 committing it, or create the schedule with the paths the runner will see.
+
+### Survival across a reboot is not verified automatically
+
+`jmo schedule install` writes a normal crontab entry — Linux and macOS only;
+there is no Windows Scheduled Task backend, so on Windows use
+`jmo schedule export` and run the schedule from CI instead. Install/uninstall is
+tested under WSL, but no automated test reboots a machine, because that is too
+disruptive to run on a dev box or a CI runner. Standard crontab entries do
+persist across reboots, so the expected behaviour is that your schedule simply
+resumes; it is unproven here rather than doubtful.
+
+**What to do:** after your first install, confirm it by hand once —
+`jmo schedule list` (or `crontab -l`) following a reboot. Worth re-checking on a
+machine where something else manages cron, such as a container or a hardened
+image that resets `/var/spool/cron`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,4 +189,4 @@ JMo Security orchestrates 28 security scanners across 11 categories:
 
 ---
 
-**Last Updated:** April 2026 | **JMo Security v1.0.5**
+**Last Updated:** August 2026 | **JMo Security v1.0.8**

--- a/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
+++ b/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
@@ -6,7 +6,7 @@
 
 ## Progress
 
-**57 / 103 resolved.**
+**60 / 103 resolved.**
 
 | Chunk | Scope | Findings | Done | Status |
 |---|---|---:|---:|---|
@@ -17,8 +17,8 @@
 | **E** | target-type-expander + security-hardening | 19 | 0 | not started |
 | **F** | the 7 agents | 13 | 0 | not started |
 | **G** | tail: refactoring, compliance, systematic-debugging, references | 11 | 0 | not started |
-| **H** | repo config authored by PR #717 | 6 | 3 | in progress |
-| | **total** | **103** | **57** | |
+| **H** | repo config authored by PR #717 | 6 | 6 | **complete** |
+| | **total** | **103** | **60** | |
 
 ## How to mark a finding off
 
@@ -641,8 +641,11 @@ downloaded, checksummed and extracted for real.
 
 - [ ] **Trivial** L81: Make rollback non-destructive
 
-## Chunk H - repo config authored by PR #717  (3/6)
+## Chunk H - repo config authored by PR #717  (6/6)
 
+Unlike A-G this chunk is repo *behaviour*, not skill prose, so CI alone is not
+sufficient evidence — the hook-scope change was verified by running the hook
+before and after.
 
 **`scripts/dev/check_doc_links.py`**
 
@@ -653,15 +656,41 @@ downloaded, checksummed and extracted for real.
 
 **`.claude/rules/testing.rules.md`**
 
-- [ ] **Minor** L156: (claim nested; read from the PR conversation)
+- [x] **Minor** L156: Synchronize the missing deliberate verification gaps
+      -> FIXED: the rules file lists three Deliberate Verification Gaps and says
+      a gap a user can hit belongs in `KNOWN_LIMITATIONS.md` too; only
+      *Concurrent scans on Windows* had made it across. Added the user-facing
+      halves of the other two. The reboot entry was **corrected mid-draft by
+      checking the code**: `jmo schedule install` is cron-only, Linux/macOS,
+      with no Windows Scheduled Task backend (`--help` says so;
+      `tests/unit/test_cron_installer.py:20` skips on win32), so it now points
+      Windows users at `schedule export`.
 
 **`.pre-commit-config.yaml`**
 
-- [ ] **Minor** L126: (claim nested; read from the PR conversation)
+- [x] **Minor** L126: Make the `doc-links` scope match the documented guarantee
+      -> FIXED on both halves. `files:` named 7 root files plus `docs/` and
+      `.claude/`, leaving **28** tracked Markdown files outside it. Because
+      `pass_filenames: false` the checker already scans every tracked file when
+      it runs, so `files:` only decides *when* — widening it to all Markdown
+      costs nothing per run and takes uncovered from 28/177 to **0/177**.
+      **The CI half was false too:** `CLAUDE.md:201` and `.gitignore:121` both
+      claim the checker "fails CI and pre-commit", but `lint-quick` ran 8 named
+      hooks and `doc-links` was not among them — only the nightly all-hooks job
+      enforced it. Added to that step. Verified by running the hook: old config
+      **Skipped** `CHANGELOG.md`, new config runs it, and a non-Markdown path
+      stays correctly inert.
 
 **`ROADMAP.md`**
 
-- [ ] **Minor** L9: (claim nested; read from the PR conversation)
+- [x] **Minor** L9: Update stale v1.0.5 release references
+      -> FIXED: `pyproject.toml:7` and `ROADMAP.md` say v1.0.8 while
+      `CLAUDE.md:11` and `docs/index.md:192` still said v1.0.5.
+      `docs/CLI_REFERENCE.md:5` says `1.0.0` and was **deliberately left** ->
+      #750: bumping that header asserts the document's *contents* describe
+      v1.0.8's CLI, which is unaudited. #750 also covers the missing guard —
+      `test_version_consistency.py` checks only the three code sites, never the
+      prose headers, which is why these drifted across three releases.
 
 **`scripts/dev/check_doc_links.py`**
 

--- a/docs/superpowers/plans/2026-08-05-published-skills-remediation.md
+++ b/docs/superpowers/plans/2026-08-05-published-skills-remediation.md
@@ -1,9 +1,24 @@
 # Remediating the newly-published `.claude/` skills and agents
 
-**Status:** discovery complete, execution not started
-**Branch:** `fix/coderabbit-findings-717` off `dev`
+**Status:** chunks A, B, C, D and H complete (60/103); E, F, G remain
+**Branch:** one branch per chunk off `dev`; PR into `dev`. Never `main`.
 **Tracking issue:** [#718](https://github.com/jimmy058910/jmo-security-repo/issues/718)
-**Endgame:** land on `dev`, then `dev -> main` as **v1.0.9**
+**Endgame:** land all 103 on `dev`, then `dev -> main` as **v1.0.9**
+
+### Decided 2026-08-08: all 103 land before v1.0.9
+
+The alternative was cutting v1.0.9 early, at 60/103, and shipping E/F/G in
+v1.0.10. The case for it: every one of the 43 remaining findings is inside
+`.claude/`, which is contributor tooling with no runtime effect on the released
+package, while `dev` is holding user-facing fixes — #725 (`slim` scans silently
+discarded), #746 (trufflehog reporting pytest function names as verified
+secrets), #734, #729.
+
+**Rejected in favour of one clean release.** v1.0.9 ships the full remediation
+and closes #718 with the tag, rather than splitting it across two releases.
+E (19) → F (13) → G (11) first; expect roughly one chunk per session.
+
+Do not re-open this at the start of the next session.
 
 ## What happened
 

--- a/docs/superpowers/plans/2026-08-05-published-skills-remediation.md
+++ b/docs/superpowers/plans/2026-08-05-published-skills-remediation.md
@@ -20,6 +20,17 @@ E (19) → F (13) → G (11) first; expect roughly one chunk per session.
 
 Do not re-open this at the start of the next session.
 
+### Release gate at 103/103, before tagging: [#752](https://github.com/jimmy058910/jmo-security-repo/issues/752)
+
+None of these 103 findings is executed by a test, so green CI proves only that
+nothing *else* broke. Before `dev -> main`, run the full Juice Shop pass plus
+`jmo validate --tier full` and `reconcile_scan_accounting.py`, and compare
+finding counts to the baselines in `docs/internal/MANUAL_TESTING_CHECKLIST.md`.
+
+**Read the job logs, not the check ticks.** Both Juice Shop E2E steps
+(`scheduled.yml:841`, `:927`) are `continue-on-error: true`, so they report
+green over real failures — the same trap as the `windows-2022` shard.
+
 ## What happened
 
 PR #717 split `.claude/` by audience and published 12 contributor skills plus 7
@@ -161,4 +172,30 @@ the PR conversation.
 - **Console output**: anything printing repository content must go through
   `harden_console_streams()` + `safe_print()` from `scripts/core/unicode_utils`.
 - **Read the `windows-2022` job log, not its check tick** — it is
-  `continue-on-error: true` and reports success over failures.
+  `continue-on-error: true` and reports success over failures. Same applies to
+  the two Juice Shop E2E steps (`scheduled.yml:841`, `:927`).
+
+### Learned in chunks C and D — apply to E, F, G
+
+- **Verify the anchored file actually contains the cited symbol.** Chunk D had
+  4 findings whose API `path` *and* `diff_hunk` said `jmo-ci-debugger/references/
+  memory-integration.md`, while the bodies analysed Python that exists only in
+  `jmo-compliance-mapper/references/memory-integration.md` — at identical line
+  numbers, because the two files share a basename and a similar length. Grep the
+  cited symbol before editing.
+- **Findings understate their own scope; grep for siblings.** Every multi-site
+  finding in C and D named fewer sites than existed (1 reported vs 4 real, twice).
+  Read the whole construct, not the cited line.
+- **"Battle-tested" is a claim to check, not a reason to trust.** The ci-debugger
+  skill asserted every fix had been proven in production; its pattern #13 remedy
+  appears in no commit (`git log -S`) and its premise was measurably false against
+  this repo's own ruleset. Test the claim against `git log` and the live API.
+- **A doc that cannot fail is a doc that never ran.** Recurring shape: a `grep`
+  that returns 0 every time (chunk B), an assertion that could never pass (C), an
+  import of a module that does not exist (A, D), a `sha256sum -c` that can never
+  resolve its file (D). If an example has a pass/fail step, **execute it** — that
+  is what caught three of these, including one of my own.
+- **`\|` inside a Markdown table is the GFM escape, not a regex escape.** It
+  renders as a bare `|`. Removing it splits the cell and drops a column. Check
+  rendering with `gh api markdown` (no leading slash — MSYS mangles `/markdown`
+  into a path).


### PR DESCRIPTION
Closes the last 3 chunk-H findings from the PR #717 review. With #749 this takes the tracker to **60 / 103**. (Tracker row lands after #749 merges, so the arithmetic accumulates cleanly rather than conflicting.)

Part of #718.

## 1. The `doc-links` hook did not cover what it claimed

`files:` named 7 root files plus `docs/` and `.claude/`, leaving **28 tracked Markdown files** outside it — `CHANGELOG.md`, `SECURITY.md`, `UPGRADE.md`, `CONTRIBUTORS.md`, and 14 `README.md`s.

Because `pass_filenames: false`, the checker **already scans every tracked Markdown file** whenever it runs — so `files:` only decides *when* it fires. Widening it to all Markdown therefore costs nothing per run:

| | uncovered tracked Markdown |
|---|---|
| before | 28 / 177 |
| after | **0 / 177** |

**The CI half of the claim was false too.** Both `CLAUDE.md:201` and `.gitignore:121` state the checker "fails **CI** and pre-commit" — but `lint-quick` ran only 8 named hooks `--all-files`, and `doc-links` was not among them. Only the nightly `scheduled.yml` all-hooks job enforced it, so a broken link could merge and sit until the next night. Added to that step, which runs on every `push` and `pull_request` (`if: github.event_name != 'schedule'`, no `needs:`).

## 2. `KNOWN_LIMITATIONS.md` carried 1 of the 3 recorded gaps

`testing.rules.md` lists three Deliberate Verification Gaps and says "if a gap here becomes something a user can hit, it belongs there too." Only *Concurrent scans on Windows* had made it across. Added the user-facing halves of the other two — MCP server memory over long sessions, and schedule survival across a reboot — each with why it is untested and the manual check.

## 3. Stale version headers

`pyproject.toml:7` and `ROADMAP.md` say **v1.0.8**; `CLAUDE.md:11` and `docs/index.md:192` still said **v1.0.5**.

`docs/CLI_REFERENCE.md:5` says `1.0.0` and was **deliberately left alone** → #750. Bumping that header asserts the document's *contents* describe v1.0.8's CLI, which I have not audited; that issue also covers the missing guard, since `test_version_consistency.py` checks only the three code sites and never the prose headers.

## Verification — this one is not docs-only, so CI is not sufficient by itself

The change alters when a hook fires, which no test asserts. Run directly:

```
OLD config, doc-links --files CHANGELOG.md       -> (no files to check) Skipped
NEW config, doc-links --files CHANGELOG.md       -> Passed   (fires)
NEW config, doc-links --files packaging/README.md-> Passed   (fires)
NEW config, doc-links --files pyproject.toml     -> Skipped  (correctly inert)
```

New regex measured against `git ls-files`: **177/177** Markdown covered, `.gitignore` still matched. `yamllint` and `actionlint` pass on the workflow change; full `pre-commit` passes on every changed file.

This PR also self-tests the CI half: the new `doc-links` step runs on this very PR.

One claim was corrected mid-draft by checking the code rather than trusting the draft — `jmo schedule install` is **cron-only, Linux/macOS**, with no Windows Scheduled Task backend (`--help` says so; `tests/unit/test_cron_installer.py:20` skips on win32). The limitation entry now says that and points Windows users at `schedule export`.
