### PR TITLE
docs(skills): #718 chunk G - the tail (11/11), tracker 103/103

### DIFF
--- a/.claude/skills/jmo-compliance-mapper/SKILL.md
+++ b/.claude/skills/jmo-compliance-mapper/SKILL.md
@@ -151,7 +151,9 @@ Output includes rank, category, score, previous rank, and trend.
 
 ### Phase 5: MITRE ATT&CK Mapping
 
-**Purpose:** Map to adversary tactics and techniques (ATT&CK for Enterprise v15.1)
+**Purpose:** Map to adversary tactics and techniques (ATT&CK for Enterprise v16.1
+— the version `scripts/core/compliance_frameworks.py` maps against; see
+[references/framework-version-updates.md](references/framework-version-updates.md))
 
 Map each CWE to tactics (e.g., TA0001 Initial Access), techniques (e.g., T1190), subtechniques, data sources, and mitigations. Example: CWE-79 maps to T1190 (Exploit Public-Facing Application) and T1552.001 (Credentials In Files).
 

--- a/.claude/skills/jmo-compliance-mapper/examples/compliance-report-examples.md
+++ b/.claude/skills/jmo-compliance-mapper/examples/compliance-report-examples.md
@@ -65,7 +65,7 @@ Reference examples for compliance report generation and output samples.
 |--------|-----------|-------|-------------|
 | Initial Access | T1190 (Exploit Public-Facing App) | 55 | M1048, M1050 |
 | Credential Access | T1552.001 (Credentials in Files) | 12 | M1047, M1027 |
-| Execution | T1059 (Command Injection) | 20 | M1038, M1042 |
+| Execution | T1059 (Command and Scripting Interpreter) | 20 | M1038, M1042 |
 
 **Attack Surface:** 3 tactics, 8 techniques
 
@@ -104,7 +104,7 @@ Generate JSON for MITRE ATT&CK Navigator visualization:
 {
   "name": "CWE-79 XSS Attack Techniques",
   "versions": {
-    "attack": "15.1",
+    "attack": "16.1",
     "navigator": "4.9.5",
     "layer": "4.5"
   },

--- a/.claude/skills/jmo-compliance-mapper/references/framework-version-updates.md
+++ b/.claude/skills/jmo-compliance-mapper/references/framework-version-updates.md
@@ -4,22 +4,42 @@ Procedures for tracking and updating compliance framework versions used by the c
 
 ## Current Framework Versions
 
-**All frameworks current as of 2025-10-24:**
+**These are the versions this mapper *emits*, not the newest releases upstream.**
+The authority is [`scripts/core/compliance_frameworks.py`](../../../../scripts/core/compliance_frameworks.py)
+— its module docstring lists all six, and the data below is copied from it:
 
-- OWASP Top 10: 2021 (current, next update: 2024 draft available, final 2025)
-- CWE Top 25: 2024 (current, released June 2024, next: June 2025)
-- CIS Controls: v8.1 (current, released May 2023, next: TBD 2025)
-- NIST CSF: 2.0 (current, released February 2024, next: ~2027)
-- PCI DSS: 4.0 (current, released March 2022, mandatory March 2025)
-- MITRE ATT&CK: v15 (current Oct 2024, quarterly updates: Jan/Apr/Jul/Oct 2025)
+| Framework | Version emitted | Where the code says so |
+|-----------|-----------------|------------------------|
+| OWASP Top 10 | 2021 | `CWE_TO_OWASP_TOP10_2021`; every category ID is `A01:2021`..`A10:2021` |
+| CWE Top 25 | 2024 | `CWE_TOP_25_2024` |
+| CIS Controls | v8.1 | module docstring |
+| NIST CSF | 2.0 | module docstring |
+| PCI DSS | 4.0 | module docstring |
+| MITRE ATT&CK | v16.1 | module docstring + `# MITRE ATT&CK v16.1 Mappings` |
+
+> **Do not "refresh" this table against upstream release notes.** Newer editions
+> exist for several of these, but writing them here would only make the document
+> disagree with the mapper. A framework version changes *here* when the mapping
+> data changes in `compliance_frameworks.py` — the code moves first.
 
 ## Update Schedule
+
+Upstream releases are the *trigger* to consider a code change, not a reason to
+edit this file on its own:
 
 - **Quarterly:** MITRE ATT&CK (check after each release)
 - **Annually:** CWE Top 25 (June), check others for updates
 - **As Announced:** OWASP Top 10, NIST CSF, CIS Controls, PCI DSS
 
+When upstream moves, the work is: update the mappings in
+`compliance_frameworks.py`, then update this table to match, then invalidate
+cached records written under the old version.
+
 ## Memory Expiration Strategy
+
+Records in `.jmo/memory/compliance/` carry the versions they were researched
+against, so a record is stale when its `framework_versions` no longer match the
+table above:
 
 ```json
 {
@@ -29,13 +49,17 @@ Procedures for tracking and updating compliance framework versions used by the c
     "cis_controls": "v8.1",
     "nist_csf": "2.0",
     "pci_dss": "4.0",
-    "mitre_attack": "v15"
+    "mitre_attack": "v16.1"
   },
-  "last_verified": "2025-10-24",
-  "expire_after_days": 90,
-  "next_check": "2026-01-24"
+  "last_verified": "2026-08-07",
+  "expire_after_days": 90
 }
 ```
+
+**Compare against the code, not against a date.** A `next_check` field was
+previously the only staleness signal here and it sat six months expired without
+anything noticing, because nothing reads it. Diffing `framework_versions`
+against `compliance_frameworks.py` is a check that cannot silently lapse.
 
 ## Quarterly Review Checklist
 
@@ -50,19 +74,25 @@ Procedures for tracking and updating compliance framework versions used by the c
 
 ### For Existing Projects
 
-1. **Run Bulk Mapping Script:**
+**There is no bulk mapping script, and none is needed.** Compliance enrichment is
+not an opt-in step — `jmo report` applies it to every finding automatically, in a
+single pass over the deduplicated set:
 
-```bash
-# Map all CWEs found in findings
-python3 scripts/dev/bulk_compliance_map.py results/summaries/findings.json
+```python
+# scripts/core/normalize_and_report.py:234
+deduped = enrich_findings_with_compliance(deduped)
 ```
 
-2. **Store in Memory:**
+So re-running the report is the whole upgrade path:
 
 ```bash
-# Stores mappings in .jmo/memory/compliance/
-# Future scans automatically use these mappings
+jmo report ./results
 ```
+
+> A `scripts/dev/bulk_compliance_map.py` was documented here for several
+> releases. It has never existed in this repository — `git ls-files` matches
+> nothing for it. Adapters return raw findings and enrichment happens centrally;
+> see the Enrichment Architecture section of [CLAUDE.md](../../../../CLAUDE.md).
 
 ### For New Projects
 

--- a/.claude/skills/jmo-compliance-mapper/references/memory-integration.md
+++ b/.claude/skills/jmo-compliance-mapper/references/memory-integration.md
@@ -98,7 +98,8 @@ after the framework moves. Returning `None` makes the refresh happen.
   "confidence": "high",
   "last_updated": "2025-09-15",
   "framework_versions": {
-    "owasp": "2021", "cwe_top_25": "2024", "cis": "8.1", "nist_csf": "2.0", "pci_dss": "4.0"
+    "owasp": "2021", "cwe_top_25": "2024", "cis": "8.1",
+    "nist_csf": "2.0", "pci_dss": "4.0", "mitre_attack": "16.1"
   },
   "created_by": "jmo-compliance-mapper v2.1.0"
 }
@@ -168,7 +169,7 @@ def store_compliance_mapping(
         "last_updated": datetime.now().isoformat(),
         "framework_versions": {
             "owasp": "2021", "cwe_top_25": "2024", "cis": "8.1",
-            "nist_csf": "2.0", "pci_dss": "4.0", "mitre_attack": "15.1"
+            "nist_csf": "2.0", "pci_dss": "4.0", "mitre_attack": "16.1"
         },
         "created_by": "jmo-compliance-mapper",
     }

--- a/.claude/skills/jmo-refactoring-assistant/SKILL.md
+++ b/.claude/skills/jmo-refactoring-assistant/SKILL.md
@@ -206,7 +206,15 @@ makefile = generate_makefile_target(config, command)
 
 ### 3. Update Test Files
 
-Split imports between modules, update function calls with new parameters, update mock paths (`@patch("wizard.X")` -> `@patch("wizard_generators.X")`).
+Split imports between modules and update function calls with new parameters.
+
+**Mock targets usually do not move.** Step 1 leaves `wizard.py` importing the
+function back (`from ... import generate_makefile_target`), so a test that mocks
+a call made *inside* `run_wizard` keeps `@patch("wizard.X")` — patching
+`wizard_generators.X` replaces the definition, not the name the caller resolves,
+and the mock silently never fires. See
+[references/test-migration-patterns.md](references/test-migration-patterns.md)
+Pattern 2 for the measured comparison.
 
 ### 4. Common Import Errors
 
@@ -219,12 +227,26 @@ Split imports between modules, update function calls with new parameters, update
 
 ---
 
-## Parameters
+## Invocation
 
-### Required
+This is a Claude Code skill, not a command-line program. There is no argument
+parser: the frontmatter declares `argument-hint: <refactoring-type>`, and
+`$ARGUMENTS` (line 12) receives everything after the skill name as one string.
 
-- `--target PATH`: File or directory to refactor
-- `--refactor-type TYPE`: One of the types below
+```text
+/jmo-refactoring-assistant split_file scripts/cli/jmo.py
+```
+
+Name the target and the refactoring type in plain language. The vocabulary below
+belongs in that sentence; it is not a flag set.
+
+> **Removed, not reworded.** Earlier revisions documented `--target`,
+> `--refactor-type`, `--function`, `--base-class-name`, `--max-lines`,
+> `--output-dir`, `--dry-run`, `--skip-tests`, `--preserve-coverage` and
+> `--avoid-circular-imports` as options. **None was ever implemented** — nothing
+> in this repository parses any of them. They are deleted rather than corrected
+> because a documented `--dry-run` reads as a guarantee that nothing is written,
+> and a documented `--skip-tests` reads as permission to skip Phase 4.
 
 ### Refactoring Types
 
@@ -238,16 +260,20 @@ Split imports between modules, update function calls with new parameters, update
 
 **`consolidate_duplicates`** - Merge duplicate code blocks. Detects similar patterns, creates shared utility functions.
 
-### Optional
+### Scope and Safety
 
-- `--function NAME`: Specific function to refactor (for extract_monolith)
-- `--base-class-name NAME`: Name for generated base class (for migrate_to_base_pattern)
-- `--max-lines N`: Maximum lines per file (for split_file, default: 500)
-- `--output-dir PATH`: Where to create new files (default: same directory)
-- `--dry-run`: Preview changes without applying
-- `--skip-tests`: Skip test migration (not recommended)
-- `--preserve-coverage`: Fail if coverage decreases (default: true)
-- `--avoid-circular-imports`: Use TYPE_CHECKING pattern (default: true)
+File access is whatever `allowed-tools` grants (`Read, Write, Edit, Glob, Grep,
+Bash`), mediated by Claude Code's permission prompts. **Nothing canonicalizes a
+path you name or rejects a `../` in it**, so the following are working rules for
+whoever runs the skill, not settings that enforce themselves:
+
+| Rule | Why it is not automatic |
+|------|-------------------------|
+| Refactor only inside this repository's working tree | A target resolving outside the tree is edited like any other; there is no containment check to fail |
+| New files land beside their source unless you say otherwise | There is no output directory to configure — say where you want them |
+| Always run Phase 4 (Test Migration) | It is the only regression guard this skill has; nothing detects that it was skipped |
+| Commit or stash before starting | Edits apply directly. There is no preview mode, so `git diff` is the review step |
+| Keep coverage at or above the pre-refactor number | Behaviour-preserving refactoring should not move it at all — a drop means tests were lost, not that a threshold was missed |
 
 ---
 

--- a/.claude/skills/jmo-refactoring-assistant/references/best-practices-troubleshooting.md
+++ b/.claude/skills/jmo-refactoring-assistant/references/best-practices-troubleshooting.md
@@ -10,11 +10,24 @@
 2. **Run tests:** `make test` (ensure baseline is green)
 3. **Check coverage:** `pytest --cov` (note current %)
 4. **Review agent findings:** Know what you're fixing
-5. **Check for circular import risks:** `grep -r "from.*import" | grep target_file`
+5. **Check for circular import risks:** find who imports the module you are about
+   to split. Substitute its bare module name — `target_file` below is a shell
+   variable, not a literal to search for:
+
+   ```bash
+   MODULE=wizard_generators   # bare module name of the file under refactor
+   git grep -n -E "^(from|import).*\b${MODULE}\b" -- 'scripts/**/*.py' 'tests/**/*.py'
+   ```
+
+   Scope it to paths and let git walk the index. A bare `grep -r "from.*import"`
+   over this repository descends into `.venv/`, `results/` and `graphify-out/`
+   and exceeds the agent Bash tool's 120-second timeout; the scoped form above
+   returns in **0.06s**.
 
 ### During Refactoring
 
-1. **Start with --dry-run:** Preview changes before applying
+1. **Review before applying:** there is no preview mode — edits land directly, so
+   the pre-refactor commit plus `git diff` is your dry run
 2. **One refactor at a time:** Don't combine multiple refactor types
 3. **Use TYPE_CHECKING for type hints:** Avoids circular imports
 4. **Apply parameter injection:** Pass dependencies explicitly
@@ -25,7 +38,12 @@
 ### After Refactoring
 
 1. **Run full test suite:** `make test`
-2. **Check coverage:** Should be >= before
+2. **Check coverage:** compare against the percentage you noted in step 3 above —
+   it should be **unchanged**. Behaviour-preserving refactoring does not move
+   coverage; a drop means tests stopped exercising the moved code, most often a
+   mock aimed at the wrong namespace (see test-migration-patterns.md Pattern 2).
+   Diff the number yourself: neither `make test` nor CI applies a
+   `--cov-fail-under` floor that would catch this for you
 3. **Run linters:** `make lint` or `ruff check && black --check`
 4. **Manual smoke test:** Verify key workflows still work
 5. **Update docstrings:** Note refactoring and cross-references
@@ -89,19 +107,25 @@
 
 **Cause:** Circular dependencies
 
-**Fix:** Use `--dry-run` to preview, manually resolve circular imports before applying. Use TYPE_CHECKING + parameter injection patterns.
+**Fix:** Ask for the proposed module split *before* any file is written, resolve
+the cycles on paper, then apply. Use TYPE_CHECKING + parameter injection patterns.
 
 ### "Coverage decreased"
 
-**Cause:** New code paths not tested
+**Cause:** New code paths not tested — or an existing test stopped reaching the
+moved code because its `@patch` target no longer resolves in the caller's
+namespace (test-migration-patterns.md Pattern 2). Rule out the second before
+writing new tests for the first; a silently-inert mock looks identical to an
+untested path in the coverage report.
 
-**Fix:** Use jmo-test-fabricator to generate tests for new modules
+**Fix:** Use jmo-test-fabricator to generate tests for genuinely new modules
 
 ### "Skill suggesting wrong split points"
 
 **Cause:** Complex function boundaries
 
-**Fix:** Use `--dry-run`, review proposed split, provide feedback for manual refinement
+**Fix:** Ask for the proposed split as a plan, review it, and give feedback before
+applying — then `git diff` against the pre-refactor commit to confirm what landed
 
 ### Common Import Errors Reference
 

--- a/.claude/skills/jmo-refactoring-assistant/references/memory-integration.md
+++ b/.claude/skills/jmo-refactoring-assistant/references/memory-integration.md
@@ -70,15 +70,21 @@ cat .jmo/memory/refactoring/circular-imports.json | jq '.solutions'
   "safety_checks": {
     "pre_refactor": [
       "git status (ensure clean working tree)",
-      "pytest --cov=scripts (baseline coverage)",
-      "git checkout -b refactor/extract-method"
+      "git rev-parse --abbrev-ref HEAD (record the base branch; do not assume main)",
+      "pytest --cov=scripts (record the baseline percentage)",
+      "git switch -c refactor/extract-method"
     ],
     "post_refactor": [
-      "pytest --cov=scripts --cov-fail-under=85",
+      "pytest --cov=scripts (compare against the recorded baseline)",
       "make lint (ensure no new violations)",
       "git diff (review all changes)"
     ],
-    "rollback": "git checkout main && git branch -D refactor/extract-method"
+    "rollback": [
+      "git stash -u (preserve uncommitted work; never discard it to switch away)",
+      "git switch - (return to the recorded base branch)",
+      "KEEP refactor/extract-method until its commits are confirmed reachable elsewhere",
+      "git branch -d refactor/extract-method (only after that; -d refuses unmerged work, which is the point)"
+    ]
   },
   "metadata": {
     "last_updated": "2025-10-24",
@@ -216,19 +222,30 @@ Memory stores proven coverage preservation techniques:
 
 ```json
 {
-  "strategy": "maintain-85-percent-coverage",
+  "strategy": "hold-coverage-at-the-recorded-baseline",
   "techniques": [
     {"name": "Baseline First", "command": "pytest --cov=scripts --cov-report=term-missing > baseline.txt"},
-    {"name": "Incremental Testing", "command": "pytest --cov=scripts.cli.jmo --cov-fail-under=85"},
-    {"name": "New Function Coverage", "command": "pytest --cov=scripts.cli.jmo::cmd_scan --cov-fail-under=90"}
+    {"name": "Incremental Testing", "command": "pytest --cov=scripts --cov-report=term-missing tests/cli/"},
+    {"name": "New Function Coverage", "command": "pytest --cov=scripts.cli.wizard_generators --cov-report=term-missing tests/unit/test_wizard_generators.py"}
   ],
   "rollback_if": [
-    "Coverage drops below 85%",
-    "New functions have <80% coverage",
+    "Total coverage is below the baseline recorded in baseline.txt",
+    "A file touched by the refactor lost coverage even though total held",
     "Integration tests fail"
   ]
 }
 ```
+
+**Compare against the baseline, not against a fixed percentage.** Earlier
+revisions of this file passed `--cov-fail-under=85` and `--cov-fail-under=90` and
+named the strategy `maintain-85-percent-coverage`. **No such floor exists in this
+repository**: `Makefile:132` runs `pytest --cov --cov-report=term-missing` with
+no threshold, `[tool.coverage.report]` in `pyproject.toml` sets no `fail_under`,
+and CI's only enforced gate is `coverage_pct < 70` at
+[`.github/workflows/ci.yml:734`](../../../../.github/workflows/ci.yml). A refactor
+that quietly drops coverage from 87% to 86% passes every one of those, which is
+exactly why the recorded baseline — not a constant — is the thing to diff against.
+Tracked as issue #756.
 
 ---
 

--- a/.claude/skills/jmo-refactoring-assistant/references/test-migration-patterns.md
+++ b/.claude/skills/jmo-refactoring-assistant/references/test-migration-patterns.md
@@ -32,19 +32,46 @@ def test_generate_makefile_target():
 
 ## Pattern 2: Mock Update
 
-**When tests mock extracted functions:**
+**When tests mock extracted functions:** patch the namespace the *caller* looks
+the name up in, which is usually **not** the module the function moved to.
+
+Extraction leaves the source module importing the function back:
 
 ```python
-# BEFORE
+# scripts/cli/wizard.py:119 -- the real shape after Task 3.6
+from scripts.cli.wizard_generators import generate_makefile_target
+```
+
+That `from X import Y` binds a **second** name, `wizard.generate_makefile_target`,
+and `run_wizard` resolves through it. Replacing the definition in
+`wizard_generators` leaves that binding untouched, so the mock never fires.
+
+```python
+# BEFORE -- and still correct when the test exercises run_wizard()
 @patch("wizard.generate_makefile_target")
 def test_run_wizard_emit_make(mock_gen):
     ...
 
-# AFTER
-@patch("wizard_generators.generate_makefile_target")  # Update module path
+# WRONG after extraction: patches the definition, not the name run_wizard calls
+@patch("wizard_generators.generate_makefile_target")
 def test_run_wizard_emit_make(mock_gen):
-    ...
+    ...  # mock_gen is never called; the real function runs
 ```
+
+**Measured**, on a two-module reproduction of the shape above:
+
+| Patch target | `run_wizard()` returns |
+|--------------|------------------------|
+| `wizard_generators.generate_makefile_target` | `REAL` -- patch is a no-op |
+| `wizard.generate_makefile_target` | `MOCKED` |
+
+Patch `wizard_generators.X` only when the test calls into `wizard_generators`
+directly, or when the caller kept a module reference (`import wizard_generators`
+then `wizard_generators.X()`), which resolves the attribute at call time.
+
+**Rule:** the patch target follows the *caller's* import style, not the
+function's new home. A move that changes Pattern 1's import path usually leaves
+Pattern 2's patch target exactly where it was.
 
 ---
 
@@ -71,7 +98,11 @@ def test_wizard_generates_makefile(tmp_path):
 - [ ] Identify all files importing extracted functions (`grep -r "from wizard import"`)
 - [ ] Split imports between old and new modules
 - [ ] Update function calls with new parameters
-- [ ] Update mock paths (`@patch("wizard.X")` -> `@patch("wizard_generators.X")`)
+- [ ] Re-check mock targets against the *caller's* namespace (Pattern 2) -- a
+      test that mocks a call made inside `wizard` keeps `@patch("wizard.X")`
+- [ ] Confirm each mock still fires (assert on `mock.called`, not just on the
+      return value -- a patch aimed at the wrong namespace fails silently)
 - [ ] Run tests after each file: `pytest tests/cli/test_wizard.py -xvs`
 - [ ] Verify no `TypeError: missing required positional argument` errors
-- [ ] Check coverage hasn't decreased: `pytest --cov`
+- [ ] Check coverage hasn't decreased: `pytest --cov` (compare against the
+      baseline captured before refactoring; there is no threshold flag to rely on)

--- a/.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md
+++ b/.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md
@@ -96,24 +96,41 @@ THEN investigate that specific component
 **Example (multi-layer system):**
 
 ```bash
-# Layer 1: Workflow
-echo "=== Secrets available in workflow: ==="
+# Layer 1: Workflow -- did the secret arrive at all?
+echo "=== Secret reaches the workflow: ==="
 echo "IDENTITY: ${IDENTITY:+SET}${IDENTITY:-UNSET}"
 
-# Layer 2: Build script
-echo "=== Env vars in build script: ==="
-env | grep IDENTITY || echo "IDENTITY not in environment"
+# Layer 2: Build script -- did it survive the process boundary?
+echo "=== Secret reaches the build script: ==="
+env | cut -d= -f1 | grep -qx IDENTITY \
+  && echo "IDENTITY: present in environment" \
+  || echo "IDENTITY: absent from environment"
 
-# Layer 3: Signing script
+# Layer 3: Signing script -- is a usable identity on the search list?
 echo "=== Keychain state: ==="
-security list-keychains
-security find-identity -v
+security list-keychains                                    # paths only
+security find-identity -v -p codesigning | tail -1         # count line, not the list
 
-# Layer 4: Actual signing
-codesign --sign "$IDENTITY" --verbose=4 "$APP"
+# Layer 4: Actual signing -- succeed/fail, without dumping internals
+codesign --sign "$IDENTITY" "$APP" && codesign --verify "$APP"
 ```
 
 **This reveals:** Which layer fails (secrets -> workflow OK, workflow -> build FAIL)
+
+**Every probe answers set-or-unset, never what the value is.** A bisection log is
+read by whoever can see the CI run, and CI logs are retained and widely readable
+— printing a credential into one is CWE-532, not a debugging convenience. The
+concrete traps this example used to contain:
+
+| Instead of | Use | Why |
+|------------|-----|-----|
+| `env \| grep IDENTITY` | the `cut -d= -f1` form above | `grep` on `env` prints `IDENTITY=<the actual value>`. Verified: with `IDENTITY` set, it echoed the credential verbatim; the replacement prints only `present`/`absent` |
+| `security find-identity -v` | `... -p codesigning \| tail -1` | The unfiltered form lists certificate hashes and common names for every identity |
+| `codesign --verbose=4` | plain sign, then `codesign --verify` | Verbosity 4 dumps signing internals; you only need the exit status to locate the failing layer |
+
+GitHub Actions masks values registered with `add-mask`, but that covers only what
+it knows about — a value derived, decoded, or re-exported inside the job is not
+masked. Do not rely on it as the redaction layer.
 
 **JMo-specific component boundaries:**
 

--- a/.claude/skills/references/memory-integration-pattern.md
+++ b/.claude/skills/references/memory-integration-pattern.md
@@ -46,7 +46,9 @@ mkdir -p .jmo/memory/{namespace}
 cat > .jmo/memory/{namespace}/{key}.json << 'EOF'
 {
   "tool": "tool-name",
-  "patterns": { ... },
+  "patterns": {
+    "example_pattern": "example value"
+  },
   "metadata": {
     "last_updated": "2026-02-15",
     "usage_count": 1,
@@ -55,6 +57,13 @@ cat > .jmo/memory/{namespace}/{key}.json << 'EOF'
 }
 EOF
 ```
+
+The `patterns` object must contain real key/value pairs. A bare `...` placeholder
+is not valid JSON, so a file written from this heredoc cannot be read back by the
+`jq` call in step 2 — measured with a strict parser, the old form fails with
+`Expecting property name enclosed in double quotes: line 3 column 17` while the
+form above parses. `{namespace}` and `{key}` are path placeholders you
+substitute; the JSON body is written literally, so it has to be valid on its own.
 
 ## Storage Format (JSON)
 

--- a/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
+++ b/docs/superpowers/plans/2026-08-05-published-skills-remediation-tracker.md
@@ -6,7 +6,7 @@
 
 ## Progress
 
-**92 / 103 resolved.**
+**103 / 103 resolved.**
 
 | Chunk | Scope | Findings | Done | Status |
 |---|---|---:|---:|---|
@@ -16,9 +16,9 @@
 | **D** | jmo-ci-debugger | 13 | 13 | **complete** |
 | **E** | target-type-expander + security-hardening | 19 | 19 | **complete** |
 | **F** | the 7 agents | 13 | 13 | **complete** |
-| **G** | tail: refactoring, compliance, systematic-debugging, references | 11 | 0 | not started |
+| **G** | tail: refactoring, compliance, systematic-debugging, references | 11 | 11 | **complete** |
 | **H** | repo config authored by PR #717 | 6 | 6 | **complete** |
-| | **total** | **103** | **92** | |
+| | **total** | **103** | **103** | **complete** |
 
 ## How to mark a finding off
 
@@ -816,30 +816,121 @@ findings understated their scope.
   back `'[REDACTED]'`. Switched to `copy.deepcopy` and recorded why `del
   safe["raw"]` is unaffected (top-level deletion touches only the copy).
 
-## Chunk G - tail: refactoring, compliance, systematic-debugging, references  (0/11)
+## Chunk G - tail: refactoring, compliance, systematic-debugging, references  (11/11)
 
+Root-cause shape: **UNBUILT SURFACE.** Three findings ask for controls on a CLI
+that was never written; two more chase upstream releases for a table whose real
+authority is a module in this repo. The reviewer treated documentation as a
+description of software that exists. Where it wasn't, the fix is to delete the
+surface, not to harden it.
 
 **`.claude/skills/jmo-compliance-mapper/references/framework-version-updates.md`**
 
-- [ ] **Major** L14: (claim nested; read from the PR conversation)
+- [x] **Major** L14 **FIXED, but not in the direction asked.** The finding says
+  refresh OWASP/CWE/ATT&CK to current public releases (2025 / 2025 / v19.1).
+  **That would have been wrong.** This table documents what the mapper *emits*,
+  and `scripts/core/compliance_frameworks.py:6-11` is the authority: OWASP 2021,
+  CWE Top 25 2024, CIS v8.1, NIST CSF 2.0, PCI DSS 4.0 are all **correct** — the
+  code literally emits `A01:2021`..`A10:2021` and names its constants
+  `CWE_TO_OWASP_TOP10_2021` / `CWE_TOP_25_2024`. Writing 2025 here would have
+  made the doc lie about the code. **One version genuinely was wrong**, and the
+  finding half-saw it: ATT&CK. Doc said `v15`; code says **v16.1** at
+  `compliance_frameworks.py:11,783`, `compliance_mapper.py:11,790`,
+  `TESTING_MATRIX.md:14,243`. Corrected across **5 sites** (finding named 3):
+  `framework-version-updates.md:14,32`, `SKILL.md:154` (`v15.1`),
+  `compliance-report-examples.md:107` (`"attack": "15.1"`),
+  `references/memory-integration.md:171` (`"mitre_attack": "15.1"`). Reframed the
+  section so the code is the stated oracle and upstream releases are a trigger to
+  change code, not this file. Dropped `next_check` — it sat 6 months expired
+  because nothing reads it; a diff against the module cannot silently lapse.
+  **Unmentioned by the finding, in the same file:** L57 told the reader to run
+  `python3 scripts/dev/bulk_compliance_map.py`, which **has never existed**
+  (`git ls-files` matches nothing). Replaced with the real path — enrichment is
+  automatic and central at `normalize_and_report.py:234`.
 
 **`.claude/skills/jmo-refactoring-assistant/SKILL.md`**
 
-- [ ] **Major** L86: Enforce the 85% coverage floor in every refactoring checklist
-- [ ] **Major** L250: (claim nested; read from the PR conversation)
-- [ ] **Major** L250: Do not expose an unrestricted `--skip-tests` path
+- [x] **Major** L86 **DISMISSED as written; the real defect was elsewhere in the
+  skill.** The finding asks to require `pytest --cov-fail-under=85` in three
+  checklists "because CI enforces 85%". **Nothing enforces 85%** — measured:
+  `Makefile:132` is `pytest --cov --cov-report=term-missing` with no threshold,
+  `[tool.coverage.report]` in `pyproject.toml` sets no `fail_under`, and a repo
+  scan finds `--cov-fail-under` **only** in `.claude/` prose and docs. CI's one
+  gate is `coverage_pct < 70` (`ci.yml:734`); the comment above it claiming
+  "Full 85% coverage is still enforced via `make test`" is itself false. Adding
+  the flag would have propagated an unenforceable gate — that is **#756**. The
+  three cited sites say "coverage must be >= before", which is *correct* advice
+  for behaviour-preserving refactoring, so they were kept and sharpened
+  (compare against a recorded baseline; a drop means tests were lost).
+  **The finding pointed at three sites that were fine and missed two that were
+  not:** `references/memory-integration.md:77,222-223` asserted
+  `--cov-fail-under=85` and `=90` and named the strategy
+  `maintain-85-percent-coverage`. Those are fixed.
+- [x] **Major** L250 (path traversal on `--target` / `--output-dir`)
+  **FIXED by deleting the fiction.** The finding says to canonicalize both paths
+  and reject traversal "before any read, edit, or write operation". There is
+  **no program to put that in.** `--target`, `--refactor-type`, `--function`,
+  `--base-class-name`, `--max-lines`, `--output-dir`, `--dry-run`,
+  `--skip-tests`, `--preserve-coverage`, `--avoid-circular-imports` appear
+  **nowhere in this repository** outside two skill docs — no argparse, no entry
+  point. The frontmatter says `argument-hint: <refactoring-type>` and `$ARGUMENTS`
+  takes one free-text string. Replaced `## Parameters` with `## Invocation`
+  (how the skill is really called) plus a `### Scope and Safety` table that
+  states containment as a working rule **and says plainly that nothing enforces
+  it** — which is the actionable form of the finding for a prompt document.
+- [x] **Major** L250 (`--skip-tests`) **FIXED — same root cause, same edit.**
+  Removed rather than reworded: a documented `--skip-tests` reads as permission
+  to skip Phase 4, and a documented `--dry-run` reads as a guarantee that nothing
+  is written. Both are false. Swept the rest of the skill for the same fiction
+  and found two more live references telling readers to "Use `--dry-run`"
+  (`best-practices-troubleshooting.md:110,122`) — both rewritten.
+  **Sibling not touched, deliberately:** `jmo-security-hardening/SKILL.md:139`
+  has an identical fictional `## Parameters` block with its own `--skip-tests`.
+  That file is chunk E's and E is closed; filed separately rather than reopening
+  a completed tally. Grep confirms the class is exactly these two skills.
 
 **`.claude/skills/jmo-refactoring-assistant/references/test-migration-patterns.md`**
 
-- [ ] **Major** L47: (claim nested; read from the PR conversation)
+- [x] **Major** L47 **FIXED, and confirmed by execution.** Pattern 2 told readers
+  to rewrite `@patch("wizard.X")` as `@patch("wizard_generators.X")` after
+  extraction. That is backwards. The skill's own step 1 leaves the caller doing
+  `from ... import X` — the real shape at `scripts/cli/wizard.py:119` — so
+  `run_wizard` resolves through `wizard.X`, and patching the definition in
+  `wizard_generators` never fires. Reproduced the two-module shape and ran it:
+  patching `wizard_generators.…` returned **`REAL`** (no-op), patching
+  `wizard.…` returned **`MOCKED`**. Rewrote Pattern 2 with that table, added the
+  rule (the patch target follows the *caller's* import style, not the function's
+  new home), and fixed the **third** site the finding did not list — the
+  migration checklist at L74 repeated the same bad rewrite. Added a
+  `mock.called` assertion to the checklist because a mis-aimed patch fails
+  **silently**: the real function just runs.
 
 **`.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md`**
 
-- [ ] **Major** L110: (claim nested; read from the PR conversation)
+- [x] **Major** L110 **FIXED; one of its two anchors was wrong.** The finding
+  claims the leaky block also lives at `jmo-systematic-debugging/SKILL.md#L99-L110`.
+  It does not — `IDENTITY`, `codesign` and `security` appear in **zero** lines of
+  that file (L99-110 there is a list of red-flag phrases). Only
+  `detailed-phase-guide.md` has it. It also mis-quotes the command as
+  `codesign --verbose=4 "$IDENTITY"`; the file says
+  `codesign --sign "$IDENTITY" --verbose=4 "$APP"`. The substance holds: L105's
+  `env | grep IDENTITY` prints the credential. **Demonstrated** — with `IDENTITY`
+  set to a sentinel it echoed `IDENTITY=Developer ID Application: SECRET-VALUE-12345`
+  verbatim; the replacement (`env | cut -d= -f1 | grep -qx IDENTITY`) prints only
+  `present`/`absent`, verified in both branches. Layer 1 already used the safe
+  set/unset idiom, so the file was inconsistent with itself. Also narrowed
+  `security find-identity -v` to its count line and dropped `--verbose=4`.
+  **Not executed:** the `security`/`codesign` lines are macOS-only and this is a
+  Windows box — those two changes are verbosity reductions reasoned from their
+  documented behaviour, not measured, and the tracker should say so.
 
 **`.claude/skills/jmo-compliance-mapper/examples/compliance-report-examples.md`**
 
-- [ ] **Minor** L69: (claim nested; read from the PR conversation)
+- [x] **Minor** L69 **FIXED, on in-repo evidence rather than the web.** The
+  finding cites attack.mitre.org for the technique name. The repo answers it
+  directly: `compliance_frameworks.py:808` and `:897` both set
+  `"techniqueName": "Command and Scripting Interpreter"` for T1059. The example
+  said `T1059 (Command Injection)` — a name the mapper never emits. Corrected.
 
 **`.claude/skills/jmo-compliance-mapper/references/memory-integration.md`**
 
@@ -847,19 +938,43 @@ findings understated their scope.
 > findings). The JSON example below was **deliberately left alone** so the chunk
 > tallies stay honest - it belongs to G, not D.
 
-- [ ] **Minor** L67: Keep the framework-version schema complete
+- [x] **Minor** L67 **FIXED.** The Example Memory Hit's `framework_versions`
+  carried five keys while `frameworks` right above it carried six, and
+  `store_compliance_mapping` in the same file writes all six. Added
+  `mitre_attack`, matching the writer's key set and value exactly (`"16.1"`,
+  per the version correction above). The finding's line reference (94-98) points
+  at the `mitre_attack` block inside `frameworks`, not at `framework_versions`;
+  the defect it describes is real regardless.
 
 **`.claude/skills/jmo-refactoring-assistant/references/best-practices-troubleshooting.md`**
 
-- [ ] **Minor** L13: Use the selected target in the import search
+- [x] **Minor** L13 **FIXED, and the command was worse than the finding said.**
+  `grep -r "from.*import" | grep target_file` does search for the literal
+  `target_file` — but the recursive half is also a documented failure in this
+  repo: unscoped `grep -r` descends into `.venv/`, `results/` and `graphify-out/`
+  and **exceeds the Bash tool's 120s timeout** (it did so twice while working
+  this chunk). Replaced with a `MODULE=` variable and
+  `git grep -n -E "^(from|import).*\b${MODULE}\b" -- 'scripts/**/*.py' 'tests/**/*.py'`,
+  executed: **6 real callers in 0.056s**.
 
 **`.claude/skills/references/memory-integration-pattern.md`**
 
-- [ ] **Minor** L56: Write valid JSON in the storage example
+- [x] **Minor** L56 **FIXED, verified by parsing both forms.** `"patterns": { ... }`
+  is not valid JSON, so step 2's `jq '.patterns'` cannot read a file step 3
+  wrote. Ran both through a strict parser: the old form fails with
+  `Expecting property name enclosed in double quotes: line 3 column 17`, the new
+  form parses. (`jq` is not installed on this box, so the claim is stated against
+  the parser actually used — not asserted about jq's exit code.)
 
 **`.claude/skills/jmo-refactoring-assistant/references/memory-integration.md`**
 
-- [ ] **Trivial** L81: Make rollback non-destructive
+- [x] **Trivial** L81 **FIXED.** `git checkout main && git branch -D refactor/…`
+  had three problems, not one: it hardcodes `main` (this repo branches off and
+  merges into `dev`), `-D` force-deletes commits that may be reachable nowhere
+  else, and it discards uncommitted work to switch away. Replaced with a
+  sequence that records the base branch instead of assuming it, stashes with
+  `-u`, keeps the branch until its commits are confirmed reachable, and uses
+  `git branch -d` — whose refusal on unmerged work *is* the safety property.
 
 ## Chunk H - repo config authored by PR #717  (6/6)
 


### PR DESCRIPTION
Closes the final chunk of the PR #717 review remediation. **Tracker goes 92 -> 103/103.**

## Root-cause shape: UNBUILT SURFACE

Prior chunks were FICTION (A), STALENESS (B), SPECULATION (D), SPECIFICITY (E), PHANTOM SYMBOLS (F). G's tail is a distinct shape: **the reviewer treated documentation as a description of software that exists.** Three findings ask for controls on a CLI that was never written; two more chase upstream framework releases for a table whose real authority is a module in this repo. Where the surface doesn't exist, the fix is to delete it, not harden it.

## Dispositions: 10 FIXED, 1 DISMISSED-with-fix-elsewhere

| Finding | Verdict |
|---|---|
| `framework-version-updates.md` L14 - stale framework versions | FIXED, **opposite direction** to the ask |
| `refactoring-assistant/SKILL.md` L86 - enforce 85% floor | **DISMISSED**; real defect was 2 sites it missed |
| `SKILL.md` L250 - path traversal on `--target`/`--output-dir` | FIXED by deleting the fiction |
| `SKILL.md` L250 - unrestricted `--skip-tests` | FIXED, same edit |
| `test-migration-patterns.md` L47 - mock patch namespace | FIXED, **confirmed by execution** |
| `detailed-phase-guide.md` L110 - redact identity diagnostics | FIXED; **1 of its 2 anchors was wrong** |
| `compliance-report-examples.md` L69 - T1059 technique name | FIXED on in-repo evidence |
| `compliance-mapper/memory-integration.md` L67 - missing `mitre_attack` | FIXED |
| `best-practices-troubleshooting.md` L13 - literal `target_file` | FIXED, worse than reported |
| `references/memory-integration-pattern.md` L56 - invalid JSON | FIXED, both forms parsed |
| `refactoring-assistant/memory-integration.md` L81 - destructive rollback | FIXED |

## The three that needed the finding overturned

**1. "Refresh the framework versions."** The finding wants OWASP 2025 / CWE 2025 / ATT&CK v19.1. That would have been **wrong** — this table documents what the mapper *emits*, and `scripts/core/compliance_frameworks.py:6-11` is the authority. The code emits `A01:2021`..`A10:2021` and names its constants `CWE_TO_OWASP_TOP10_2021` / `CWE_TOP_25_2024`. Writing 2025 would make the doc contradict the code.

One version genuinely *was* wrong and the finding half-saw it: ATT&CK. Doc said `v15`, code says **v16.1** (`compliance_frameworks.py:11,783`, `compliance_mapper.py:11,790`, `TESTING_MATRIX.md:14,243`). Corrected across **5 sites**; the finding named 3.

**2. "Enforce the 85% coverage floor."** Nothing enforces 85%. Measured:

| Where | What it actually says |
|---|---|
| `Makefile:132` | `pytest --cov --cov-report=term-missing` - no threshold |
| `pyproject.toml [tool.coverage.report]` | no `fail_under` |
| `ci.yml:734` | `if coverage_pct < 70` - the only enforced gate |
| repo-wide `--cov-fail-under` | `.claude/` prose and docs only |

`ci.yml:732`'s own comment ("Full 85% coverage is still enforced via `make test`") is false. Adding the flag would propagate an unenforceable gate - that is #756. The three cited sites say "coverage must be >= before", which is correct for behaviour-preserving refactoring, so they were kept and sharpened. **The finding pointed at three sites that were fine and missed two that were not**: `refactoring-assistant/references/memory-integration.md:77,222-223` asserted `--cov-fail-under=85`/`=90`. Those are fixed.

**3. "Constrain refactoring paths / restrict `--skip-tests`."** There is no program to put a path check in. `--target`, `--refactor-type`, `--function`, `--base-class-name`, `--max-lines`, `--output-dir`, `--dry-run`, `--skip-tests`, `--preserve-coverage`, `--avoid-circular-imports` appear **nowhere in this repository** outside two skill docs. The frontmatter declares `argument-hint: <refactoring-type>` and `$ARGUMENTS` takes one free-text string. Replaced `## Parameters` with `## Invocation` plus a Scope-and-Safety table that states containment as a working rule **and says plainly that nothing enforces it** - the actionable form for a prompt document.

## Verification

Docs-only, so CI is genuinely sufficient for the diff itself. Not optional, and done:

- **Mock-patch claim, executed.** Reproduced the two-module shape from `scripts/cli/wizard.py:119`. Patching `wizard_generators.generate_makefile_target` -> `run_wizard()` returns **`REAL`** (no-op). Patching `wizard.generate_makefile_target` -> **`MOCKED`**. The documented guidance was backwards.
- **JSON claim, executed.** Old heredoc: `Expecting property name enclosed in double quotes: line 3 column 17`. New: parses, `.patterns` = `{"example_pattern": "example value"}`.
- **Credential leak, demonstrated.** With a sentinel value, `env | grep IDENTITY` echoed `IDENTITY=Developer ID Application: SECRET-VALUE-12345` verbatim. Replacement prints only `present`/`absent`, verified in both branches.
- **Replacement grep, executed.** `git grep` scoped form returns **6 real callers in 0.056s**; the form it replaces exceeds the 120s tool timeout.
- **`check_doc_links.py`**: 161 tracked files, all links resolve, exit 0 (new 4-level relative links included).
- **GFM pipe escape**, checked against `gh api markdown`: `\|` renders a 3-cell row with a literal pipe inside the code span.
- **Line endings**: `git diff --numstat` equals `--ignore-cr-at-eol --numstat` on all 11 files.
- **Pre-commit**: all applicable hooks pass (markdownlint, doc-links, mixed-line-ending).

**Stated limit:** the `security find-identity` / `codesign --verbose=4` changes are macOS-only and this is a Windows box. Those two are verbosity reductions reasoned from documented behaviour, **not measured**. Everything else above was run.

## Wrong anchors and understated scope (the recurring pattern)

- **Wrong anchor:** `detailed-phase-guide.md` L110's finding claims a sibling at `jmo-systematic-debugging/SKILL.md#L99-L110`. `IDENTITY`/`codesign`/`security` appear in **zero** lines of that file. It also mis-quotes the command as `codesign --verbose=4 "$IDENTITY"`; the file says `codesign --sign "$IDENTITY" --verbose=4 "$APP"`.
- **Understated scope, 5 of 11 findings:** ATT&CK version (3 named, 5 real), mock targets (2 named, 3 real), coverage floors (3 named sites were fine, 2 unnamed were wrong), `--dry-run` references (2 extra live sites), and `bulk_compliance_map.py` - a script cited at `framework-version-updates.md:57` that **has never existed** and no finding mentioned.

## Deliberately not touched

`jmo-security-hardening/SKILL.md:139` carries an identical fictional `## Parameters` block with its own `--skip-tests`. That file belongs to **chunk E, which is closed** - fixing it here would muddy a completed tally. Filed separately. Grep confirms the class is exactly these two skills.

Refs #718