### PR TITLE
fix(schema): cvss is an object, and prove it stays that way

### DIFF
--- a/.claude/skills/jmo-dashboard-builder/SKILL.md
+++ b/.claude/skills/jmo-dashboard-builder/SKILL.md
@@ -181,7 +181,7 @@ export interface CommonFinding {
   remediation?: string
   references?: string[]
   tags?: string[]
-  cvss?: number
+  cvss?: { version?: string; score: number; vector?: string }
   context?: { snippet?: string; lines?: string[] }
   compliance?: {
     owaspTop10_2021?: string[]

--- a/docs/schemas/common_finding.v1.json
+++ b/docs/schemas/common_finding.v1.json
@@ -20,7 +20,16 @@
     "message": { "type": "string" },
     "description": { "type": "string" },
     "severity": { "type": "string", "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"] },
-    "cvss": { "type": "number" },
+    "cvss": {
+      "type": "object",
+      "description": "Best available CVSS score. Adapters select v3 over v2 and keep the vector, so the score stays auditable. Omitted entirely when the tool reports no score -- Finding.to_dict() drops None, so this is never null.",
+      "required": ["score"],
+      "properties": {
+        "version": { "type": "string", "description": "CVSS revision, e.g. \"3.x\" or \"2.0\"" },
+        "score": { "type": "number", "minimum": 0, "maximum": 10, "description": "Base score" },
+        "vector": { "type": "string", "description": "Base vector string, e.g. \"AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"" }
+      }
+    },
     "tool": {
       "type": "object",
       "required": ["name", "version"],

--- a/scripts/core/common_finding_schema.json
+++ b/scripts/core/common_finding_schema.json
@@ -20,7 +20,16 @@
     "message": { "type": "string" },
     "description": { "type": "string" },
     "severity": { "type": "string", "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"] },
-    "cvss": { "type": "number" },
+    "cvss": {
+      "type": "object",
+      "description": "Best available CVSS score. Adapters select v3 over v2 and keep the vector, so the score stays auditable. Omitted entirely when the tool reports no score -- Finding.to_dict() drops None, so this is never null.",
+      "required": ["score"],
+      "properties": {
+        "version": { "type": "string", "description": "CVSS revision, e.g. \"3.x\" or \"2.0\"" },
+        "score": { "type": "number", "minimum": 0, "maximum": 10, "description": "Base score" },
+        "vector": { "type": "string", "description": "Base vector string, e.g. \"AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"" }
+      }
+    },
     "tool": {
       "type": "object",
       "required": ["name", "version"],

--- a/scripts/dashboard/src/types/findings.ts
+++ b/scripts/dashboard/src/types/findings.ts
@@ -27,7 +27,11 @@ export interface CommonFinding {
   }
   references?: string[]
   tags?: string[]
-  cvss?: number
+  cvss?: {
+    version?: string
+    score: number
+    vector?: string
+  }
   context?: {
     snippet?: string
     lines?: string[]

--- a/tests/adapters/test_adapter_schema_conformance.py
+++ b/tests/adapters/test_adapter_schema_conformance.py
@@ -1,0 +1,201 @@
+"""
+Contract tests: real adapter output must validate against the published schema.
+
+The gap these close: `docs/schemas/common_finding.v1.json` is the schema JMo
+publishes, but nothing ever validated *actual scan output* against it.
+`schema_validator` was imported only by `scripts/core/validators/scan_validator.py`,
+and only with synthetic inputs (`validate_finding({})`, `validate_findings([])`) --
+that checks the validator, not the adapters.
+
+So the two drifted. The schema declared `"cvss": {"type": "number"}` while every
+producer emitted an object and `history_db.py` read `.get("score")` off it. The
+schema was wrong for at least three releases and no test could notice, because no
+test ever fed it a real finding.
+
+These tests feed it real findings. They are cheap because they reuse each
+adapter's own parse path -- no tools required, no network.
+
+See issue #757.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.core.schema_validator import (
+    JSONSCHEMA_AVAILABLE,
+    load_schema,
+    validate_finding,
+)
+
+pytestmark = pytest.mark.skipif(
+    not JSONSCHEMA_AVAILABLE, reason="jsonschema not installed"
+)
+
+
+# --------------------------------------------------------------------------
+# Raw tool payloads, shaped like the real thing. Kept minimal but structurally
+# faithful -- the point is to exercise the adapter's own mapping code.
+# --------------------------------------------------------------------------
+
+GRYPE_RAW: dict[str, Any] = {
+    "matches": [
+        {
+            "vulnerability": {
+                "id": "CVE-2024-1234",
+                "severity": "High",
+                "description": "Example vulnerability in a pinned dependency",
+                "cvss": [
+                    {
+                        "version": "3.1",
+                        "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                        "metrics": {"baseScore": 9.8},
+                    }
+                ],
+                "fix": {"versions": ["1.2.3"], "state": "fixed"},
+            },
+            "artifact": {
+                "name": "libexample",
+                "version": "1.0.0",
+                "type": "python",
+                "purl": "pkg:pypi/libexample@1.0.0",
+                "locations": [{"path": "/app/requirements.txt"}],
+            },
+        }
+    ]
+}
+
+DEPENDENCY_CHECK_RAW: dict[str, Any] = {
+    "scanInfo": {"engineVersion": "10.0.4"},
+    "dependencies": [
+        {
+            "fileName": "libexample-1.0.0.jar",
+            "filePath": "/app/lib/libexample-1.0.0.jar",
+            "vulnerabilities": [
+                {
+                    "name": "CVE-2024-5678",
+                    "severity": "CRITICAL",
+                    "description": "Example vulnerability in a jar",
+                    "cvssv3": {
+                        "baseScore": 9.1,
+                        "baseSeverity": "CRITICAL",
+                        "vectorString": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+                    },
+                }
+            ],
+        }
+    ],
+}
+
+
+def _parse_grype(path: Path) -> list[dict[str, Any]]:
+    from scripts.core.adapters.grype_adapter import _load_grype_internal
+
+    return _load_grype_internal(path)
+
+
+def _parse_dependency_check(path: Path) -> list[dict[str, Any]]:
+    from scripts.core.adapters.dependency_check_adapter import (
+        _load_dependency_check_internal,
+    )
+
+    return _load_dependency_check_internal(path)
+
+
+# (label, raw payload, parse function) -- both known cvss producers.
+CVSS_PRODUCERS = [
+    ("grype", GRYPE_RAW, _parse_grype),
+    ("dependency-check", DEPENDENCY_CHECK_RAW, _parse_dependency_check),
+]
+
+
+@pytest.mark.parametrize(
+    "label,raw,parse", CVSS_PRODUCERS, ids=[p[0] for p in CVSS_PRODUCERS]
+)
+def test_adapter_output_validates_against_published_schema(
+    label: str, raw: dict[str, Any], parse: Any, tmp_path: Path
+) -> None:
+    """Findings an adapter really produces must satisfy the published schema."""
+    out_file = tmp_path / f"{label}.json"
+    out_file.write_text(json.dumps(raw), encoding="utf-8")
+
+    findings = parse(out_file)
+    assert findings, f"{label} adapter parsed zero findings from a valid payload"
+
+    schema = load_schema()
+    for finding in findings:
+        errors = validate_finding(finding, schema)
+        assert not errors, f"{label} finding violates the published schema: {errors}"
+
+
+@pytest.mark.parametrize(
+    "label,raw,parse", CVSS_PRODUCERS, ids=[p[0] for p in CVSS_PRODUCERS]
+)
+def test_cvss_is_an_object_carrying_its_vector(
+    label: str, raw: dict[str, Any], parse: Any, tmp_path: Path
+) -> None:
+    """cvss is an object with a numeric score, not a bare number.
+
+    `history_db.py` reads `finding.get("cvss", {}).get("score")`. A bare float
+    there raises AttributeError, so the object shape is load-bearing rather than
+    stylistic -- and dropping the vector would discard the score's provenance.
+    """
+    out_file = tmp_path / f"{label}.json"
+    out_file.write_text(json.dumps(raw), encoding="utf-8")
+
+    findings = parse(out_file)
+    cvss_values = [f["cvss"] for f in findings if f.get("cvss") is not None]
+    assert cvss_values, f"{label} produced no cvss for a payload that carries one"
+
+    for cvss in cvss_values:
+        assert isinstance(
+            cvss, dict
+        ), f"{label} emitted {type(cvss).__name__}, not dict"
+        assert isinstance(cvss["score"], (int, float))
+        assert 0 <= cvss["score"] <= 10
+        assert cvss.get("vector"), "vector dropped -- the score is no longer auditable"
+        # The exact accessor history_db.py uses.
+        assert cvss.get("score") is not None
+
+
+def test_schema_rejects_a_bare_number_cvss() -> None:
+    """Guard the guard: prove the rule bites instead of merely being permissive.
+
+    Without this, relaxing `cvss` back to something that accepts anything would
+    keep every test above green.
+    """
+    schema = load_schema()
+    finding = {
+        "schemaVersion": "1.2.0",
+        "id": "0123456789abcdef",
+        "ruleId": "CVE-2024-1234",
+        "severity": "HIGH",
+        "tool": {"name": "grype", "version": "0.100.0"},
+        "location": {"path": "/app/requirements.txt", "startLine": 0},
+        "message": "Example",
+        "cvss": 9.8,
+    }
+    errors = validate_finding(finding, schema)
+    assert errors, "schema accepted a bare-number cvss; the object rule is not enforced"
+    assert any("object" in e for e in errors), errors
+
+
+def test_schema_requires_a_score_when_cvss_is_present() -> None:
+    """A cvss object without a score is useless to its only consumer."""
+    schema = load_schema()
+    finding = {
+        "schemaVersion": "1.2.0",
+        "id": "0123456789abcdef",
+        "ruleId": "CVE-2024-1234",
+        "severity": "HIGH",
+        "tool": {"name": "grype", "version": "0.100.0"},
+        "location": {"path": "/app/requirements.txt", "startLine": 0},
+        "message": "Example",
+        "cvss": {"version": "3.x", "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+    }
+    errors = validate_finding(finding, schema)
+    assert errors, "schema accepted a cvss object with no score"

--- a/tests/unit/test_schema_compliance.py
+++ b/tests/unit/test_schema_compliance.py
@@ -377,7 +377,15 @@ class TestAdapterOutputCompliance:
             "message": "Complete finding with all fields",
             "description": "Detailed description of the finding",
             "severity": "HIGH",
-            "cvss": 7.5,
+            # Matches what adapters actually emit -- grype_adapter.py:63-67 and
+            # dependency_check_adapter.py:178-190 both build this shape, and
+            # history_db.py:1088 reads `.get("score")` off it. This fixture
+            # previously said `7.5`, which no adapter has ever produced (#757).
+            "cvss": {
+                "version": "3.x",
+                "score": 7.5,
+                "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            },
             "tool": {"name": "full-adapter", "version": "2.0.0"},
             "location": {
                 "path": "src/vulnerable.py",


### PR DESCRIPTION
Closes #757.

## The disagreement

`docs/schemas/common_finding.v1.json:23` declared `"cvss": { "type": "number" }`. **Nothing has ever emitted a number.**

| Layer | What it says |
|---|---|
| `plugin_api.py:46` — the **live** adapter contract, used by all 27 adapters | `cvss: dict[str, Any] \| None` |
| `grype_adapter.py:63-67` | `{version, score, vector}` |
| `dependency_check_adapter.py:178-190` | identical shape |
| `history_db.py:1088` | `finding.get("cvss", {}).get("score")` — **AttributeError on a float** |
| `sarif_reporter.py:130` | passes through, shape-agnostic |
| `base_adapter.py:156` (dead module, #745) | documents `cvss: dict` |
| `tests/adapters/test_dependency_check_adapter.py:60-62` | already asserts `cvss["version"]`, `["score"]`, `["vector"]` |
| **`common_finding.v1.json:23`** | **`number` — the lone outlier** |

Seven sites say object, one says number. **So the schema moves, not the code.**

Emitting a bare number would discard the vector — a CVSS score without `AV:N/AC:L/…` can't be audited or recomputed — and would break `history_db`. "Fix the code" is a three-file change that ends with less information.

`Finding.to_dict()` drops `None` values, so `cvss` is either this object or **absent**, never `null`. The schema needs no null branch, and `cvss` stays out of `required`.

## Why it could drift this far

`schema_validator` was imported by exactly one module — `scripts/core/validators/scan_validator.py` — and only with **synthetic** inputs (`validate_finding({})`, `validate_findings([])`). That exercises the validator; it never exercises the adapters. **No test has ever fed a real finding to the published schema**, so the two were free to disagree for releases.

That is the actual defect, so the fix ships with the missing gate rather than deferring it: `tests/adapters/test_adapter_schema_conformance.py` parses real output from both `cvss` producers through their own adapter code and validates it against the published schema. No tools, no network — it reuses each adapter's parse path.

It also **guards the guard**: `test_schema_rejects_a_bare_number_cvss` asserts the schema *rejects* `9.8`, so loosening the rule later cannot pass silently.

## Verification

Named gate CI cannot provide: **nothing in CI validates real scan output against the published schema** — that is the whole bug. So the verification is feeding real adapter output through it, plus proving the new rule can fail.

| Check | Result |
|---|---|
| New tests | **6 passed** |
| **Mutation** — schema reverted to `{"type": "number"}` | **3 failed, 3 passed** |
| Restored | **6 passed** |
| Real grype output vs **old** schema | 1 error: `is not of type 'number'` |
| Real grype output vs **new** schema | **0 errors** |
| `tests/adapters` + `tests/core/test_schema_validator.py` | **1859 passed** |
| `sample-findings.json` (5 findings), before **and** after | 0 errors — change is scoped to this one field |
| Line endings | `--numstat` == `--ignore-cr-at-eol --numstat` on both files |

The mutation was done with a **file backup**, not `git checkout --`, which discards uncommitted work in the target file.

The three tests that fail under mutation are exactly the schema-dependent ones; the two `test_cvss_is_an_object_carrying_its_vector` cases keep passing because they assert on *adapter output*, not on the schema — which is correct.

## Judgment call worth flagging

`"required": ["score"]`. I included it: `score` is the field the only shape-dependent consumer reads, so an object without one is useless. Say so if you'd rather it be permissive — it is a one-line change.