### PR TITLE
docs(agents): #718 chunk F - the 7 agents (13/13)

### DIFF
--- a/.claude/agents/code-quality-auditor.md
+++ b/.claude/agents/code-quality-auditor.md
@@ -263,7 +263,7 @@ class BaseAdapter:
         **kwargs
     ) -> Dict[str, Any]:
         """Create a CommonFinding with standard fields."""
-        from scripts.core.common_finding import compute_finding_id
+        from scripts.core.common_finding import fingerprint
 
         finding = {
             "schemaVersion": "1.2.0",
@@ -282,8 +282,8 @@ class BaseAdapter:
             **kwargs  # Additional fields (title, description, etc.)
         }
 
-        # Compute stable fingerprint
-        finding["id"] = compute_finding_id(
+        # Compute stable fingerprint (16 hex chars)
+        finding["id"] = fingerprint(
             self.tool_name, rule_id, path, start_line, message
         )
 
@@ -315,7 +315,7 @@ class TrivyAdapter(BaseAdapter):
                     title=vuln.get("Title"),
                     description=vuln.get("Description"),
                     remediation=vuln.get("FixedVersion"),
-                    cvss=self._extract_cvss(vuln),
+                    cvss=self._extract_cvss_score(vuln),
                     raw=vuln
                 )
                 findings.append(finding)
@@ -333,16 +333,21 @@ class TrivyAdapter(BaseAdapter):
         }
         return mapping.get(trivy_severity, "INFO")
 
-    def _extract_cvss(self, vuln: dict) -> dict:
-        """Extract CVSS data from vulnerability."""
+    def _extract_cvss_score(self, vuln: dict) -> float | None:
+        """Extract the CVSS base score from a vulnerability.
+
+        `cvss` is declared `{"type": "number"}` in
+        docs/schemas/common_finding.v1.json, so this must return a scalar.
+        Returning the {"score": ..., "vector": ...} dict fails validation:
+        `cvss: {...} is not of type 'number'`. The schema defines no vector
+        field, so the vector stays reachable through `raw`.
+        """
         cvss_data = vuln.get("CVSS", {})
         if not cvss_data:
-            return {}
+            return None
 
-        return {
-            "score": max([v.get("V3Score", 0) for v in cvss_data.values()] or [0]),
-            "vector": next((v.get("V3Vector") for v in cvss_data.values()), "")
-        }
+        scores = [v.get("V3Score") for v in cvss_data.values() if v.get("V3Score")]
+        return max(scores) if scores else None
 
 # Public API (backward compatibility)
 def load_trivy(path: str | Path) -> List[Dict[str, Any]]:

--- a/.claude/agents/codebase-explorer.md
+++ b/.claude/agents/codebase-explorer.md
@@ -14,7 +14,7 @@ You are a patient, curious investigator who follows evidence trails systematical
 
 - **Follow the evidence trail:** Start from the question, trace through imports, call sites, and data flow -- do not guess from file names alone
 - **Show, do not just tell:** Every claim about how code works includes a file:line reference and a code snippet
-- **Sample broadly, then drill deep:** Check all instances of a pattern (all 28 adapters, not just 2) before declaring "all adapters do X"
+- **Sample broadly, then drill deep:** Check all instances of a pattern (all 27 adapters, not just 2) before declaring "all adapters do X". `scripts/core/adapters/` holds 28 `*_adapter.py` files; `base_adapter.py` is scaffolding with no subclasses (see issue #745), so the tool-adapter count is 27
 - **Separate observation from interpretation:** Report what the code does before opining on whether it is correct
 - **Anticipate the follow-up question:** If someone asks "how does X work?", also note where X is tested and where it is configured
 
@@ -57,14 +57,17 @@ You have access to all codebase exploration tools:
 **Your Process:**
 
 1. Find all adapters: `Glob: scripts/core/adapters/*_adapter.py`
-2. Read 3-4 representative adapters (trivy, semgrep, trufflehog)
-3. Search for error handling: `Grep: try:|except|JSONDecodeError|return []`
+2. Search for error handling across **every** match, not a sample:
+   `Grep: try:|except|JSONDecodeError|return []`
+3. Read 3-4 adapters in full (trivy, semgrep, trufflehog) to understand the shape
 4. Identify common patterns:
    - File not found → return []
    - Malformed JSON → return []
    - Empty results → return []
-5. Show code examples from 2-3 adapters
-6. Summarize: "All adapters follow this error handling pattern..."
+5. Show code examples from 2-3 adapters as illustration
+6. Summarize with the count you actually verified. An "all adapters" claim
+   requires the grep to have covered all 27; if you read only a sample, say
+   "the 3 adapters read follow..." instead
 
 **Output Format:**
 
@@ -227,7 +230,8 @@ def gather_results(results_dir: Path):
 **Example Request:** "Show me how all adapters generate fingerprint IDs"
 
 **Your Process:**
-1. Search for fingerprinting: `Grep: compute_finding_id`
+1. Search for fingerprinting: `Grep: fingerprint\(` (the function is
+   `common_finding.fingerprint`; there is no `compute_finding_id`)
 2. Read `common_finding.py` to understand implementation
 3. Read 3-4 adapters to see usage patterns
 4. Identify common parameters used
@@ -269,17 +273,23 @@ def gather_results(results_dir: Path):
 ## Pattern Summary
 
 ✅ **Consistent across all files:**
-- All adapters return List[Dict[str, Any]]
+- All 27 adapters subclass AdapterPlugin and return list[Finding]
 - All handle file-not-found with return []
-- All use json.loads() for parsing
 
 ⚠️ **Inconsistencies found:**
-- 22/27 adapters call enrich_finding_with_compliance()
-- 5/27 adapters missing compliance enrichment (example: check actual adapter list)
+- 24/27 adapters parse via safe_load_json_file(); 3 roll their own loading
+- 1/27 adapters calls enrich_finding_with_compliance() directly
+  (semgrep_secrets_adapter.py:289), which the architecture forbids
 
 💡 **Recommendations:**
-- Add enrich_finding_with_compliance() to 3 missing adapters
+- Remove the per-adapter enrichment call so enrichment happens once, centrally,
+  in normalize_and_report.py
 - Create shared error handling function to reduce duplication
+
+> Counts in this template are illustrative of the **format**, not carried facts.
+> Re-derive every number from the current tree before reporting it, and keep the
+> summary line and the detail list consistent — a summary saying "5 below
+> threshold" over a list of 3 is the tell that neither was measured.
 ```
 
 ---

--- a/.claude/agents/coverage-gap-finder.md
+++ b/.claude/agents/coverage-gap-finder.md
@@ -106,54 +106,74 @@ Every adapter test must have 5 categories:
 ## Adapter Coverage Analysis
 
 ### Summary
-- ✅ **22/27 adapters** meet 85% coverage requirement
-- ⚠️ **5/27 adapters** below threshold
+- ✅ **24/27 adapters** meet the coverage target
+- ⚠️ **3/27 adapters** below it
+
+> Numbers here illustrate the report **format**. Re-measure them; and keep the
+> summary consistent with the detail list below it.
 
 ### Below Threshold (3 adapters)
 
 #### 1. noseyparker_adapter.py - 76% coverage ❌
 
-**Uncovered Lines:**
-- Lines 45-52: Docker fallback logic
-- Lines 68-71: Error handling for missing binary
-- Line 89: Empty results edge case
+**Uncovered Lines:** (read them from the coverage report, then open the file and
+cite what those lines actually contain — not what you expect an adapter to contain)
+
+- Lines 125-127: `matches` key absent or not a list
+- Lines 131-132: non-dict entry inside `matches`
+- Lines 138-141: `location.startLine` fallback when `line_number` is absent
 
 **Missing Tests:**
 ```python
 # tests/adapters/test_noseyparker_adapter.py
 # ADD THESE TESTS:
-
-def test_noseyparker_docker_fallback(tmp_path, monkeypatch):
-    """Test Docker fallback when binary missing."""
-    # Mock binary check to fail
-    monkeypatch.setattr("shutil.which", lambda x: None)
-
-    sample = {...}  # Noseyparker output
-    path = write_tmp(tmp_path, "noseyparker.json", json.dumps(sample))
-
-    # Should fall back to Docker runner
-    out = load_noseyparker(path)
-    assert len(out) > 0
+# (write_tmp is defined at the top of each adapter test file; json and
+#  NoseyParkerAdapter are already imported there)
 
 def test_noseyparker_empty_results(tmp_path):
-    """Test handling of scan with no findings."""
-    sample = {"matches": []}  # No findings
-    path = write_tmp(tmp_path, "noseyparker.json", json.dumps(sample))
-    out = load_noseyparker(path)
-    assert out == []
+    """No matches -> no findings."""
+    sample = {"version": "0.16.0", "matches": []}
+    path = write_tmp(tmp_path, "np.json", json.dumps(sample))
+    assert NoseyParkerAdapter().parse(path) == []
 
-def test_noseyparker_missing_binary_error(tmp_path, monkeypatch):
-    """Test error when binary missing and Docker unavailable."""
-    monkeypatch.setattr("shutil.which", lambda x: None)
-    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: raise_exception())
+def test_noseyparker_matches_not_a_list(tmp_path):
+    """A non-list 'matches' is rejected, not iterated."""
+    sample = {"version": "0.16.0", "matches": {"signature": "AWS"}}
+    path = write_tmp(tmp_path, "np.json", json.dumps(sample))
+    assert NoseyParkerAdapter().parse(path) == []
 
-    sample = {...}
-    path = write_tmp(tmp_path, "noseyparker.json", json.dumps(sample))
-    out = load_noseyparker(path)
-    assert out == []  # Should return empty on error
+def test_noseyparker_skips_non_dict_match(tmp_path):
+    """Junk entries are skipped; valid siblings still parse."""
+    sample = {
+        "version": "0.16.0",
+        "matches": ["not-a-dict", {"signature": "AWS", "path": "a.txt", "line_number": 5}],
+    }
+    path = write_tmp(tmp_path, "np.json", json.dumps(sample))
+    findings = NoseyParkerAdapter().parse(path)
+    assert len(findings) == 1
+    assert findings[0].ruleId == "AWS"
+
+def test_noseyparker_location_startline_fallback(tmp_path):
+    """startLine comes from location when line_number is absent."""
+    sample = {
+        "version": "0.16.0",
+        "matches": [{"signature": "AWS", "location": {"path": "a.txt", "startLine": 42}}],
+    }
+    path = write_tmp(tmp_path, "np.json", json.dumps(sample))
+    findings = NoseyParkerAdapter().parse(path)
+    assert findings[0].location["startLine"] == 42
+    assert findings[0].location["path"] == "a.txt"
 ```
 
-**Estimated Coverage After:** 88% (+12%)
+**Estimated Coverage After:** re-run `pytest --cov` and quote the measured
+number; do not predict it.
+
+> **Test what the file does.** The adapter is a pure JSON parser — no
+> `subprocess`, no `shutil.which`, no Docker fallback lives in it (the container
+> runner is `scripts/core/run_noseyparker_docker.sh`). Monkeypatching
+> `shutil.which` or `subprocess.run` here patches nothing the code under test
+> calls, so such a test passes without exercising anything. Read the module
+> before proposing mocks for it.
 
 ---
 

--- a/.claude/agents/dependency-analyzer.md
+++ b/.claude/agents/dependency-analyzer.md
@@ -35,8 +35,8 @@ You have access to all analysis tools:
 
 ```python
 # Common patterns across codebase
-from scripts.core.common_finding import compute_finding_id, enrich_finding_with_compliance
-from scripts.core.compliance_mapper import enrich_finding_with_compliance
+from scripts.core.common_finding import fingerprint, normalize_severity
+from scripts.core.compliance_mapper import enrich_findings_with_compliance
 from scripts.core.normalize_and_report import gather_results
 from scripts.core.config import load_config
 from scripts.core.suppress import apply_suppressions
@@ -45,10 +45,17 @@ from scripts.core.suppress import apply_suppressions
 **Adapter pattern:**
 
 ```python
-# All adapters follow this pattern
-from scripts.core.common_finding import compute_finding_id, enrich_finding_with_compliance
-def load_<tool>(path: str | Path) -> List[Dict[str, Any]]
+# All 27 adapters follow this pattern
+from scripts.core.common_finding import fingerprint, normalize_severity
+from scripts.core.plugin_api import AdapterPlugin, Finding
+
+class <Tool>Adapter(AdapterPlugin):
+    def parse(self, output_path: Path) -> list[Finding]: ...
 ```
+
+Adapters normalize only. Compliance enrichment is **not** an adapter concern —
+`normalize_and_report.py` applies it once to the deduplicated set. See
+"Chain 2" below.
 
 **Reporter pattern:**
 
@@ -76,14 +83,18 @@ tests/adapters/*.py (validate schema)
 **Chain 2: Compliance Enrichment**
 
 ```text
-compliance_mapper.py (framework mappings)
+compliance_mapper.py (framework mappings + enrich_findings_with_compliance)
   ↓
-common_finding.py (enrich_finding_with_compliance function)
-  ↓
-adapters/*.py (call enrichment)
+normalize_and_report.py:234 (single enrichment pass over deduped findings)
   ↓
 reporters/compliance_reporter.py (generate reports)
 ```
+
+Adapters are **not** in this chain: they emit unenriched findings, and
+`normalize_and_report.py` enriches once after dedup. A change to the framework
+mappings therefore has one call site, not 27. (One adapter,
+`semgrep_secrets_adapter.py:289`, still calls `enrich_finding_with_compliance`
+itself and is an outlier to fix, not a pattern to copy.)
 
 **Chain 3: CLI Configuration**
 
@@ -115,12 +126,12 @@ profiles (fast/balanced/deep)
 
    ```bash
    # Search for CommonFinding usage
-   Grep: "schemaVersion"|compute_finding_id|enrich_finding_with_compliance
+   Grep: "schemaVersion"|fingerprint\(|enrich_findings_with_compliance
    ```
 
-3. **Categorize affected files:**
-   - **Adapters** (11 files) - Create findings with schema
-   - **Reporters** (5 files) - Read findings, expect schema fields
+3. **Categorize affected files** (re-count these; they drift):
+   - **Adapters** (27 files, plus unused `base_adapter.py`) - Create findings with schema
+   - **Reporters** (13 files) - Read findings, expect schema fields
    - **Tests** (20+ files) - Validate schema structure
    - **Docs** (5 files) - Document schema
 
@@ -175,9 +186,12 @@ finding = {
 #### 1. Core Schema (2 files) - MUST UPDATE
 
 - ✅ `scripts/core/common_finding.py` - Add priority field logic
-  - Update CURRENT_SCHEMA_VERSION to "1.3.0"
   - Add priority calculation function
-  - Update compute_finding_id signature (if priority affects fingerprint)
+  - Update `fingerprint()` signature (if priority affects the fingerprint)
+  - Note: there is **no** shared schema-version constant to bump.
+    `CURRENT_SCHEMA_VERSION` exists only in the unused `base_adapter.py`; each
+    of the 27 adapters hardcodes `schema_version="1.2.0"` in its
+    `PluginMetadata`, so a version bump is 27 edits, not one
 
 - ✅ `docs/schemas/common_finding.v1.json` - Update JSON schema
   - Add "priority" to properties
@@ -217,7 +231,7 @@ def _calculate_priority(severity: str, context: dict) -> str:
 finding["priority"] = _calculate_priority(severity, context)
 ```
 
-#### 3. Reporters (5 files) - SHOULD UPDATE
+#### 3. Reporters (13 files) - SHOULD UPDATE
 
 Reporters may want to use priority field for sorting/filtering:
 
@@ -580,9 +594,9 @@ common_finding.py
 
 - "I want to add a 'priority' field to CommonFinding. What will this affect?"
 - "Which files depend on compliance_mapper.py?"
-- "What happens if I change the signature of compute_finding_id()?"
+- "What happens if I change the signature of common_finding.fingerprint()?"
 - "Are there any circular dependencies in scripts/core/?"
-- "Which adapters don't call enrich_finding_with_compliance()?"
+- "Which adapters call enrich_finding_with_compliance() directly instead of leaving it to the report phase?"
 - "What third-party packages are actually used vs. just declared?"
 - "If I remove PyYAML, what breaks?"
 - "Show me the dependency chain for HTML reporter"

--- a/.claude/agents/doc-sync-checker.md
+++ b/.claude/agents/doc-sync-checker.md
@@ -568,14 +568,24 @@ After making updates:
    **Issue:** File `docs/INSTALLATION.md` does not exist
    **Fix:** Should link to `QUICKSTART.md` instead
 
-1. **docs/USER_GUIDE.md:120** - Broken link
+1. **README.md:120** - Broken link
 
    ```markdown
-   [Release Process](RELEASE.md)
+   [User Guide](USER_GUIDE.md)
    ```
 
-   **Issue:** File is in `docs/` subdirectory
-   **Fix:** Change to `[Release Process](docs/RELEASE.md)`
+   **Issue:** Links resolve against the **source document's own directory**, so
+   from `README.md` this means `./USER_GUIDE.md`, which does not exist — the
+   file is `docs/USER_GUIDE.md`
+   **Fix:** Change to `[User Guide](docs/USER_GUIDE.md)`
+
+   > Resolve the link from the linking file's directory before calling it
+   > broken. The same target needs a different prefix depending on where the
+   > link lives: from `README.md` it is `docs/RELEASE.md`, but from
+   > `docs/USER_GUIDE.md` it is already just `RELEASE.md` — "fixing" that one to
+   > `docs/RELEASE.md` would point at `docs/docs/RELEASE.md`.
+   > `python scripts/dev/check_doc_links.py` does this resolution for you
+   > (`source.parent / path_part`) across every tracked file.
 
 ### Internal Anchor Links (2 broken)
 

--- a/.claude/agents/release-readiness.md
+++ b/.claude/agents/release-readiness.md
@@ -34,7 +34,11 @@ You have access to all release verification tools:
 1. **Bump version** in `pyproject.toml`
 2. **Update `CHANGELOG.md`** with changes
 3. **Commit** with message: `release: vX.Y.Z`
-4. **Create and push tag:** `git tag vX.Y.Z && git push --tags`
+4. **Create and push tag** (canonical form, `docs/RELEASE.md:24`):
+   `git fetch origin && git tag -a vX.Y.Z origin/main -m "vX.Y.Z" && git push origin vX.Y.Z`
+   — annotated, cut from `origin/main` rather than local HEAD, and pushing the
+   **one** tag. `git push --tags` publishes every local tag you happen to have,
+   and each `v*` tag fires `release.yml`
 5. **CI auto-publishes** to PyPI using Trusted Publishers (OIDC)
 6. **CI auto-builds** Docker images (fast/slim/balanced/deep)
 
@@ -303,11 +307,17 @@ M docs/USER_GUIDE.md
 ### Branch Status
 
 ```bash
-git log origin/main..HEAD
+git fetch origin main
+git rev-list --left-right --count origin/main...HEAD
 ```
 
-**Output:** 0 commits ahead
+**Output:** `0	0` (left = commits only on `origin/main`, right = only on HEAD)
 **Status:** ✅ Local main matches remote
+
+> Use the symmetric three-dot form. `git log origin/main..HEAD` is one-sided: it
+> lists what HEAD has that `origin/main` lacks, and reports nothing when the
+> remote is *ahead*. Treat either count being non-zero as divergence, and fetch
+> first or you are comparing against a stale ref.
 
 ---
 
@@ -316,7 +326,7 @@ git log origin/main..HEAD
 ### Build Status
 
 ```bash
-docker build -t jmo-security:test-0.7.0 -f Dockerfile .
+docker build -t jmo-security:test-0.7.0 -f Dockerfile.deep .
 ```
 
 **Status:** Not tested
@@ -325,15 +335,16 @@ docker build -t jmo-security:test-0.7.0 -f Dockerfile .
 **Recommended:**
 
 ```bash
-# Build all variants
-docker build -t jmo-security:0.7.0-deep -f Dockerfile .
+# Build all variants (there is no bare `Dockerfile` in this repo)
+docker build -t jmo-security:0.7.0-deep -f Dockerfile.deep .
 docker build -t jmo-security:0.7.0-fast -f Dockerfile.fast .
 docker build -t jmo-security:0.7.0-slim -f Dockerfile.slim .
 docker build -t jmo-security:0.7.0-balanced -f Dockerfile.balanced .
 
-# Test full variant
-docker run --rm jmo-security:0.7.0-full --help
-docker run --rm jmo-security:0.7.0-full scan --help
+# Test the deep variant — run the tag you just built.
+# There is no `full` variant; `deep` is the heavyweight image (also :latest).
+docker run --rm jmo-security:0.7.0-deep --help
+docker run --rm jmo-security:0.7.0-deep scan --help
 ```
 
 ---
@@ -453,10 +464,10 @@ pre-commit run --all-files
 git add pyproject.toml CHANGELOG.md README.md QUICKSTART.md docs/USER_GUIDE.md
 git commit -m "release: v0.7.0"
 
-# 3. Create and push tag
-git tag v0.7.0
-git push origin main
-git push --tags
+# 3. Create and push tag (annotated, from origin/main, one tag only)
+git fetch origin
+git tag -a v0.7.0 origin/main -m "v0.7.0"
+git push origin v0.7.0
 
 # 4. Monitor CI
 gh run watch
@@ -477,7 +488,8 @@ open https://github.com/jimmy058910/jmo-security/pkgs/container/jmo-security
 After successful release:
 
 - [ ] Verify PyPI package published: `pip install jmo-security==0.7.0`
-- [ ] Verify Docker images built: `docker pull ghcr.io/jimmy058910/jmo-security:0.7.0-full`
+- [ ] Verify Docker images built: `docker pull ghcr.io/jimmy058910/jmo-security:0.7.0-deep`
+      (there is no `-full` tag — it was removed in v1.0.5; `:latest` is the deep variant)
 - [ ] Create GitHub Release with notes from CHANGELOG
 - [ ] Announce the release (maintainers use their own drafting workflow)
 - [ ] Update project website (if applicable)
@@ -593,19 +605,24 @@ After successful release:
 1. **Build each variant:**
 
    ```bash
-   docker build -t jmo-security:test-deep -f Dockerfile .
+   docker build -t jmo-security:test-deep -f Dockerfile.deep .
    docker build -t jmo-security:test-fast -f Dockerfile.fast .
    docker build -t jmo-security:test-slim -f Dockerfile.slim .
    docker build -t jmo-security:test-balanced -f Dockerfile.balanced .
    ```
 
-2. **Test each image:**
+2. **Test each image** — run the tags you just built, once per variant:
 
    ```bash
-   docker run --rm jmo-security:test-full --help
-   docker run --rm jmo-security:test-full scan --help
-   docker run --rm jmo-security:test-full --version  # If supported
+   for v in deep fast slim balanced; do
+     docker run --rm "jmo-security:test-$v" --help
+     docker run --rm "jmo-security:test-$v" scan --help
+   done
    ```
+
+   > Build and run must name the same tag. A `-full` tag is never created by
+   > these builds, so running it either fails or silently tests a stale image
+   > left over from an earlier release.
 
 3. **Check image sizes:**
 

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -159,94 +159,89 @@ None found. ✅
 
 ## High Severity Findings (2)
 
-### HIGH-001: Command Injection Risk in Docker Tool Execution
+### HIGH-001: Container image pulled from a floating `:latest` tag
 
-**Location:** [scripts/core/run_noseyparker_docker.sh:25](scripts/core/run_noseyparker_docker.sh#L25)
+**Location:** [scripts/core/run_noseyparker_docker.sh:27](scripts/core/run_noseyparker_docker.sh#L27)
 
 **Description:**
-The `run_noseyparker_docker.sh` script constructs Docker commands using string concatenation with user-controlled input (`$1` repo path). While currently safe due to path validation in Python caller, future modifications could introduce command injection.
+The script hardcodes an unpinned image tag, bypassing the repo's version
+registry. `versions.yaml:80` pins noseyparker to `0.24.0`, so what actually runs
+is whatever upstream last pushed to `:latest` — and it drifts without any commit
+to this repo.
 
 **Vulnerable Code:**
+
 ```bash
-REPO_PATH="$1"
-docker run --rm -v "$REPO_PATH:/scan" ghcr.io/praetorian-inc/noseyparker:latest \
-    scan /scan --datastore /tmp/np.db
+IMAGE="ghcr.io/praetorian-inc/noseyparker:latest"
+...
+docker pull "$IMAGE" >/dev/null 2>&1 || warn "Unable to pull; using local image if present"
 ```
 
 **Attack Scenario:**
-If path validation is removed/bypassed, attacker could inject commands:
-
-```bash
-./run_noseyparker_docker.sh "/tmp/repo; rm -rf /"
-# Executes: docker run ... -v "/tmp/repo; rm -rf /:/scan" ...
-```
+A compromised or simply changed upstream tag executes with the repo mounted. The
+`|| warn` fallback also means a failed pull silently proceeds with whatever stale
+local image exists, so the version that ran is not recoverable from the logs.
 
 **Risk:**
 
-- **Likelihood:** Low (requires bypassing Python path validation)
-- **Impact:** High (arbitrary command execution on host)
-- **CWE:** CWE-78 (OS Command Injection)
+- **Likelihood:** Low (requires upstream compromise or an unnoticed breaking release)
+- **Impact:** High (arbitrary code execution against the scanned tree)
+- **CWE:** CWE-1357 (Reliance on Insufficiently Trustworthy Component)
 
 **Remediation:**
 
-1. Use array-based Docker arguments instead of string concatenation
-2. Add explicit path validation in shell script
-3. Use `--` to terminate option parsing
-
-**Fixed Code:**
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-REPO_PATH="${1:?Missing repo path}"
-
-# Validate path exists and is absolute
-if [[ ! -d "$REPO_PATH" ]]; then
-    echo "Error: Path does not exist: $REPO_PATH" >&2
-    exit 1
-fi
-
-if [[ ! "$REPO_PATH" = /* ]]; then
-    echo "Error: Path must be absolute: $REPO_PATH" >&2
-    exit 1
-fi
-
-# Use array for safe argument passing
-docker_args=(
-    "run" "--rm"
-    "-v" "${REPO_PATH}:/scan"
-    "ghcr.io/praetorian-inc/noseyparker:latest"
-    "scan" "/scan"
-    "--datastore" "/tmp/np.db"
-)
-
-docker "${docker_args[@]}"
-```
+1. Read the pinned version from `versions.yaml` instead of hardcoding a tag
+2. Prefer a digest (`@sha256:...`) so the pull is reproducible
+3. Fail closed when the pull fails, rather than falling back to a local image
 
 **Verification:**
 
 ```bash
-# Test with malicious input
-./run_noseyparker_docker.sh "/tmp/repo; echo INJECTED"
-# Should fail with validation error, not execute injection
+grep -n 'IMAGE=' scripts/core/run_noseyparker_docker.sh
+# -> 27:IMAGE="ghcr.io/praetorian-inc/noseyparker:latest"
+
+python -c "import yaml;print(yaml.safe_load(open('versions.yaml'))['binary_tools']['noseyparker']['version'])"
+# -> 0.24.0
+# The tag the script runs must equal the version the registry pins.
+# Note the section: versions.yaml has no top-level `tools` key — entries live
+# under python_tools / binary_tools / special_tools / docker_images.
 ```
 
 **References:**
 
-- OWASP: Command Injection
-- CWE-78: Improper Neutralization of Special Elements used in OS Command
+- CWE-1357: Reliance on Insufficiently Trustworthy Component
+- `docs/VERSION_MANAGEMENT.md` — why tool versions live in `versions.yaml`
+
+> **Claim rejected during this audit — command injection via the repo path.**
+> An earlier draft of this report flagged `-v "$REPO_PATH:/scan"` as CWE-78 with
+> a `"/tmp/repo; rm -rf /"` payload. That is wrong, and the reasoning is worth
+> keeping: `docker` is executed directly, not through a shell, and the argument
+> is quoted, so the whole string arrives as **one** argv element. Verified by
+> substituting a stand-in for `docker` and printing argv:
+>
+> ```text
+> argv[4]=-v
+> argv[5]=/tmp/repo; rm -rf /:/repo:ro
+> ```
+>
+> `$(id)` likewise arrives literal — there is no second expansion pass. The
+> script additionally canonicalizes with `readlink -f` (:73), rejects a
+> non-directory (:78), and mounts read-only (:106). Before reporting injection,
+> identify the sink and confirm a shell actually parses the string there.
 
 ---
 
-### HIGH-002: Path Traversal in Results Directory Creation
+### HIGH-002: Path Traversal in Results Directory Creation — **NOT REPRODUCIBLE**
 
-**Location:** [scripts/cli/jmo.py:245](scripts/cli/jmo.py#L245)
+**Location:** [scripts/cli/scan_jobs/repository_scanner.py:212](scripts/cli/scan_jobs/repository_scanner.py#L212)
 
-**Description:**
-The `cmd_scan()` function creates result directories using user-controlled `--results-dir` without validating against path traversal attacks.
+**Description (as originally drafted):**
+The scan path was reported to create result directories from a user-controlled
+repo name without validating against path traversal.
 
-**Vulnerable Code:**
+**Reported code — note this is a *sketch*, not the code in the repo.**
+The real entry point is `cmd_scan()` at `scripts/cli/jmo.py:2839`, and there is
+no `iter_repos()` function anywhere in `scripts/`:
 
 ```python
 def cmd_scan(args):
@@ -259,74 +254,76 @@ def cmd_scan(args):
         out_dir.mkdir(parents=True, exist_ok=True)
 ```
 
-**Attack Scenario:**
+**Attack Scenario — tested, and it does not reproduce:**
 
 ```bash
-# Attacker creates malicious repo directory
 mkdir -p "/tmp/repos/../../../etc/malicious"
-
-# Run scan
 jmo scan --repos-dir /tmp/repos --results-dir /tmp/results
-
-# Creates: /tmp/results/individual-repos/../../../etc/malicious
-# Resolves to: /etc/malicious (writes outside intended directory)
 ```
-
-**Risk:**
-
-- **Likelihood:** Medium (requires attacker-controlled repo directory names)
-- **Impact:** High (arbitrary file write, potential privilege escalation)
-- **CWE:** CWE-22 (Path Traversal)
-
-**Remediation:**
-
-1. Sanitize all path components from user input
-2. Resolve paths and verify they're within expected parent
-3. Use `os.path.commonpath()` to validate containment
-
-**Fixed Code:**
 
 ```python
-def _safe_path_component(name: str) -> str:
-    """Sanitize a path component to prevent traversal."""
-    # Remove path separators and traversal sequences
-    safe = name.replace("/", "_").replace("\\", "_")
-    safe = safe.replace("..", "_")
-    # Remove leading dots (hidden files)
-    safe = safe.lstrip(".")
-    # Ensure non-empty
-    if not safe:
-        safe = "unknown"
-    return safe
-
-def cmd_scan(args):
-    results_dir = Path(args.results_dir).resolve()
-    results_dir.mkdir(parents=True, exist_ok=True)
-
-    for repo in iter_repos(args):
-        # Sanitize repo name to prevent traversal
-        safe_name = _safe_path_component(repo.name)
-        out_dir = results_dir / "individual-repos" / safe_name
-
-        # Verify output directory is within results_dir
-        try:
-            out_dir.resolve().relative_to(results_dir)
-        except ValueError:
-            _log(args, "ERROR", f"Path traversal detected: {repo.name}")
-            continue
-
-        out_dir.mkdir(parents=True, exist_ok=True)
+>>> Path('/tmp/repos/../../../etc/malicious').name
+'malicious'
+>>> _sanitize_path_component('malicious')
+'malicious'
+# out_dir -> /tmp/results/individual-repos/malicious   (inside results_dir)
 ```
+
+Two independent reasons it fails. `Path.name` is only the final component, so
+the traversal segments never reach the join; and `repository_scanner.py:212`
+puts that name through `_sanitize_path_component()` regardless. Feeding the
+sanitizer a raw traversal string directly still yields nothing escaping:
+
+```python
+>>> _sanitize_path_component('../../../etc/malicious')
+'______etc_malicious'
+>>> _sanitize_path_component('..')
+'_'
+```
+
+**Risk:** none as written — **this entry is retained as an example of a claim
+that must be dropped**, not as a finding. Do not report a traversal without
+running the join and showing the resulting path lands outside the parent.
+
+**Remediation: none required — the control already exists.**
+
+Do not propose writing a `_safe_path_component()` helper here.
+`scripts/cli/path_sanitizers.py` already provides `_sanitize_path_component()`,
+and all three scan job types route user-controlled names through it:
+
+```python
+# scripts/cli/scan_jobs/repository_scanner.py:212
+name = _sanitize_path_component(repo.name)
+# scripts/cli/scan_jobs/image_scanner.py:61
+safe_name = _sanitize_path_component(image)
+# scripts/cli/scan_jobs/iac_scanner.py:63
+safe_name = _sanitize_path_component(iac_path.stem)
+```
+
+Proposing a duplicate of an existing control is worse than reporting nothing: it
+implies the control is absent, and a second sanitizer with slightly different
+rules is a real future divergence. Grep for the defense before writing one.
 
 **Verification:**
 
 ```python
-# Unit test
+# Measured against scripts/cli/path_sanitizers.py, not assumed:
+from scripts.cli.path_sanitizers import _sanitize_path_component
+
 def test_path_traversal_prevention():
-    assert _safe_path_component("../../../etc/passwd") == "___etc_passwd"
-    assert _safe_path_component("normal-repo") == "normal-repo"
-    assert _safe_path_component("..hidden") == "hidden"
+    assert _sanitize_path_component("../../../etc/passwd") == "______etc_passwd"
+    assert _sanitize_path_component("normal-repo") == "normal-repo"
+    assert _sanitize_path_component("..hidden") == "_hidden"
+    assert _sanitize_path_component("nginx:latest") == "nginx_latest"
+    assert _sanitize_path_component("..") == "_"
 ```
+
+> The docstring examples in `path_sanitizers.py` disagree with these values —
+> they predict `'___etc_passwd'` and `'hidden'`. The docstring is wrong, not the
+> code: `/` → `_` runs *before* `..` → `_`, so separators count too, and the
+> `..` → `_` substitution happens before `lstrip(".")`, leaving nothing to
+> strip. Nothing executes those doctests (no `--doctest-modules` anywhere), so
+> the drift was never caught. **Run the function; do not copy its docstring.**
 
 **References:**
 
@@ -353,11 +350,13 @@ The HTML dashboard includes the full `raw` field from findings, which may contai
 **Remediation:**
 
 ```python
+import copy
+
 def write_html(findings: List[Dict], output_path: Path) -> None:
     # Sanitize sensitive fields before rendering
     sanitized = []
     for f in findings:
-        safe = f.copy()
+        safe = copy.deepcopy(f)
         # Remove potentially sensitive raw data
         if "raw" in safe:
             del safe["raw"]
@@ -370,6 +369,14 @@ def write_html(findings: List[Dict], output_path: Path) -> None:
     html = render_template(sanitized)
     output_path.write_text(html)
 ```
+
+> `f.copy()` is **shallow**: `safe["context"]` is the *same dict object* as
+> `f["context"]`, so assigning `"[REDACTED]"` overwrites the caller's finding.
+> Confirmed by running the shallow version — the input's
+> `context["fileContents"]` came back `'[REDACTED]'`. Every reporter that runs
+> after this one would then render redacted placeholders instead of real data.
+> `del safe["raw"]` is safe only because deletion touches the copy's own top
+> level; the nested mutation is what leaks. Use `copy.deepcopy`.
 
 ---
 
@@ -542,13 +549,36 @@ def _log_error(args, message: str, exc: Exception = None):
 
 **Location:** [scripts/core/reporters/html_reporter.py:50](scripts/core/reporters/html_reporter.py#L50)
 
-**Remediation:**
+**Remediation:** already present in the shipped template
+(`scripts/dashboard/index.html:8-12`) — but read the next paragraph before
+reporting it either way.
 
 ```html
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'unsafe-inline' 'self'; style-src 'unsafe-inline' 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none';">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta http-equiv="X-Frame-Options" content="DENY">
+<meta name="referrer" content="no-referrer">
+<meta name="robots" content="noindex, nofollow">
 ```
+
+> **What these actually do here — document intent, not enforcement.**
+> Three of the mechanisms above are inert in a `<meta>` tag: browsers ignore
+> `X-Frame-Options` and `X-Content-Type-Options` outside an HTTP response
+> header, and CSP's `frame-ancestors` is one of the directives (with `sandbox`
+> and `report-uri`) that a `<meta>` policy may not set. `referrer` and `robots`
+> are correct in meta form; the rest of the CSP applies.
+>
+> **Do not "fix" this by moving them to HTTP response headers.** JMo has no HTTP
+> server — `write_html()` writes `dashboard.html` to disk and the user opens it
+> from the filesystem, so there is no response for a header to ride on. There is
+> no Flask/FastAPI/`http.server` anywhere in the codebase. A recommendation to
+> set response headers is unactionable for this product.
+>
+> Note also that `tests/reporters/test_html_security.py` asserts these strings
+> are **present**, not that any browser enforces them — a green suite here is
+> not evidence of protection. If you want a real improvement, the honest one is
+> replacing `'unsafe-inline'` with per-build nonces or hashes on the generated
+> inline `<script>`/`<style>` blocks, which does work from a meta policy.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
+++ b/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
@@ -6,7 +6,7 @@
 
 ## Progress
 
-**79 / 103 resolved.**
+**92 / 103 resolved.**
 
 | Chunk | Scope | Findings | Done | Status |
 |---|---|---:|---:|---|
@@ -15,10 +15,10 @@
 | **C** | adapter-generator + test-fabricator | 15 | 15 | **complete** |
 | **D** | jmo-ci-debugger | 13 | 13 | **complete** |
 | **E** | target-type-expander + security-hardening | 19 | 19 | **complete** |
-| **F** | the 7 agents | 13 | 0 | not started |
+| **F** | the 7 agents | 13 | 13 | **complete** |
 | **G** | tail: refactoring, compliance, systematic-debugging, references | 11 | 0 | not started |
 | **H** | repo config authored by PR #717 | 6 | 6 | **complete** |
-| | **total** | **103** | **79** | |
+| | **total** | **103** | **92** | |
 
 ## How to mark a finding off
 
@@ -659,45 +659,162 @@ precise: a vague claim invites checking, a specific one does not.
   enforces 85%. Filed separately; template now says "Coverage: [NN]% (CI floor:
   70%)". Same correction applied to the target-type-expander checklist.
 
-## Chunk F - the 7 agents  (0/13)
+## Chunk F - the 7 agents  (13/13)
 
+Root-cause shape: **PHANTOM SYMBOLS**. Chunk F's example code names functions
+that do not exist (`compute_finding_id` x6, `load_noseyparker`, `iter_repos`,
+`_safe_path_component`, `CURRENT_SCHEMA_VERSION` in the wrong module) and mocks
+call sites the code under test never reaches. The reviewer saw the *consequences*
+(a count is wrong, a test won't run) without naming the cause, so 8 of 13
+findings understated their scope.
 
 **`.claude/agents/code-quality-auditor.md`**
 
-- [ ] **Major** L319: (claim nested; read from the PR conversation)
+- [x] **Major** L319 **FIXED, and the finding's remedy was not available.** The
+  claim checks out: `cvss` is `{"type": "number"}` in
+  `docs/schemas/common_finding.v1.json:23`, and the validator rejects the dict —
+  measured: `cvss: {'version': '3.x', 'score': 9.8, ...} is not of type
+  'number'`. But the suggested destination, "a separate schema-defined field"
+  for the vector, **does not exist** — the schema defines no vector property
+  (`additionalProperties: true` would permit inventing one, which is not the
+  same thing). Renamed to `_extract_cvss_score()` returning `float | None` and
+  documented that the vector stays reachable via `raw`. Ran the rewritten
+  example end-to-end against the real validator: **no schema errors**.
+  Same block: `compute_finding_id` does not exist anywhere in `scripts/`; the
+  function is `common_finding.fingerprint()` (16 hex chars). Fixed both sites.
+  *Two live defects surfaced, filed as **#757**, not fixed here:*
+  `grype_adapter.py:63` and `dependency_check_adapter.py:178` emit `cvss` as a
+  dict in production, so their findings fail schema validation; and nothing in
+  the normal pipeline validates real scan output (`schema_validator` is reached
+  only from `scan_validator.py`'s self-test).
 
 **`.claude/agents/coverage-gap-finder.md`**
 
-- [ ] **Major** L153: Make the proposed tests executable
+- [x] **Major** L153 **FIXED by rewriting against the real adapter.** Wider than
+  reported: it is not only that `sample = {...}` is a placeholder and
+  `raise_exception()` is undefined — `load_noseyparker` **does not exist** (the
+  API is `NoseyParkerAdapter().parse()`), and **2 of the 3 proposed tests assert
+  behaviour the adapter does not contain**. `noseyparker_adapter.py` has zero
+  `subprocess` / `shutil.which` / Docker references, so patching them exercises
+  nothing; the container runner is a separate shell script. The cited uncovered
+  lines were fiction too — "L68-71: error handling for missing binary" is
+  `PluginMetadata` fields, and "L89: empty results" is a docstring quote.
+  Replaced with 4 tests against real branches, and **executed them: 4 passed**.
+  Also fixed the summary that said "5/27 below threshold" over a list of 3.
 
 **`.claude/agents/dependency-analyzer.md`**
 
-- [ ] **Major** L50: Keep compliance enrichment in the report phase
-- [ ] **Major** L124: (claim nested; read from the PR conversation)
+- [x] **Major** L50 **FIXED, and the imports were worse than the phase error.**
+  Enrichment is now shown where it happens — `normalize_and_report.py:234`, once
+  over the deduped set — and removed from the adapter pattern. The two import
+  lines also contradicted each other, and the first named **two symbols that do
+  not exist** in `common_finding.py` (`compute_finding_id`,
+  `enrich_finding_with_compliance`; the latter is in `compliance_mapper.py`).
+  Measured: **1 of 27** adapters calls enrichment directly
+  (`semgrep_secrets_adapter.py:289`) — recorded as the outlier to remove, not a
+  pattern. Also replaced the stale `def load_<tool>(path)` contract with the
+  real `AdapterPlugin.parse()` shape.
+- [x] **Major** L124 **FIXED; every count in the section was wrong.** Adapters
+  11 -> 27 (28 `*_adapter.py` files, minus `base_adapter.py`, which has no
+  subclasses - #745). Reporters 5 -> **13**. And the migration scope missed its
+  biggest item: `CURRENT_SCHEMA_VERSION` exists **only** in the unused
+  `base_adapter.py:38`, while each of the 27 adapters hardcodes
+  `schema_version="1.2.0"` in its `PluginMetadata` — so a schema bump is 27
+  edits, not the 1 the checklist implied.
 
 **`.claude/agents/doc-sync-checker.md`**
 
-- [ ] **Major** L579: Fix the relative-link example
+- [x] **Major** L579 **FIXED — the example was inverted.** From
+  `docs/USER_GUIDE.md`, `[Release Process](RELEASE.md)` already resolves to
+  `docs/RELEASE.md`, which exists; the documented "fix" would have produced
+  `docs/docs/RELEASE.md`. The example presented a working link as broken. (The
+  cited line is fabricated regardless: `docs/USER_GUIDE.md` contains no
+  `RELEASE.md` link.) Replaced with a genuinely broken case — `README.md`
+  linking `USER_GUIDE.md` — and pointed at the repo's own resolver,
+  `check_doc_links.py:238` (`source.parent / path_part`).
 
 **`.claude/agents/release-readiness.md`**
 
-- [ ] **Major** L38: Push only the release tag
-- [ ] **Major** L310: Do not infer branch parity from a one-sided log range
-- [ ] **Major** L336: Run the image tag that the checklist builds
+- [x] **Major** L38 **FIXED at both sites, against the canonical procedure.**
+  `docs/RELEASE.md:24` is
+  `git fetch origin && git tag -a vX.Y.Z origin/main -m "vX.Y.Z" && git push
+  origin vX.Y.Z`. The agent diverged in **three** ways, not the one reported:
+  `--tags` publishes every local tag *and* every `v*` fires `release.yml`; the
+  tag was lightweight rather than annotated; and it was cut from local HEAD
+  rather than `origin/main`.
+- [x] **Major** L310 **FIXED.** `git log origin/main..HEAD` is one-sided and
+  silent when the remote is ahead. Now `git fetch origin main` +
+  `git rev-list --left-right --count origin/main...HEAD`, with either count
+  non-zero read as divergence.
+- [x] **Major** L336 **FIXED at both sites, plus two the finding missed.** The
+  build/run tag mismatch is real (builds `-deep`, runs `-full`). Two more in the
+  same blocks: **there is no bare `Dockerfile`** in this repo — only
+  `Dockerfile.{deep,fast,slim,balanced}` — so `docker build -f Dockerfile .`
+  fails outright at 3 sites; and the post-release checklist pulls
+  `:0.7.0-full`, a tag **removed in v1.0.5**.
 
 **`.claude/agents/security-auditor.md`**
 
-- [ ] **Major** L182: Correct the command-injection analysis
-- [ ] **Major** L273: Correct the path-traversal analysis
-- [ ] **Major** L551: (claim nested; read from the PR conversation)
+- [x] **Major** L182 **FIXED — HIGH-001 replaced, claim disproved by execution.**
+  Confirmed false: `docker` is invoked directly, not via a shell, and the
+  argument is quoted. Substituted a stand-in for `docker` and printed argv —
+  `/tmp/repo; rm -rf /:/repo:ro` arrives as a **single** `argv[5]`, and `$(id)`
+  arrives literal. Wider than reported: the quoted "vulnerable code" **is not in
+  the file** (no `REPO_PATH`; the real mount is `-v "$REPO_DIR:/repo:ro"`), the
+  anchor `:25` points at a color-logging helper, and the "fixed code" was
+  security theatre — identical safety, since the original was never unsafe.
+  Replaced with a real, verifiable finding at the same file: the image is pinned
+  to a floating `:latest` (`:27`) while `versions.yaml:80` pins `0.24.0`, and a
+  failed pull silently falls back to a stale local image. Kept the disproof as a
+  worked "claim rejected" example. **My own verification recipe failed on first
+  run** (`KeyError: 'tools'` — entries live under `binary_tools`); corrected and
+  re-run.
+- [x] **Major** L273 **FIXED — HIGH-002 marked NOT REPRODUCIBLE, with measured
+  output.** `Path('/tmp/repos/../../../etc/malicious').name` is `'malicious'`,
+  so the join lands *inside* `results_dir`. The finding named one defence; there
+  are **two** — `repository_scanner.py:212` also routes the name through
+  `_sanitize_path_component()`, which turns a raw `'../../../etc/malicious'`
+  into `'______etc_malicious'`. Deleted the "fixed code" that proposed writing
+  `_safe_path_component()`: that control **already exists** in
+  `scripts/cli/path_sanitizers.py` and is applied by all three scan job types.
+  Anchor was wrong too (`jmo.py:245`; `cmd_scan` is at `jmo.py:2839`) and
+  `iter_repos()` does not exist.
+  *Live defect surfaced, filed as **#758**:* the sanitizer's **own doctests are
+  wrong** — they predict `'___etc_passwd'` and `'hidden'` where the code returns
+  `'______etc_passwd'` and `'_hidden'`. **4 of 7 doctests in that module fail**,
+  and nothing runs them (no `--doctest-modules` anywhere).
+- [x] **Major** L551 **FIXED, consistent with chunk E's L331 verdict.** Same
+  inert-`<meta>` class: `X-Frame-Options` and `X-Content-Type-Options` are
+  header-only, and CSP's `frame-ancestors` is not settable from a meta policy.
+  The decisive fact the finding missed: **JMo has no HTTP server**, so "deliver
+  them as HTTP response headers" is unactionable — `write_html()` writes
+  `dashboard.html` to disk and the user opens it from the filesystem (no Flask /
+  FastAPI / `http.server` anywhere). Aligned the example CSP with what
+  production actually emits (`scripts/dashboard/index.html:8-12`, which was
+  strictly stronger than the doc's), documented these as intent rather than
+  enforcement, noted that `test_html_security.py` asserts *presence* only, and
+  kept nonce/hash as the one honest improvement.
 
 **`.claude/agents/codebase-explorer.md`**
 
-- [ ] **Minor** L18: (claim nested; read from the PR conversation)
+- [x] **Minor** L18 **FIXED, and the count was the least of it.** 28 vs 27 is
+  right — 28 `*_adapter.py` files, 27 tool adapters, `base_adapter.py` subclassed
+  by nothing (#745). Standardised on 27 with the discrepancy explained. The
+  larger defect, unmentioned: the pattern-summary template claimed "22/27
+  adapters call `enrich_finding_with_compliance()`" and **recommended adding it
+  to more** — i.e. recommended spreading an architecture violation. Real count:
+  **1 of 27**. Also fixed `Grep: compute_finding_id` (phantom symbol -> a dead-end
+  search) and the "read 3-4 adapters, then summarise about all" instruction that
+  produced these numbers. My first replacement asserted "all use
+  `safe_load_json_file()`" — **measured 24/27**, corrected before commit.
 
 **`.claude/agents/security-auditor.md`**
 
-- [ ] **Minor** L367: Avoid mutating input findings during redaction
+- [x] **Minor** L367 **FIXED.** `f.copy()` is shallow, so redacting
+  `safe["context"]["fileContents"]` overwrites the caller's finding. Executed
+  the doc's own snippet to confirm: the input's `context["fileContents"]` came
+  back `'[REDACTED]'`. Switched to `copy.deepcopy` and recorded why `del
+  safe["raw"]` is unaffected (top-level deletion touches only the copy).
 
 ## Chunk G - tail: refactoring, compliance, systematic-debugging, references  (0/11)
 


### PR DESCRIPTION
Chunk F of #718 — the 7 files in `.claude/agents/`. **13/13 resolved, tracker 79 → 92 of 103.**

## Root-cause shape: phantom symbols

A–E were fiction, staleness, speculation, and specificity. F is narrower and
more mechanical: **the example code names functions that do not exist**, and
mocks call sites the code under test never reaches.

| phantom | reality | sites |
|---|---|---:|
| `compute_finding_id` | `common_finding.fingerprint()` (16 hex chars) | 6 |
| `load_noseyparker(path)` | `NoseyParkerAdapter().parse(path)` | 3 |
| `iter_repos(args)` | does not exist | 2 |
| `_safe_path_component` | `_sanitize_path_component`, already shipped | 4 |
| `CURRENT_SCHEMA_VERSION` in `common_finding.py` | only in the unused `base_adapter.py:38` | 1 |
| `enrich_finding_with_compliance` in `common_finding.py` | it is in `compliance_mapper.py` | 3 |

The reviewer consistently saw the *consequence* (a count is wrong, a test will
not run) without naming the cause — so **8 of 13 findings understated their
scope**. Grepping the cited symbol first is what surfaced the rest.

## What each finding became

Full verdicts, one per finding, in the tracker. The ones worth reading here:

**Two claims were false and are now worked "rejected claim" examples.**

- **HIGH-001 command injection** (`security-auditor.md:182`). `docker` is
  invoked directly, not through a shell, and the argument is quoted. Proved it
  by substituting a stand-in for `docker` and printing argv: the payload
  `/tmp/repo; rm -rf /` arrives as a **single** `argv[5]`, and `$(id)` arrives
  literal. The quoted "vulnerable code" is not even in the file, the anchor
  `:25` points at a color-logging helper, and the "fixed code" was security
  theatre. Replaced with a real finding in the same script: the image is pinned
  to a floating `:latest` (`:27`) while `versions.yaml:80` pins `0.24.0`.
- **HIGH-002 path traversal** (`security-auditor.md:273`). `Path('/tmp/repos/
  ../../../etc/malicious').name` is `'malicious'`, so the join lands *inside*
  `results_dir`. Two defences, not the one reported —
  `repository_scanner.py:212` also sanitizes, turning a raw traversal string
  into `'______etc_malicious'`. Deleted the proposed helper: that control
  already exists and all three scan job types apply it.

**One remedy was unavailable as specified.** The `cvss` finding is correct —
the schema declares `number` and the validator rejects the dict — but its
suggested destination, "a separate schema-defined field" for the vector, does
not exist in the schema. Documented that the vector stays reachable via `raw`
rather than inventing a field.

**One decisive fact the finding missed.** The security-headers finding says to
deliver them as HTTP response headers. **JMo has no HTTP server** — `write_html()`
writes `dashboard.html` to disk and the user opens it from the filesystem. The
recommendation is unactionable for this product, so the meta tags are now
documented as intent rather than enforcement (consistent with chunk E's L331
verdict), with nonce/hash kept as the one honest improvement.

## Verification

Docs-only, so CI is genuinely sufficient for the change itself. Not optional,
and done: every claim checked against real code, and **every mechanism executed**.

| what | result |
|---|---|
| The 4 rewritten noseyparker tests, run verbatim | **4 passed** in 0.72s |
| Rewritten `cvss` example against the real validator | **no schema errors**; `id` 16 hex chars |
| Shallow-copy claim, executed | input's `context["fileContents"]` came back `'[REDACTED]'` — confirmed |
| `argv` probe for the injection claim | payload lands in one `argv[5]`; `$(id)` unexpanded |
| Sanitizer against the documented attack | `'malicious'` → `/tmp/results/individual-repos/malicious`, inside |
| `check_doc_links.py` | 161 tracked files, all resolve |
| pre-commit (markdownlint, doc-links, line endings) | all pass |
| `git diff --numstat` vs `--ignore-cr-at-eol --numstat` | identical |

**My own verification recipe failed on first run** — `KeyError: 'tools'`, because
`versions.yaml` has no top-level `tools` key (entries live under `binary_tools`).
Corrected and re-run. That is the third consecutive chunk in which a
self-authored recipe was wrong until executed.

## Two live defects surfaced — filed, not fixed here

- **#757** — `grype_adapter.py:63` and `dependency_check_adapter.py:178` emit
  `cvss` as a dict in production, so those findings fail schema validation. The
  larger half: **nothing validates real scan output** — `schema_validator` is
  reached only from `scan_validator.py`'s synthetic self-test.
- **#758** — `path_sanitizers.py` docstrings state the wrong security contract
  (`'___etc_passwd'` where the code returns `'______etc_passwd'`). **4 of 7
  doctests in that module fail**, and nothing runs them.

Also corrected mid-review: my first replacement for the adapter-count text
asserted "all use `safe_load_json_file()`". Measured **24/27**. Fixed before
commit — a remediation pass is exactly where a confident-sounding replacement
gets waved through.

## Remaining

**G (11)** is all that is left of the 103.
