### PR TITLE
docs: state the coverage floor CI actually enforces

### DIFF
--- a/.claude/agents/code-quality-auditor.md
+++ b/.claude/agents/code-quality-auditor.md
@@ -41,7 +41,9 @@ You have access to all code analysis tools:
 
 **Target Thresholds:**
 
-- **Test Coverage:** ≥85% (enforced by CI)
+- **Test Coverage:** ≥85% as a review target — **not a CI gate**. CI's only
+  enforced floor is 70% (`.github/workflows/ci.yml:734`); `--cov-fail-under` is
+  set nowhere in this repository (#756)
 - **Cyclomatic Complexity:** ≤10 per function
 - **File Length:** ≤500 lines (exceptions: adapters ≤300 lines)
 - **Function Length:** ≤50 lines
@@ -708,7 +710,7 @@ RETRIES_DEEP = 1
 RETRIES_MAX = 3
 
 # Coverage constants
-COVERAGE_THRESHOLD = 85  # CI enforces 85%+
+COVERAGE_THRESHOLD = 85  # review target; CI's enforced floor is 70% (#756)
 
 # Schema versions
 SCHEMA_VERSION_CURRENT = "1.2.0"

--- a/.claude/agents/code-quality-auditor.md
+++ b/.claude/agents/code-quality-auditor.md
@@ -909,8 +909,8 @@ pyright scripts/
 # 5. Run tests
 make test
 
-# 6. Check coverage
-pytest --cov=scripts --cov-fail-under=85
+# 6. Check coverage (CI's only floor is 70%, at ci.yml:734 -- see #756)
+pytest --cov=scripts --cov-report=term-missing
 ```
 
 ---

--- a/.claude/agents/coverage-gap-finder.md
+++ b/.claude/agents/coverage-gap-finder.md
@@ -739,7 +739,8 @@ def test_specific_edge_case(tmp_path: Path):
 
 5. **"Will this code pass CI?"**
    - Run coverage check
-   - Compare to 85% threshold
+   - Compare to CI's **70%** floor (`ci.yml:734`) — that is the only number that
+     can fail the build. Report 85% separately, as a target rather than a gate
    - Report pass/fail
    - List gaps if failing
 

--- a/.claude/agents/coverage-gap-finder.md
+++ b/.claude/agents/coverage-gap-finder.md
@@ -31,9 +31,12 @@ You have access to all testing analysis tools:
 
 ### Coverage Requirements
 
-- **CI Enforcement:** ≥85% coverage required (see `.github/workflows/ci.yml`)
-- **Command:** `pytest tests/ --cov=scripts --cov-fail-under=85`
-- **Current Status:** 8,000+ tests, 87% coverage
+- **CI Enforcement:** **70%**, and only there — `.github/workflows/ci.yml:734`
+  (`if coverage_pct < 70: sys.exit(1)`). `--cov-fail-under` is set nowhere in
+  this repository (#756), so treat any higher figure as an aspiration, not a gate
+- **Command:** `pytest tests/ --cov=scripts --cov-report=term-missing`
+- **Current Status:** 8,000+ tests. **Measure current coverage before quoting
+  it** — a percentage copied from a doc is how the 85% claim survived unchecked
 
 ### Test File Structure
 
@@ -638,8 +641,7 @@ pytest tests/ --cov=scripts --cov-report=html --cov-report=term-missing
 ```bash
 pytest tests/adapters/test_trivy_adapter.py \
   --cov=scripts/core/adapters/trivy_adapter.py \
-  --cov-report=term-missing \
-  --cov-fail-under=85
+  --cov-report=term-missing
 ```
 
 **Coverage by category:**

--- a/.claude/agents/release-readiness.md
+++ b/.claude/agents/release-readiness.md
@@ -187,10 +187,13 @@ pytest tests/integration/ -v
 ### Coverage
 
 ```bash
-pytest tests/ --cov=scripts --cov-fail-under=85
+pytest tests/ --cov=scripts --cov-report=term-missing
 ```
 
-**Status:** ⚠️ 84% (below threshold)
+**Status:** report the measured number against CI's actual floor — **70%**
+(`.github/workflows/ci.yml:734`). Nothing sets `--cov-fail-under` (#756), so a
+figure like 84% is **passing**, not "below threshold". Flag a *drop from the
+previous release* rather than a miss against a constant that isn't enforced.
 **Action:** Add tests to reach 85%+
 
 ---

--- a/.claude/rules/testing.rules.md
+++ b/.claude/rules/testing.rules.md
@@ -16,11 +16,27 @@ references:
 
 ## Test Coverage & CI Requirements
 
-**Mandatory:** `pytest --cov-fail-under=85` in CI.
+**The only enforced coverage floor is 70%**, in `.github/workflows/ci.yml:734`:
+
+```python
+if coverage_pct < 70:
+    sys.exit(1)
+```
+
+`--cov-fail-under` is set **nowhere** — not in `make test` (`Makefile:132` runs
+`pytest --cov --cov-report=term-missing`, no threshold), not in
+`[tool.coverage.report]`, not in any workflow. Tracked as **#756**.
 
 - All new code must include tests.
-- Aim for >87% coverage (current baseline).
 - Use `--cov=scripts --cov-report=term-missing` to identify gaps.
+- **Compare against the previous run, not against a constant.** Because nothing
+  fails between 70% and the current level, a regression in that band is invisible
+  to CI — diffing the number yourself is the only thing that catches it.
+
+> This section previously read "**Mandatory:** `pytest --cov-fail-under=85` in
+> CI" and "Aim for >87% (current baseline)". Both were unenforced, and the 87%
+> was never measured in-repo. A stated guarantee is a claim to verify — the same
+> failure class as #747 (pinned version drift) and #750 (prose version headers).
 
 ## Running Tests Locally
 

--- a/.claude/skills/jmo-adapter-generator/SKILL.md
+++ b/.claude/skills/jmo-adapter-generator/SKILL.md
@@ -112,7 +112,7 @@ Persist tool patterns, exit codes, pitfalls, and test fixtures to `.jmo/memory/a
 
 ### Phase 9: Run Validation Suite
 
-Run `make test && make lint && make pre-commit-run`. Verify plugin discovery, coverage >=85%, memory file exists. Full checklist in [references/detailed-phase-guide.md](references/detailed-phase-guide.md#phase-9-run-validation-suite).
+Run `make test && make lint && make pre-commit-run`. Verify plugin discovery, memory file exists, and >=85% coverage **of the new adapter module** — a bar for new code, not a gate `make test` applies (it sets no threshold; CI's only floor is 70% repo-wide, `ci.yml:734`, see #756). Full checklist in [references/detailed-phase-guide.md](references/detailed-phase-guide.md#phase-9-run-validation-suite).
 
 ### Phase 10: Create Pull Request
 

--- a/.claude/skills/jmo-ci-debugger/SKILL.md
+++ b/.claude/skills/jmo-ci-debugger/SKILL.md
@@ -40,7 +40,7 @@ jobs:
 
   test-matrix:       # 10-15 min (parallel)
     - Ubuntu/macOS x Python 3.10/3.11/3.12
-    - pytest with >=85% coverage threshold
+    - pytest, sharded x4; coverage gate is 70% (ci.yml:734), not 85%
 
   lint-full:         # 5-10 min (nightly only)
     - Complete pre-commit suite (all markdown, Python, shell, YAML)
@@ -78,7 +78,7 @@ jobs:
 | 6 | Dependabot Cascading | `ModuleNotFoundError` (13+ PRs) | `@dependabot rebase` via `gh pr comment` | Easy |
 | 7 | Markdownlint | `MD036/no-emphasis-as-heading` | Fix ALL violations: headings, blank lines, code fence langs | Easy |
 | 8 | Pre-commit Hooks | `ruff...Failed` / `black...Failed` | Run `make fmt` then `pre-commit run --all-files` | Easy-Med |
-| 9 | Test Coverage | `Coverage of X% below 85%` | Add missing tests for uncovered lines | Medium |
+| 9 | Test Coverage | `is below 70% CI threshold` (coverage-aggregate job, not pytest) | Add missing tests for uncovered lines | Medium |
 | 10 | Lockfile Drift | `uv.lock needs to be updated` | Run `make deps-lock`, commit uv.lock | Easy |
 | 11 | YAML Syntax | `syntax error: expected <block` | Fix indentation, quote special chars, use 2-space indent | Easy-Med |
 | 12 | Branch Protection | `GH013: Repository rule violations` | Use feature branches + PRs (never push directly to main) | Easy |
@@ -157,7 +157,8 @@ make fmt && make lint && make test   # Pre-push checks
 Key prevention rules:
 
 1. **Black before Ruff** - enforced in `.pre-commit-config.yaml` hook order
-2. **Coverage >= 85%** - aim for 90%+ to maintain buffer
+2. **Coverage** - CI fails below **70%** (ci.yml:734); 85%+ is the project's own
+   target, enforced by review rather than by the build
 3. **Fix ALL violations** - not just new ones (Technical Debt Principle)
 4. **Feature branches** - never push directly to main
 5. **Cross-platform buffers** - 5-10% for floats, 20-30% for timing

--- a/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
+++ b/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
@@ -1027,8 +1027,10 @@ New code not sufficiently tested, or tests don't cover all branches.
 
 **Where This Occurs:**
 
-- ci.yml, test-matrix job
-- pytest with `--cov-fail-under=85`
+- `ci.yml`, the `Verify coverage threshold` step of the `coverage-aggregate` job
+- An inline Python check, **not** a pytest flag: `if coverage_pct < 70: sys.exit(1)`
+  (`ci.yml:734`). `--cov-fail-under` is set nowhere in this repository (#756), so
+  grepping for it to find the gate returns nothing and misleads.
 
 **Quick Diagnosis:**
 

--- a/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
+++ b/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
@@ -1015,11 +1015,15 @@ git commit --no-verify -m "emergency hotfix"
 **Symptoms:**
 
 ```text
-FAILED tests/adapters/test_snyk_adapter.py::test_snyk_basic
-=============================== Coverage =============================
-TOTAL                        1234    245     82%
-FAILED: Coverage of 82% is below threshold of 85%
+📊 Combined coverage: 68.7%
+❌ Coverage 68.7% is below 70% CI threshold
 ```
+
+Those two lines are the **real** symptom, printed by the `Verify coverage
+threshold` step of the `coverage-aggregate` job. pytest itself emits nothing
+here — `--cov-fail-under` is set nowhere (#756), so there is no
+`Coverage of N% is below threshold` line to search for. Grep the run log for
+`is below 70% CI threshold`.
 
 **Root Cause:**
 
@@ -1078,7 +1082,9 @@ def test_snyk_nested_arrays(tmp_path: Path):
 
 **Coverage Best Practices:**
 
-- **Aim for >90%:** Gives buffer below 85% threshold
+- **Aim for >90%:** CI fails only below 70% (`ci.yml:734`), so the buffer you are
+  keeping is against review and against the next regression, not against a build
+  failure
 - **Test all error paths:** Not just happy path
 - **Use coverage report:** `--cov-report=html` for visual coverage map
 - **Don't skip tests:** Avoid `@pytest.mark.skip` without good reason
@@ -1394,7 +1400,7 @@ gh pr merge --squash
 ```bash
 # Pre-flight checklist (prevents PR failures)
 make pre-commit-run  # All pre-commit hooks
-make test           # Tests with coverage >=85%
+make test           # Tests with a coverage report -- no threshold (#756)
 make lint           # Additional linting
 
 # Check for common issues

--- a/.claude/skills/jmo-ci-debugger/references/error-pattern-matching.md
+++ b/.claude/skills/jmo-ci-debugger/references/error-pattern-matching.md
@@ -183,10 +183,14 @@ CI Failure
     |   |-- ModuleNotFoundError (multiple PRs) -> #6 Dependabot
     |   |-- ModuleNotFoundError (one job, after a pip install) -> #18 Bare pip install
     |   |-- collected 0 items, then Error 5 -> #18 Bare pip install
-    |   |-- Coverage below 85% -> #9 Test Coverage
     |   |-- Float assertion failures -> #16 Platform Precision
     |   |-- FileNotFoundError: React -> #17 React Build Check
     |   +-- Other test failures -> Check test code
+    |
+    +-- coverage-aggregate (after the shards)
+    |   +-- "is below 70% CI threshold" -> #9 Test Coverage
+    |       (the gate lives here, NOT in test-matrix -- the shards carry no
+    |        coverage threshold of their own)
     |
     +-- lint-full (nightly)
     |   |-- 4+ tool failures -> #14 Nightly Cascading

--- a/.claude/skills/jmo-ci-debugger/references/prevention-strategies-full.md
+++ b/.claude/skills/jmo-ci-debugger/references/prevention-strategies-full.md
@@ -41,7 +41,7 @@ Test CI conditions locally:
 # Simulate test matrix (Python 3.10, 3.11, 3.12)
 for py in 3.10 3.11 3.12; do
   docker run --rm -v $(pwd):/workspace -w /workspace python:$py-slim \
-    bash -c "pip install -e .[dev] && pytest --cov --cov-fail-under=85"
+    bash -c "pip install -e .[dev] && pytest --cov --cov-report=term-missing"
 done
 
 # Simulate quick-checks

--- a/.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md
+++ b/.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md
@@ -640,9 +640,10 @@ pytest tests/adapters/ -v
 pytest tests/integration/ -v
 # NO new failures
 
-# 4. Check coverage
+# 4. Check coverage of the module you changed
 pytest --cov=scripts/core/adapters/tool_adapter --cov-fail-under=85
-# MUST be >=85%
+# A local bar for the module under repair -- NOT a CI gate. CI's only enforced
+# floor is 70% repo-wide (ci.yml:734); --cov-fail-under is set nowhere. See #756.
 
 # 5. Run pre-commit hooks
 pre-commit run --all-files

--- a/.claude/skills/jmo-test-fabricator/SKILL.md
+++ b/.claude/skills/jmo-test-fabricator/SKILL.md
@@ -351,7 +351,9 @@ Real test files from this project to use as examples:
 ### Coverage
 
 - [ ] All tests pass: `pytest tests/adapters/test_<tool>_adapter.py -v`
-- [ ] Coverage >=85%: `pytest ... --cov=scripts/core/adapters/<tool>_adapter --cov-fail-under=85`
+- [ ] Coverage >=85% **for the new adapter module** (a local bar for new code, not
+      a CI gate — CI's only floor is 70% repo-wide, `ci.yml:734`, see #756):
+      `pytest ... --cov=scripts/core/adapters/<tool>_adapter --cov-fail-under=85`
 - [ ] Coverage report reviewed: `--cov-report=term-missing` shows no critical gaps
 
 ### Code Quality

--- a/.claude/skills/jmo-test-fabricator/SKILL.md
+++ b/.claude/skills/jmo-test-fabricator/SKILL.md
@@ -34,7 +34,7 @@ Generate comprehensive pytest test suites for JMo Security with fabricated fixtu
 
 **Config/CLI Testing:** Config loaders, YAML parsing, field validation, multi-target helpers, argument parsing.
 
-**General:** CI coverage below 85%, new CommonFinding schema features, improving coverage for any module.
+**General:** coverage below the project's 85% target (CI itself fails only below 70%, `ci.yml:734`), new CommonFinding schema features, improving coverage for any module.
 
 ---
 

--- a/.claude/skills/jmo-test-fabricator/references/ci-platform-validation.md
+++ b/.claude/skills/jmo-test-fabricator/references/ci-platform-validation.md
@@ -240,8 +240,16 @@ jmo --help
 
 ### GitHub Actions Workflow
 
+> **These two blocks are templates to adopt, not descriptions of this repo.**
+> JMo's real `ci.yml` shards tests with `pytest-split` and enforces coverage
+> through an inline `if coverage_pct < 70` check in the `coverage-aggregate`
+> job (`ci.yml:734`) — not via `--cov-fail-under`, which is set nowhere here
+> (#756). The real `.pre-commit-config.yaml` has **no** `pytest-adapter-coverage`
+> hook. Copying either block verbatim into this repository would add a gate that
+> does not currently exist, which is a decision, not a fix.
+
 ```yaml
-# .github/workflows/ci.yml
+# Template: .github/workflows/ci.yml
 name: CI
 
 on: [push, pull_request]
@@ -268,7 +276,7 @@ jobs:
 ### Pre-commit Hook
 
 ```yaml
-# .pre-commit-config.yaml
+# Template: .pre-commit-config.yaml
 repos:
   - repo: local
     hooks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,8 +729,8 @@ jobs:
           # from merged <line> hits, so this reads true aggregate coverage
           # rather than shard-1's standalone value (which was the source of
           # the spurious "drop from 71.6% to 68.7%" investigated in PR #355).
-          # Full 85% coverage is still enforced via `make test` (sequential,
-          # full suite without filtered markers).
+          # No higher floor is enforced anywhere: `--cov-fail-under` is unset
+          # repo-wide and `make test` carries no threshold either. See #756.
           if coverage_pct < 70:
               print(f"❌ Coverage {coverage_pct:.1f}% is below 70% CI threshold")
               sys.exit(1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Setup: [docs/MCP_SETUP.md](docs/MCP_SETUP.md)
 - **Subprocess security:** Never use `shell=True` — always pass command as list
 - **Adapter naming:** `PluginMetadata.name` uses underscores matching filename
 - **Compliance enrichment:** Handled centrally in `normalize_and_report.py`, not in adapters
-- **Test coverage:** CI requires ≥85% (`pytest --cov-fail-under=85`)
+- **Test coverage:** CI's only enforced floor is **70%** (`.github/workflows/ci.yml:734`). Nothing sets `--cov-fail-under` anywhere (#756)
 - **Conventional commits:** `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `ci:`
 
 ## Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ JMo Security is a terminal-first security audit toolkit orchestrating 29 scanner
 
 **Version:** v1.0.8 (latest released — see CHANGELOG.md for full history)
 **Philosophy:** Two-phase architecture: scan (invoke tools) → report (normalize, dedupe, output)
-**Test Coverage:** 8,000+ tests, 87% coverage, CI requires ≥85% (sharded across 4 parallel jobs); CI quick threshold 70% (excludes slow/docker/requires_tools/smoke)
+**Test Coverage:** 8,000+ tests, sharded across 4 parallel jobs. The **only enforced floor is 70%** (`.github/workflows/ci.yml:734`, on the marker-filtered suite — excludes slow/docker/requires_tools/smoke). Nothing sets `--cov-fail-under` (#756); measure current coverage rather than quoting a figure from this file
 
 **Key v1.0 Features:**
 
@@ -373,7 +373,7 @@ See [docs/USER_GUIDE.md](docs/USER_GUIDE.md) for complete configuration referenc
 
 | Issue | Solution |
 |-------|----------|
-| Tests failing | `make test --maxfail=1`, check coverage ≥85% |
+| Tests failing | `make test` (already carries `--maxfail=1` via `TEST_FLAGS`). No local coverage gate exists — CI's floor is 70%, `ci.yml:734` (#756) |
 | Tool not found | `jmo tools check`, then `jmo tools install` |
 | Tool startup crash | `jmo tools clean --force && jmo tools install <tool>` |
 | Pre-commit fails | `make fmt`, `make lint` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ JMo Security is a terminal-first security audit toolkit orchestrating 29 scanner
 ### Mandatory Guardrails
 
 1. **Pre-commit Order:** Black MUST run before Ruff (see `.pre-commit-config.yaml`)
-2. **Test Coverage:** CI requires ≥85% (`pytest --cov-fail-under=85`)
+2. **Test Coverage:** CI's only enforced floor is **70%** (`.github/workflows/ci.yml:734`, on the marker-filtered suite). Nothing sets `--cov-fail-under` — not `make test`, not `pyproject.toml`. Write tests to the standard the codebase holds itself to, but do not cite 85% as a gate (#756)
 3. **Subprocess Security:** NEVER use `shell=True` in subprocess calls. See [.claude/rules/python-safety.rules.md](.claude/rules/python-safety.rules.md)
 4. **Conventional Commits:** `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `perf:`, `ci:`
 5. **Path Security:** Validate all user paths against directory traversal

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -253,7 +253,7 @@ Remember to update CHANGELOG.md with user-facing changes.
    ```bash
    make test
    # or
-   pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing --cov-fail-under=85
+   pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing
    ```
 
 3. **Verify linting and formatting:**

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -209,7 +209,7 @@ Remember to update CHANGELOG.md with user-facing changes.
 
 - **No PyPI API token required!** This repo uses Trusted Publishers (OIDC) for tokenless publishing.
 - Ensure the repository is configured as a Trusted Publisher in PyPI settings (one-time setup).
-- Ensure tests are green and coverage passes locally (≥85% required).
+- Ensure tests are green locally. There is no local coverage gate to pass — `make test` prints a report and sets no threshold (#756); CI's only floor is 70% (`.github/workflows/ci.yml:734`).
 - Update `CHANGELOG.md` with all user-facing changes from the "Unreleased" section.
 
 ## Pre-Release Checklist
@@ -840,7 +840,7 @@ docker run --rm --platform linux/amd64 jmogaming/jmo-security:latest --help
 - The package exposes the `jmo` console script.
 - Coverage reports are uploaded to Codecov as part of the tests workflow (tokenless OIDC).
 - License is defined via SPDX string in `pyproject.toml` and the `LICENSE` file is included in the distribution.
-- CI enforces: tests passing, coverage ≥85%, pre-commit checks, reproducible dev deps.
+- CI enforces: tests passing, coverage ≥70% (`.github/workflows/ci.yml:734` — the only coverage gate that exists, see #756), pre-commit checks, reproducible dev deps.
 
 ## Post-Release
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2817,7 +2817,7 @@ Common failure modes in `.github/workflows/tests.yml` and how to fix them:
   - Fix locally: `make pre-commit-run` or run individual hooks. Config lives in `.pre-commit-config.yaml`; YAML rules in `.yamllint.yaml`; ruff/black use defaults in this repo. Docs: <https://pre-commit.com/>
 
 - Test coverage threshold not met
-  - Symptom: Tests pass, but `--cov-fail-under=85` fails the job.
+  - Symptom: Tests pass, but the coverage job fails with `Coverage N% is below 70% CI threshold` (`.github/workflows/ci.yml:734` — the only enforced floor).
   - Fix locally: run `pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing` to identify gaps, then add tests. High‑leverage areas include adapters' malformed/empty JSON handling and reporters' edge cases. Pytest‑cov docs: <https://pytest-cov.readthedocs.io/>
 
 - Codecov upload warnings (tokenless OIDC)

--- a/docs/internal/TESTING_MATRIX.md
+++ b/docs/internal/TESTING_MATRIX.md
@@ -15,7 +15,7 @@
 
 **Total Possible Combinations:** 6 x 28 x 3 x 5 x 6 = **15,120 test scenarios**
 **Current Test Suite:** 8,000+ tests across unit/adapters/reporters/integration
-**Coverage:** 87% (CI enforced minimum: 85%)
+**Coverage:** measure it before quoting it — CI's only enforced minimum is **70%** (`.github/workflows/ci.yml:734`), and nothing sets `--cov-fail-under` (#756)
 
 ---
 
@@ -349,7 +349,7 @@ All 28 tools benefit from universal compliance enrichment via [scripts/core/comp
 **Current State:**
 
 - **Total Tests:** 8,000+
-- **Coverage:** 87% (CI enforced minimum: 85%)
+- **Coverage:** measure it before quoting it — CI's only enforced minimum is **70%** (`.github/workflows/ci.yml:734`); `--cov-fail-under` is set nowhere (#756)
 - **CI Platforms:** 2 OS (Linux, macOS) x 3 Python versions (3.10, 3.11, 3.12) = 6 matrix jobs
 - **Test Categories:**
   - Unit tests


### PR DESCRIPTION
Refs #756. Applies the issue's **option 3** across the repository.

## What was false

Fourteen sites claimed CI requires ≥85% coverage via `--cov-fail-under=85`. **No such gate exists.**

| Where | What it actually does |
|---|---|
| `Makefile:132` | `pytest --cov --cov-report=term-missing` — no threshold |
| `pyproject.toml` `[tool.coverage.report]` | no `fail_under` key |
| `.github/workflows/ci.yml:734` | `if coverage_pct < 70: sys.exit(1)` — **the only enforced floor** |
| everywhere else | `.hypothesis/` cache constants and `.venv/`'s own coverage.py source |

`ci.yml:732`'s own comment — "Full 85% coverage is still enforced via `make test`" — points at the one place it is *not* enforced.

## Not a blanket strip of the number 85

Three different things were mixed together and only the first is #756. Stripping all of them mechanically would have removed working guidance:

**1. False claims about JMo's CI — corrected.**
- `ci-failure-catalog.md` located the gate in "ci.yml, test-matrix job, pytest with `--cov-fail-under=85`". Anyone grepping for that finds nothing. Now names the real inline check and says why grep misleads.
- `release-readiness.md` reported `⚠️ 84% (below threshold)`. 84% **passes** the real 70% floor. Now says to flag a *drop from the previous release* rather than a miss against an unenforced constant.

**2. Per-module quality bars — kept, scope made explicit.** Requiring 85% on a single new adapter is a real, working command (`--cov-fail-under=85` scoped to one module) and a reasonable standard for new code. These were only misleading where they read as a CI gate, so they now say so.

**3. Template snippets — kept, relabelled.** `ci-platform-validation.md` presented two blocks headed `# .github/workflows/ci.yml` and `# .pre-commit-config.yaml` as though they described this repo. They don't — the real `ci.yml` shards with `pytest-split`, and `.pre-commit-config.yaml` has **no** `pytest-adapter-coverage` hook (measured: grep count `0`). Now labelled `Template:` with a note that adopting them would **add** a gate, not restore one. Same family as the fictional-CLI finding in #760/#761.

Also removed `>87% (current baseline)` from `testing.rules.md`. That figure was never measured in-repo — and quoting a copied percentage is exactly how the 85% claim survived unchecked.

## Deliberately left alone

- Three sites that already *explain* the absence (chunk E and G work): `security-commit-template.md:104`, `jmo-target-type-expander/SKILL.md:353`, `jmo-refactoring-assistant/references/memory-integration.md:240`
- Plan and tracker docs under `docs/superpowers/` — historical records
- `tests/core/test_release_validator.py:906` — the string is a **mock input** testing the validator's own parsing, not a claim

## Option 1 is not included, on purpose

Adding `--cov-fail-under` to `make test` needs the current coverage number first. The issue says coverage is "**reportedly** ~87%" — setting a floor on a reported figure is precisely the mistake this issue documents. The measurement was still running at time of writing.

Nothing in this PR presumes the outcome: every site states the *enforced* floor and points at `ci.yml:734`, so adding a local `make test` floor later is purely additive and won't require re-touching these 13 files.

## Verification

Docs-only. CI checks form; the substance here is whether each claim matches the code, so:

| Check | Result |
|---|---|
| `check_doc_links.py` | **161 tracked files, all links resolve** |
| markdownlint / mixed-line-ending / trailing-whitespace | Passed |
| Line endings | `--numstat` == `--ignore-cr-at-eol --numstat` on all **13** files |
| `pytest-adapter-coverage` in real `.pre-commit-config.yaml` | **0** — confirms the template claim |
| `--cov-fail-under` in executable paths | **0** — confirms the core finding |

Every replacement figure cites its source line rather than restating a number.