### PR TITLE
ci: raise the enforced coverage floor to 80%

### DIFF
--- a/.claude/agents/code-quality-auditor.md
+++ b/.claude/agents/code-quality-auditor.md
@@ -42,7 +42,7 @@ You have access to all code analysis tools:
 **Target Thresholds:**
 
 - **Test Coverage:** ≥85% as a review target — **not a CI gate**. CI's only
-  enforced floor is 70% (`.github/workflows/ci.yml:734`); `--cov-fail-under` is
+  enforced floor is 80% (`.github/workflows/ci.yml:734`); `--cov-fail-under` is
   set nowhere in this repository (#756)
 - **Cyclomatic Complexity:** ≤10 per function
 - **File Length:** ≤500 lines (exceptions: adapters ≤300 lines)
@@ -710,7 +710,7 @@ RETRIES_DEEP = 1
 RETRIES_MAX = 3
 
 # Coverage constants
-COVERAGE_THRESHOLD = 85  # review target; CI's enforced floor is 70% (#756)
+COVERAGE_THRESHOLD = 85  # review target; CI's enforced floor is 80% (#756)
 
 # Schema versions
 SCHEMA_VERSION_CURRENT = "1.2.0"
@@ -911,7 +911,7 @@ pyright scripts/
 # 5. Run tests
 make test
 
-# 6. Check coverage (CI's only floor is 70%, at ci.yml:734 -- see #756)
+# 6. Check coverage (CI's only floor is 80%, at ci.yml:734 -- see #756)
 pytest --cov=scripts --cov-report=term-missing
 ```
 

--- a/.claude/agents/coverage-gap-finder.md
+++ b/.claude/agents/coverage-gap-finder.md
@@ -31,8 +31,8 @@ You have access to all testing analysis tools:
 
 ### Coverage Requirements
 
-- **CI Enforcement:** **70%**, and only there — `.github/workflows/ci.yml:734`
-  (`if coverage_pct < 70: sys.exit(1)`). `--cov-fail-under` is set nowhere in
+- **CI Enforcement:** **80%**, and only there — `.github/workflows/ci.yml:734`
+  (`if coverage_pct < 80: sys.exit(1)`). `--cov-fail-under` is set nowhere in
   this repository (#756), so treat any higher figure as an aspiration, not a gate
 - **Command:** `pytest tests/ --cov=scripts --cov-report=term-missing`
 - **Current Status:** 8,000+ tests. **Measure current coverage before quoting
@@ -739,7 +739,7 @@ def test_specific_edge_case(tmp_path: Path):
 
 5. **"Will this code pass CI?"**
    - Run coverage check
-   - Compare to CI's **70%** floor (`ci.yml:734`) — that is the only number that
+   - Compare to CI's **80%** floor (`ci.yml:734`) — that is the only number that
      can fail the build. Report 85% separately, as a target rather than a gate
    - Report pass/fail
    - List gaps if failing

--- a/.claude/agents/release-readiness.md
+++ b/.claude/agents/release-readiness.md
@@ -190,7 +190,7 @@ pytest tests/integration/ -v
 pytest tests/ --cov=scripts --cov-report=term-missing
 ```
 
-**Status:** report the measured number against CI's actual floor — **70%**
+**Status:** report the measured number against CI's actual floor — **80%**
 (`.github/workflows/ci.yml:734`). Nothing sets `--cov-fail-under` (#756), so a
 figure like 84% is **passing**, not "below threshold". Flag a *drop from the
 previous release* rather than a miss against a constant that isn't enforced.

--- a/.claude/rules/testing.cross-platform.rules.md
+++ b/.claude/rules/testing.cross-platform.rules.md
@@ -290,8 +290,10 @@ Pytest invocations in CI workflows use these filter sets. Each filter is tuned t
 
 | Workflow:Job | Filter | Rationale |
 |---|---|---|
-| `ci.yml` quick-checks (sharded ×4) | `-m "not smoke and not requires_tools and not docker"` | Excludes tests needing PyPI release, real scanners, or Docker daemon. |
-| `ci.yml` Quick coverage check | `-m "not smoke and not requires_tools and not docker and not slow"` | Adds `not slow` for the coverage-only run (≥70% threshold). |
+| `ci.yml` test-sharded — Ubuntu ×4 (`:312`) | `-m "not smoke and not requires_tools and not docker"` | **The only job that produces coverage** (`--cov=scripts`). `coverage-aggregate` merges the four shard XMLs and enforces the 80% floor (`:734`). `slow` included. |
+| `ci.yml` test-sharded — macOS (`:327`) | `-m "not smoke and not requires_tools and not docker"` | Same suite, **no coverage** — the step is literally named "Run tests (macOS, no coverage)". |
+| `ci.yml` test-sharded — Windows (`:352`) | `-m "not smoke and not requires_tools and not docker and not slow"` | Adds `not slow` for runtime; also `-p no:xdist -p no:rerunfailures`, `--timeout=60`. **No coverage.** |
+| `ci.yml` windows-native-encoding collection floor (`:448`) | `-m "not smoke and not requires_tools and not docker and not slow"` | `--collect-only` count guard, fails under 7800 collected. Not a test run; no coverage. |
 | `ci.yml` tool-contract-tests | `-m "requires_tools"` | Tools installed via the `Install tools` step earlier in the job. |
 | `scheduled.yml` Nightly Extended | `-m "not requires_tools and not smoke"` | Includes slow tests intentionally (omit `not slow`) since nightly has the time budget. Excludes real-tool + smoke tests because runner doesn't install tools or install released package. |
 | `scheduled.yml` Tool Smoke Tests | `-m "smoke"` | Runs only `@pytest.mark.smoke` tests against released `jmo-security` PyPI package. |
@@ -306,7 +308,8 @@ Pytest invocations in CI workflows use these filter sets. Each filter is tuned t
 
 - **Always exclude `requires_tools` and `smoke`** unless the runner explicitly installs the prerequisite (real tool binaries or the released PyPI wheel).
 - **Always exclude `docker`** unless the runner has a Docker daemon (Linux runners do; macOS/Windows runners require setup).
-- **`slow` is NOT excluded from PR-time CI.** `ci.yml`'s **sharded** jobs (`:312`, `:327`) run `-m "not smoke and not requires_tools and not docker"` — slow tests included. Only the **Quick coverage check** (`:352`) and `nightly-cross-platform` (`:448`) add `and not slow`. Exclude it when the job's budget is tight, not because it is PR-time.
+- **`slow` is NOT excluded from PR-time CI.** The **Ubuntu and macOS** shards (`:312`, `:327`) run `-m "not smoke and not requires_tools and not docker"` — slow tests included. The **Windows** shard (`:352`) and the `windows-native-encoding` collection floor (`:448`) add `and not slow`; so does `nightly-cross-platform`, which lives in **`scheduled.yml:241`**, not `ci.yml`. Exclude it when the job's budget is tight, not because it is PR-time.
+- **There is no "Quick coverage check" job.** The table above used to list one, with a `≥70% threshold` it did not have, citing `:352` — which is the Windows shard, a step named "no coverage". `ci.yml` has exactly one coverage gate: the `Verify coverage threshold` step of `coverage-aggregate` (`:734`). If you are hunting a coverage failure, that is the only place it can come from.
 - **Use `-m "<marker>"` to RUN only that marker**'s tests after installing prerequisites; use `-m "not <marker>"` to EXCLUDE.
 
 ### Reproducing a shard locally

--- a/.claude/rules/testing.rules.md
+++ b/.claude/rules/testing.rules.md
@@ -16,10 +16,10 @@ references:
 
 ## Test Coverage & CI Requirements
 
-**The only enforced coverage floor is 70%**, in `.github/workflows/ci.yml:734`:
+**The only enforced coverage floor is 80%**, in `.github/workflows/ci.yml:734`:
 
 ```python
-if coverage_pct < 70:
+if coverage_pct < 80:
     sys.exit(1)
 ```
 
@@ -30,7 +30,7 @@ if coverage_pct < 70:
 - All new code must include tests.
 - Use `--cov=scripts --cov-report=term-missing` to identify gaps.
 - **Compare against the previous run, not against a constant.** Because nothing
-  fails between 70% and the current level, a regression in that band is invisible
+  fails between 80% and the current level, a regression in that band is invisible
   to CI — diffing the number yourself is the only thing that catches it.
 
 > This section previously read "**Mandatory:** `pytest --cov-fail-under=85` in

--- a/.claude/skills/jmo-adapter-generator/SKILL.md
+++ b/.claude/skills/jmo-adapter-generator/SKILL.md
@@ -112,7 +112,7 @@ Persist tool patterns, exit codes, pitfalls, and test fixtures to `.jmo/memory/a
 
 ### Phase 9: Run Validation Suite
 
-Run `make test && make lint && make pre-commit-run`. Verify plugin discovery, memory file exists, and >=85% coverage **of the new adapter module** — a bar for new code, not a gate `make test` applies (it sets no threshold; CI's only floor is 70% repo-wide, `ci.yml:734`, see #756). Full checklist in [references/detailed-phase-guide.md](references/detailed-phase-guide.md#phase-9-run-validation-suite).
+Run `make test && make lint && make pre-commit-run`. Verify plugin discovery, memory file exists, and >=85% coverage **of the new adapter module** — a bar for new code, not a gate `make test` applies (it sets no threshold; CI's only floor is 80% repo-wide, `ci.yml:734`, see #756). Full checklist in [references/detailed-phase-guide.md](references/detailed-phase-guide.md#phase-9-run-validation-suite).
 
 ### Phase 10: Create Pull Request
 

--- a/.claude/skills/jmo-ci-debugger/SKILL.md
+++ b/.claude/skills/jmo-ci-debugger/SKILL.md
@@ -40,7 +40,7 @@ jobs:
 
   test-matrix:       # 10-15 min (parallel)
     - Ubuntu/macOS x Python 3.10/3.11/3.12
-    - pytest, sharded x4; coverage gate is 70% (ci.yml:734), not 85%
+    - pytest, sharded x4; coverage gate is 80% (ci.yml:734), not 85%
 
   lint-full:         # 5-10 min (nightly only)
     - Complete pre-commit suite (all markdown, Python, shell, YAML)
@@ -78,7 +78,7 @@ jobs:
 | 6 | Dependabot Cascading | `ModuleNotFoundError` (13+ PRs) | `@dependabot rebase` via `gh pr comment` | Easy |
 | 7 | Markdownlint | `MD036/no-emphasis-as-heading` | Fix ALL violations: headings, blank lines, code fence langs | Easy |
 | 8 | Pre-commit Hooks | `ruff...Failed` / `black...Failed` | Run `make fmt` then `pre-commit run --all-files` | Easy-Med |
-| 9 | Test Coverage | `is below 70% CI threshold` (coverage-aggregate job, not pytest) | Add missing tests for uncovered lines | Medium |
+| 9 | Test Coverage | `is below 80% CI threshold` (coverage-aggregate job, not pytest) | Add missing tests for uncovered lines | Medium |
 | 10 | Lockfile Drift | `uv.lock needs to be updated` | Run `make deps-lock`, commit uv.lock | Easy |
 | 11 | YAML Syntax | `syntax error: expected <block` | Fix indentation, quote special chars, use 2-space indent | Easy-Med |
 | 12 | Branch Protection | `GH013: Repository rule violations` | Use feature branches + PRs (never push directly to main) | Easy |
@@ -157,7 +157,7 @@ make fmt && make lint && make test   # Pre-push checks
 Key prevention rules:
 
 1. **Black before Ruff** - enforced in `.pre-commit-config.yaml` hook order
-2. **Coverage** - CI fails below **70%** (ci.yml:734); 85%+ is the project's own
+2. **Coverage** - CI fails below **80%** (ci.yml:734); 85%+ is the project's own
    target, enforced by review rather than by the build
 3. **Fix ALL violations** - not just new ones (Technical Debt Principle)
 4. **Feature branches** - never push directly to main

--- a/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
+++ b/.claude/skills/jmo-ci-debugger/references/ci-failure-catalog.md
@@ -1015,15 +1015,15 @@ git commit --no-verify -m "emergency hotfix"
 **Symptoms:**
 
 ```text
-📊 Combined coverage: 68.7%
-❌ Coverage 68.7% is below 70% CI threshold
+📊 Combined coverage: 78.9%
+❌ Coverage 78.9% is below 80% CI threshold
 ```
 
 Those two lines are the **real** symptom, printed by the `Verify coverage
 threshold` step of the `coverage-aggregate` job. pytest itself emits nothing
 here — `--cov-fail-under` is set nowhere (#756), so there is no
 `Coverage of N% is below threshold` line to search for. Grep the run log for
-`is below 70% CI threshold`.
+`is below 80% CI threshold`.
 
 **Root Cause:**
 
@@ -1032,7 +1032,7 @@ New code not sufficiently tested, or tests don't cover all branches.
 **Where This Occurs:**
 
 - `ci.yml`, the `Verify coverage threshold` step of the `coverage-aggregate` job
-- An inline Python check, **not** a pytest flag: `if coverage_pct < 70: sys.exit(1)`
+- An inline Python check, **not** a pytest flag: `if coverage_pct < 80: sys.exit(1)`
   (`ci.yml:734`). `--cov-fail-under` is set nowhere in this repository (#756), so
   grepping for it to find the gate returns nothing and misleads.
 
@@ -1082,7 +1082,7 @@ def test_snyk_nested_arrays(tmp_path: Path):
 
 **Coverage Best Practices:**
 
-- **Aim for >90%:** CI fails only below 70% (`ci.yml:734`), so the buffer you are
+- **Aim for >90%:** CI fails only below 80% (`ci.yml:734`), so the buffer you are
   keeping is against review and against the next regression, not against a build
   failure
 - **Test all error paths:** Not just happy path

--- a/.claude/skills/jmo-ci-debugger/references/error-pattern-matching.md
+++ b/.claude/skills/jmo-ci-debugger/references/error-pattern-matching.md
@@ -188,7 +188,7 @@ CI Failure
     |   +-- Other test failures -> Check test code
     |
     +-- coverage-aggregate (after the shards)
-    |   +-- "is below 70% CI threshold" -> #9 Test Coverage
+    |   +-- "is below 80% CI threshold" -> #9 Test Coverage
     |       (the gate lives here, NOT in test-matrix -- the shards carry no
     |        coverage threshold of their own)
     |

--- a/.claude/skills/jmo-refactoring-assistant/references/memory-integration.md
+++ b/.claude/skills/jmo-refactoring-assistant/references/memory-integration.md
@@ -241,7 +241,7 @@ revisions of this file passed `--cov-fail-under=85` and `--cov-fail-under=90` an
 named the strategy `maintain-85-percent-coverage`. **No such floor exists in this
 repository**: `Makefile:132` runs `pytest --cov --cov-report=term-missing` with
 no threshold, `[tool.coverage.report]` in `pyproject.toml` sets no `fail_under`,
-and CI's only enforced gate is `coverage_pct < 70` at
+and CI's only enforced gate is `coverage_pct < 80` at
 [`.github/workflows/ci.yml:734`](../../../../.github/workflows/ci.yml). A refactor
 that quietly drops coverage from 87% to 86% passes every one of those, which is
 exactly why the recorded baseline — not a constant — is the thing to diff against.

--- a/.claude/skills/jmo-security-hardening/templates/security-commit-template.md
+++ b/.claude/skills/jmo-security-hardening/templates/security-commit-template.md
@@ -27,7 +27,7 @@ Defense Layers:
 Testing:
 - make fmt && make lint && make test: clean
 - [X]/[X] tests passing
-- Coverage: [NN]% (CI floor: 70%)
+- Coverage: [NN]% (CI floor: 80%)
 - Bandit: 0 findings (was [N])
 - Fuzzing: [Y]/[Y] malicious inputs blocked
 
@@ -71,7 +71,7 @@ Defense Layers:
 Testing:
 - make fmt && make lint && make test: clean
 - 123/123 tests passing
-- Coverage: 87% (CI floor: 70%)
+- Coverage: 87% (CI floor: 80%)
 - Bandit: 0 findings (was 6 vulnerable code patterns)
 - Fuzzing: 106/106 malicious inputs blocked
 
@@ -105,5 +105,5 @@ threshold is misleading here: `--cov-fail-under=85` appears in `.claude/` prose
 but in no executable path. `make test` runs `pytest ... --cov
 --cov-report=term-missing` with no `--cov-fail-under`, and
 `[tool.coverage.report]` in `pyproject.toml` sets no `fail_under`. The only
-enforced floor is **70%**, in `.github/workflows/ci.yml:734`. Put the real
+enforced floor is **80%**, in `.github/workflows/ci.yml:734`. Put the real
 measured percentage in the commit; do not claim a gate that will not fire.

--- a/.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md
+++ b/.claude/skills/jmo-systematic-debugging/references/detailed-phase-guide.md
@@ -643,7 +643,7 @@ pytest tests/integration/ -v
 # 4. Check coverage of the module you changed
 pytest --cov=scripts/core/adapters/tool_adapter --cov-fail-under=85
 # A local bar for the module under repair -- NOT a CI gate. CI's only enforced
-# floor is 70% repo-wide (ci.yml:734); --cov-fail-under is set nowhere. See #756.
+# floor is 80% repo-wide (ci.yml:734); --cov-fail-under is set nowhere. See #756.
 
 # 5. Run pre-commit hooks
 pre-commit run --all-files

--- a/.claude/skills/jmo-target-type-expander/SKILL.md
+++ b/.claude/skills/jmo-target-type-expander/SKILL.md
@@ -349,6 +349,6 @@ When adding a new target type, verify all items:
 ### Quality Assurance
 
 - [ ] Pre-commit hooks pass (`make fmt && make lint`)
-- [ ] Full test suite passes (`make test`; CI's enforced coverage floor is 70%,
+- [ ] Full test suite passes (`make test`; CI's enforced coverage floor is 80%,
       in `.github/workflows/ci.yml:734` -- nothing sets `--cov-fail-under=85`)
 - [ ] CI pipeline passes

--- a/.claude/skills/jmo-test-fabricator/SKILL.md
+++ b/.claude/skills/jmo-test-fabricator/SKILL.md
@@ -34,7 +34,7 @@ Generate comprehensive pytest test suites for JMo Security with fabricated fixtu
 
 **Config/CLI Testing:** Config loaders, YAML parsing, field validation, multi-target helpers, argument parsing.
 
-**General:** coverage below the project's 85% target (CI itself fails only below 70%, `ci.yml:734`), new CommonFinding schema features, improving coverage for any module.
+**General:** coverage below the project's 85% target (CI itself fails only below 80%, `ci.yml:734`), new CommonFinding schema features, improving coverage for any module.
 
 ---
 
@@ -352,7 +352,7 @@ Real test files from this project to use as examples:
 
 - [ ] All tests pass: `pytest tests/adapters/test_<tool>_adapter.py -v`
 - [ ] Coverage >=85% **for the new adapter module** (a local bar for new code, not
-      a CI gate — CI's only floor is 70% repo-wide, `ci.yml:734`, see #756):
+      a CI gate — CI's only floor is 80% repo-wide, `ci.yml:734`, see #756):
       `pytest ... --cov=scripts/core/adapters/<tool>_adapter --cov-fail-under=85`
 - [ ] Coverage report reviewed: `--cov-report=term-missing` shows no critical gaps
 

--- a/.claude/skills/jmo-test-fabricator/references/ci-platform-validation.md
+++ b/.claude/skills/jmo-test-fabricator/references/ci-platform-validation.md
@@ -242,7 +242,7 @@ jmo --help
 
 > **These two blocks are templates to adopt, not descriptions of this repo.**
 > JMo's real `ci.yml` shards tests with `pytest-split` and enforces coverage
-> through an inline `if coverage_pct < 70` check in the `coverage-aggregate`
+> through an inline `if coverage_pct < 80` check in the `coverage-aggregate`
 > job (`ci.yml:734`) — not via `--cov-fail-under`, which is set nowhere here
 > (#756). The real `.pre-commit-config.yaml` has **no** `pytest-adapter-coverage`
 > hook. Copying either block verbatim into this repository would add a gate that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,18 +724,18 @@ jobs:
 
           print(f"📊 Combined coverage: {coverage_pct:.1f}%")
 
-          # CI threshold is 70% (excludes requires_tools/docker/smoke tests).
+          # CI threshold is 80% (excludes requires_tools/docker/smoke tests).
           # The aggregate XML merge in the previous step recomputes line-rate
           # from merged <line> hits, so this reads true aggregate coverage
           # rather than shard-1's standalone value (which was the source of
           # the spurious "drop from 71.6% to 68.7%" investigated in PR #355).
-          # No higher floor is enforced anywhere: `--cov-fail-under` is unset
-          # repo-wide and `make test` carries no threshold either. See #756.
-          if coverage_pct < 70:
-              print(f"❌ Coverage {coverage_pct:.1f}% is below 70% CI threshold")
+          # Raised 70 -> 80 after measuring 86.4%, stable +/-0.1 over 5 runs.
+          # `--cov-fail-under` is still unset repo-wide -- see #756.
+          if coverage_pct < 80:
+              print(f"❌ Coverage {coverage_pct:.1f}% is below 80% CI threshold")
               sys.exit(1)
           else:
-              print(f"✅ Coverage {coverage_pct:.1f}% meets 70% CI threshold")
+              print(f"✅ Coverage {coverage_pct:.1f}% meets 80% CI threshold")
           EOF
 
       - name: Upload coverage to Codecov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Setup: [docs/MCP_SETUP.md](docs/MCP_SETUP.md)
 - **Subprocess security:** Never use `shell=True` — always pass command as list
 - **Adapter naming:** `PluginMetadata.name` uses underscores matching filename
 - **Compliance enrichment:** Handled centrally in `normalize_and_report.py`, not in adapters
-- **Test coverage:** CI's only enforced floor is **70%** (`.github/workflows/ci.yml:734`). Nothing sets `--cov-fail-under` anywhere (#756)
+- **Test coverage:** CI's only enforced floor is **80%** (`.github/workflows/ci.yml:734`). Nothing sets `--cov-fail-under` anywhere (#756)
 - **Conventional commits:** `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `ci:`
 
 ## Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ JMo Security is a terminal-first security audit toolkit orchestrating 29 scanner
 
 **Version:** v1.0.8 (latest released — see CHANGELOG.md for full history)
 **Philosophy:** Two-phase architecture: scan (invoke tools) → report (normalize, dedupe, output)
-**Test Coverage:** 8,000+ tests, sharded across 4 parallel jobs. The **only enforced floor is 70%** (`.github/workflows/ci.yml:734`, on the marker-filtered suite — excludes slow/docker/requires_tools/smoke). Nothing sets `--cov-fail-under` (#756); measure current coverage rather than quoting a figure from this file
+**Test Coverage:** 8,000+ tests, sharded across 4 parallel jobs. The **only enforced floor is 80%** (`.github/workflows/ci.yml:734`, on the marker-filtered suite — excludes slow/docker/requires_tools/smoke). Nothing sets `--cov-fail-under` (#756); measure current coverage rather than quoting a figure from this file
 
 **Key v1.0 Features:**
 
@@ -27,7 +27,7 @@ JMo Security is a terminal-first security audit toolkit orchestrating 29 scanner
 ### Mandatory Guardrails
 
 1. **Pre-commit Order:** Black MUST run before Ruff (see `.pre-commit-config.yaml`)
-2. **Test Coverage:** CI's only enforced floor is **70%** (`.github/workflows/ci.yml:734`, on the marker-filtered suite). Nothing sets `--cov-fail-under` — not `make test`, not `pyproject.toml`. Write tests to the standard the codebase holds itself to, but do not cite 85% as a gate (#756)
+2. **Test Coverage:** CI's only enforced floor is **80%** (`.github/workflows/ci.yml:734`, on the marker-filtered suite). Nothing sets `--cov-fail-under` — not `make test`, not `pyproject.toml`. Write tests to the standard the codebase holds itself to, but do not cite 85% as a gate (#756)
 3. **Subprocess Security:** NEVER use `shell=True` in subprocess calls. See [.claude/rules/python-safety.rules.md](.claude/rules/python-safety.rules.md)
 4. **Conventional Commits:** `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `perf:`, `ci:`
 5. **Path Security:** Validate all user paths against directory traversal
@@ -373,7 +373,7 @@ See [docs/USER_GUIDE.md](docs/USER_GUIDE.md) for complete configuration referenc
 
 | Issue | Solution |
 |-------|----------|
-| Tests failing | `make test` (already carries `--maxfail=1` via `TEST_FLAGS`). No local coverage gate exists — CI's floor is 70%, `ci.yml:734` (#756) |
+| Tests failing | `make test` (already carries `--maxfail=1` via `TEST_FLAGS`). No local coverage gate exists — CI's floor is 80%, `ci.yml:734` (#756) |
 | Tool not found | `jmo tools check`, then `jmo tools install` |
 | Tool startup crash | `jmo tools clean --force && jmo tools install <tool>` |
 | Pre-commit fails | `make fmt`, `make lint` |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -209,7 +209,7 @@ Remember to update CHANGELOG.md with user-facing changes.
 
 - **No PyPI API token required!** This repo uses Trusted Publishers (OIDC) for tokenless publishing.
 - Ensure the repository is configured as a Trusted Publisher in PyPI settings (one-time setup).
-- Ensure tests are green locally. There is no local coverage gate to pass — `make test` prints a report and sets no threshold (#756); CI's only floor is 70% (`.github/workflows/ci.yml:734`).
+- Ensure tests are green locally. There is no local coverage gate to pass — `make test` prints a report and sets no threshold (#756); CI's only floor is 80% (`.github/workflows/ci.yml:734`).
 - Update `CHANGELOG.md` with all user-facing changes from the "Unreleased" section.
 
 ## Pre-Release Checklist
@@ -840,7 +840,7 @@ docker run --rm --platform linux/amd64 jmogaming/jmo-security:latest --help
 - The package exposes the `jmo` console script.
 - Coverage reports are uploaded to Codecov as part of the tests workflow (tokenless OIDC).
 - License is defined via SPDX string in `pyproject.toml` and the `LICENSE` file is included in the distribution.
-- CI enforces: tests passing, coverage ≥70% (`.github/workflows/ci.yml:734` — the only coverage gate that exists, see #756), pre-commit checks, reproducible dev deps.
+- CI enforces: tests passing, coverage ≥80% (`.github/workflows/ci.yml:734` — the only coverage gate that exists, see #756), pre-commit checks, reproducible dev deps.
 
 ## Post-Release
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2817,7 +2817,7 @@ Common failure modes in `.github/workflows/tests.yml` and how to fix them:
   - Fix locally: `make pre-commit-run` or run individual hooks. Config lives in `.pre-commit-config.yaml`; YAML rules in `.yamllint.yaml`; ruff/black use defaults in this repo. Docs: <https://pre-commit.com/>
 
 - Test coverage threshold not met
-  - Symptom: Tests pass, but the coverage job fails with `Coverage N% is below 70% CI threshold` (`.github/workflows/ci.yml:734` — the only enforced floor).
+  - Symptom: Tests pass, but the coverage job fails with `Coverage N% is below 80% CI threshold` (`.github/workflows/ci.yml:734` — the only enforced floor).
   - Fix locally: run `pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing` to identify gaps, then add tests. High‑leverage areas include adapters' malformed/empty JSON handling and reporters' edge cases. Pytest‑cov docs: <https://pytest-cov.readthedocs.io/>
 
 - Codecov upload warnings (tokenless OIDC)

--- a/docs/internal/TESTING_MATRIX.md
+++ b/docs/internal/TESTING_MATRIX.md
@@ -15,7 +15,7 @@
 
 **Total Possible Combinations:** 6 x 28 x 3 x 5 x 6 = **15,120 test scenarios**
 **Current Test Suite:** 8,000+ tests across unit/adapters/reporters/integration
-**Coverage:** measure it before quoting it — CI's only enforced minimum is **70%** (`.github/workflows/ci.yml:734`), and nothing sets `--cov-fail-under` (#756)
+**Coverage:** measure it before quoting it — CI's only enforced minimum is **80%** (`.github/workflows/ci.yml:734`), and nothing sets `--cov-fail-under` (#756)
 
 ---
 
@@ -349,7 +349,7 @@ All 28 tools benefit from universal compliance enrichment via [scripts/core/comp
 **Current State:**
 
 - **Total Tests:** 8,000+
-- **Coverage:** measure it before quoting it — CI's only enforced minimum is **70%** (`.github/workflows/ci.yml:734`); `--cov-fail-under` is set nowhere (#756)
+- **Coverage:** measure it before quoting it — CI's only enforced minimum is **80%** (`.github/workflows/ci.yml:734`); `--cov-fail-under` is set nowhere (#756)
 - **CI Platforms:** 2 OS (Linux, macOS) x 3 Python versions (3.10, 3.11, 3.12) = 6 matrix jobs
 - **Test Categories:**
   - Unit tests


### PR DESCRIPTION
Refs #756.

## Why

Coverage measures **86.4%**. CI failed only below **70%**. That is a **16.4-point band in which a regression is invisible to the build** — #764 documented the gap honestly; this closes it.

## Why 80, from measurement

CI's own `coverage-aggregate` step, read from five runs across three branches:

| Run | Branch | Reported |
|---|---|---|
| 31240266226 | `dev` | 86.4% |
| 31239445888 | `fix/757-cvss-schema-object` | 86.4% |
| 31239443972 | `fix/757-cvss-schema-object` | 86.4% |
| 31239239989 | `docs/756-coverage-floor-honesty` | 86.5% |
| 31239238208 | `docs/756-coverage-floor-honesty` | 86.5% |

Spread **0.1 points**. An 80% floor leaves **6.4 points** of buffer — 64× the observed variance, so shard reshuffling cannot trip it. A floor that fires on noise is worse than no floor.

The measurement covers exactly what the gate sees: the **Ubuntu** shards only (`ci.yml:295-312`, `--cov=scripts`, `-m "not smoke and not requires_tools and not docker"`, `slow` **included**), merged ×4 by `coverage-aggregate`. macOS and Windows run without coverage.

## Why this is NOT `--cov-fail-under` on `make test`

#756's option 1 was measured and **rejected**:

| Finding | Measurement |
|---|---|
| `make test` cannot complete on a clean maintainer box | **4 failures** (`test_integer_overflow_in_scan_parameters` (#748), `test_quick_tier_runs`, `test_large_findings_batch_handling`, `test_100k_findings_memory_usage`). `TEST_FLAGS` carries `--maxfail=1`, so it aborts **before** coverage prints |
| Its marker set is not the one 86.4% describes | `make test` = `not smoke and not requires_tools` — **docker included**; the 86.4% excludes docker. A number from a different marker set is not the number the gate sees |
| Local collection is unreliable | xdist workers **gw3 and gw4 dropped their coverage data**, yielding a meaningless **32%** from an otherwise complete 8043-passed run |

A floor there would gate nothing and fire on environment. CI is what protects the branch, so the floor belongs in CI.

## Proof the new gate can fail

Running the exact block from `ci.yml:734-738`:

| Input | Result | exit |
|---|---|---|
| 86.4% (today) | PASS | 0 |
| 80.0% | PASS | 0 |
| **79.9%** | **REJECT** | **1** |
| 68.7% | REJECT | 1 |

79.9% is the case that matters: it **passed the old gate and fails the new one**.

## Scope: 25 sites, 21 files

#764 had just written "70%" across the whole documentation surface, so leaving any behind recreates exactly the contradiction #764 existed to remove.

**`if coverage_pct < 80:` stays on line 734** — the comment edit is length-preserving on purpose, because **13 files cite `ci.yml:734`** and a one-line drift would silently invalidate all of them. Verified after editing.

### Three sites needed judgment, not substitution

- **`ci-failure-catalog.md`** — its example failure showed `68.7%`, which fails both floors and so no longer illustrates the new one. Now **78.9%**: a value that passes the old gate and fails the new one, which is the case a reader must learn to recognise.
- **`testing.cross-platform.rules.md`** — tabulated a **"Quick coverage check" job that does not exist**, with a `≥70% threshold` it never had, citing `:352` — which is the **Windows shard**, a step literally named *"Run tests (Windows, no coverage)"*. The same bullet attributed `:448` to `nightly-cross-platform`; `:448` is a `--collect-only` count guard inside `windows-native-encoding`, and `nightly-cross-platform` lives in **`scheduled.yml:241`**, a different file. Bumping that row's number would have preserved the fiction, so the region is rewritten against what the workflow does. (The table also called the sharded job `quick-checks`; it is `test-sharded`.)
- **`CHANGELOG.md`** — left alone. "Threshold restored 68% → 70%" records what was true at a past release; rewriting it falsifies history rather than updating a claim.

## Verification

| Check | Result |
|---|---|
| `if coverage_pct < 80:` still line 734 | yes — 13 citations stay valid |
| Gate rejects 79.9%, accepts 80.0% | verified, table above |
| Repo-wide sweep for surviving `70%`-as-coverage-floor | **0** (remaining `70`s are `40-70 min` scan durations, Trivy `0.70.0`, grade bands `70-79`, a Slack progress bar) |
| `ci.yml` parses | yes, 7 jobs |
| markdownlint-cli2 / yamllint / actionlint | Passed |
| `check_doc_links.py` | 161 files, all resolve |
| Full pre-commit at commit | 22 hooks, 0 failures |
| EOL flip check | clean |

**The live check on this PR is itself the last piece of evidence:** if `coverage-aggregate` goes green, the new floor has been exercised against real coverage on real CI.
