### PR TITLE
fix(e2e): stop the e2e gate reporting success over a failing suite

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -908,9 +908,44 @@ jobs:
             echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
           fi
 
-      - name: Install external security tools via Homebrew
+      - name: Install external security tools
         run: |
-          brew install semgrep trivy syft checkov hadolint || echo "Some tools failed"
+          set -euo pipefail
+
+          # checkov is pinned from versions.yaml AT RUNTIME, not copied into
+          # this file. Two separate defects made run 31241312938 report a
+          # green tick over a scanner that found nothing (#769):
+          #
+          #   1. Homebrew installs whatever bottle is current. It gave this job
+          #      checkov 3.3.0 against a versions.yaml pin of 3.3.8, and 3.3.0
+          #      returned zero findings on a deliberately vulnerable fixture.
+          #      A hardcoded pin here would only move the drift -- that is #747
+          #      (ci.yml said trufflehog 3.94.3, versions.yaml said 3.95.9).
+          #      Reading the source of truth leaves nowhere to forget.
+          #   2. `|| echo "Some tools failed"` made a scanner that never
+          #      installed indistinguishable from one that found nothing.
+          CHECKOV_VERSION="$(python3 -c \
+            "import yaml; print(yaml.safe_load(open('versions.yaml'))['python_tools']['checkov']['version'])")"
+          echo "checkov pin from versions.yaml: ${CHECKOV_VERSION}"
+          uv pip install "checkov==${CHECKOV_VERSION}"
+
+          # Binary tools have no per-version Homebrew formulae, so they stay
+          # unpinned -- but the install may no longer fail quietly. Pinning
+          # these too is a real remaining gap, tracked separately.
+          brew install semgrep trivy syft hadolint
+
+          missing=0
+          for t in checkov semgrep trivy syft hadolint; do
+            if command -v "$t" >/dev/null 2>&1; then
+              echo "  $t -> $(command -v "$t")"
+            else
+              echo "::error::$t did not install"
+              missing=1
+            fi
+          done
+          [[ "${missing}" -eq 0 ]] || exit 1
+
+          checkov --version
 
       - name: Run macOS test suite
         run: |
@@ -1213,8 +1248,12 @@ jobs:
               "$1" "$2" 2>/dev/null || echo 0
           }
 
+          reports=0
+          total_failed=0
+
           for report_file in test-results/*/pytest-report.json; do
             if [[ -f "$report_file" ]]; then
+              reports=$((reports + 1))
               job=$(dirname "$report_file" | xargs basename \
                 | sed 's/-results-.*//' | sed 's/e2e-//')
 
@@ -1222,6 +1261,7 @@ jobs:
               passed=$(get_field "$report_file" passed)
               failed=$(get_field "$report_file" failed)
               skipped=$(get_field "$report_file" skipped)
+              total_failed=$((total_failed + failed))
 
               {
                 echo "### $job Results"
@@ -1235,6 +1275,10 @@ jobs:
           done
 
           cat summary.md
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+
+          echo "E2E_REPORTS=$reports" >> "$GITHUB_ENV"
+          echo "E2E_TOTAL_FAILED=$total_failed" >> "$GITHUB_ENV"
 
       - name: Upload summary
         uses: actions/upload-artifact@v7
@@ -1242,6 +1286,37 @@ jobs:
           name: e2e-test-summary-${{ github.run_id }}
           path: summary.md
           retention-days: 90
+
+      # The five e2e jobs run their pytest step under `continue-on-error: true`
+      # so that results and logs still upload when tests fail. The side effect
+      # was that a failing suite rendered as a green check: run 31241312938 had
+      # `2 failed` and an explicit "E2E Release Readiness: FAIL (89.5%)" in the
+      # macOS log while every job, and the run, reported success.
+      #
+      # This step is the gate. It runs after the artifacts are safely uploaded,
+      # reads the same pytest-report.json files the summary above already
+      # parses, and is the only thing here allowed to fail the run.
+      #
+      # Absent evidence fails too: zero reports means the suites did not run,
+      # which must not be indistinguishable from a clean pass. That is the same
+      # mistake in a different costume.
+      - name: Fail the run if any e2e test failed
+        run: |
+          echo "reports found: ${E2E_REPORTS} | tests failed: ${E2E_TOTAL_FAILED}"
+
+          if [[ "${E2E_REPORTS}" -eq 0 ]]; then
+            echo "::error::No pytest-report.json was produced by any e2e job." \
+              "The suites did not run, so this is a failure, not a pass."
+            exit 1
+          fi
+
+          if [[ "${E2E_TOTAL_FAILED}" -gt 0 ]]; then
+            echo "::error::${E2E_TOTAL_FAILED} e2e test(s) failed." \
+              "See the job summary above for the per-suite breakdown."
+            exit 1
+          fi
+
+          echo "All ${E2E_REPORTS} e2e suite(s) reported zero failures."
 
 # ==============================================================================
 # PERFORMANCE TESTS - Benchmark comparison

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1287,11 +1287,18 @@ jobs:
           path: summary.md
           retention-days: 90
 
-      # The five e2e jobs run their pytest step under `continue-on-error: true`
-      # so that results and logs still upload when tests fail. The side effect
-      # was that a failing suite rendered as a green check: run 31241312938 had
-      # `2 failed` and an explicit "E2E Release Readiness: FAIL (89.5%)" in the
-      # macOS log while every job, and the run, reported success.
+      # e2e-ubuntu and e2e-macos run their pytest step under
+      # `continue-on-error: true` so that results and logs still upload when
+      # tests fail. The side effect was that a failing suite rendered as a
+      # green check: run 31241312938 had `2 failed` and an explicit
+      # "E2E Release Readiness: FAIL (89.5%)" in the macOS log while every job,
+      # and the run, reported success.
+      #
+      # Those two are also the only jobs that upload a pytest-report.json, so
+      # two reports -- not five -- is the expected count here. The other three
+      # e2e jobs (tool-integration, contract, visual) have no
+      # continue-on-error, so a failure in one of them already fails the run on
+      # its own and needs no gate.
       #
       # This step is the gate. It runs after the artifacts are safely uploaded,
       # reads the same pytest-report.json files the summary above already
@@ -1300,6 +1307,10 @@ jobs:
       # Absent evidence fails too: zero reports means the suites did not run,
       # which must not be indistinguishable from a clean pass. That is the same
       # mistake in a different costume.
+      #
+      # TODO(issue-772): partial absence is not caught yet -- one report when
+      # two are expected still passes. Tightening that needs a count that
+      # survives adding a sixth e2e job; see the issue for the options.
       - name: Fail the run if any e2e test failed
         run: |
           echo "reports found: ${E2E_REPORTS} | tests failed: ${E2E_TOTAL_FAILED}"

--- a/scripts/core/adapters/shellcheck_adapter.py
+++ b/scripts/core/adapters/shellcheck_adapter.py
@@ -65,6 +65,25 @@ from scripts.core.plugin_api import (
     adapter_plugin,
 )
 
+# Per-rule severity overrides, applied after the normal level -> severity map.
+#
+# The level mapping itself is correct: shellcheck really does report these at
+# `level: "error"`, and error -> HIGH is right for the rules that describe what
+# a script *does*. These describe how the file is *encoded*, and they fire once
+# per line, so a single mis-saved file can outweigh every real finding in a
+# scan.
+#
+# Measured on Juice Shop, `fast` profile, Windows checkout (#768): SC1017 alone
+# produced 83 findings from 2 files -- 35% of the whole scan -- and every one
+# was HIGH. Excluding them took the scan from 234 findings to 151, and HIGH
+# from 99 to 16.
+#
+# Downgraded rather than suppressed: "this file has CRLF line endings" is worth
+# reporting, it is just not a HIGH security finding.
+RULE_SEVERITY_OVERRIDES: dict[str, str] = {
+    "SC1017": "INFO",  # Literal carriage return; fires per line on CRLF files.
+}
+
 
 @adapter_plugin(
     PluginMetadata(
@@ -181,8 +200,11 @@ def _load_shellcheck_internal(path: str | Path) -> list[dict[str, Any]]:
         code_str = f"SC{code}" if isinstance(code, int) else str(code or "SC0000")
         message = str(item.get("message") or code_str)
 
-        # Map level to severity using centralized mapping
-        severity = map_tool_severity("shellcheck", level)
+        # Map level to severity using centralized mapping, then apply any
+        # per-rule override (see RULE_SEVERITY_OVERRIDES for why).
+        severity = RULE_SEVERITY_OVERRIDES.get(
+            code_str, map_tool_severity("shellcheck", level)
+        )
 
         # Create fingerprint
         fid = fingerprint("shellcheck", code_str, file_path, start_line, message)

--- a/tests/adapters/test_shellcheck_adapter.py
+++ b/tests/adapters/test_shellcheck_adapter.py
@@ -143,6 +143,64 @@ def test_shellcheck_level_mapping_function():
     assert map_tool_severity("shellcheck", "unknown") == "INFO"
 
 
+def test_sc1017_is_downgraded_to_info_but_still_reported(tmp_path: Path):
+    """SC1017 is a CRLF encoding lint, not a HIGH security finding (#768).
+
+    shellcheck emits it at `level: "error"`, once per line, so a single
+    CRLF-saved file can dominate a scan: measured 83 HIGH findings from 2 files
+    on Juice Shop, 35% of the whole `fast` profile.
+
+    It is downgraded, not dropped -- the finding still exists, at INFO.
+    """
+    sample = [
+        {
+            "file": "bootstrap.sh",
+            "line": n,
+            "endLine": n,
+            "column": 1,
+            "endColumn": 1,
+            "level": "error",
+            "code": 1017,
+            "message": "Literal carriage return. Run script through tr -d '\\r' .",
+        }
+        for n in (1, 2, 3)
+    ]
+    p = write(tmp_path, "shellcheck.json", json.dumps(sample))
+
+    findings = ShellCheckAdapter().parse(p)
+
+    assert len(findings) == 3, "downgraded, not suppressed - all 3 still reported"
+    assert {f.severity for f in findings} == {"INFO"}
+    assert {f.ruleId for f in findings} == {"SC1017"}
+
+
+def test_other_error_level_rules_stay_high(tmp_path: Path):
+    """The override is scoped to SC1017; `error -> HIGH` is otherwise intact.
+
+    Guards the obvious wrong fix for #768 -- demoting every shellcheck `error`,
+    which would hide real defects along with the CRLF noise.
+    """
+    sample = [
+        {
+            "file": "script.sh",
+            "line": 1,
+            "endLine": 1,
+            "column": 1,
+            "endColumn": 1,
+            "level": "error",
+            "code": 1073,
+            "message": "Couldn't parse this if expression.",
+        }
+    ]
+    p = write(tmp_path, "shellcheck.json", json.dumps(sample))
+
+    findings = ShellCheckAdapter().parse(p)
+
+    assert len(findings) == 1
+    assert findings[0].ruleId == "SC1073"
+    assert findings[0].severity == "HIGH"
+
+
 def test_shellcheck_empty_results(tmp_path: Path):
     """Test ShellCheck adapter handles empty array."""
     sample = []

--- a/tests/e2e/test_wizard_workflows.py
+++ b/tests/e2e/test_wizard_workflows.py
@@ -32,8 +32,16 @@ class TestWizardWorkflows:
                 "scripts.cli.jmo",
                 "wizard",
                 "--yes",
-                "--repos-dir",
+                # `--repos-dir` is a `jmo scan` flag, not a wizard flag -- the
+                # wizard takes `--target` / `--target-type`. Passing it made
+                # argparse exit 2 before `--emit-script` was ever read, so this
+                # test asserted nothing about emitted scripts. Confusingly, the
+                # script the wizard *emits* does contain `--repos-dir`, because
+                # that is the scan command it generates.
+                "--target",
                 str(E2E_FIXTURES),
+                "--target-type",
+                "repo",
                 "--profile",
                 "fast",
                 "--emit-script",
@@ -45,7 +53,7 @@ class TestWizardWorkflows:
         )
         assert result.returncode == 0, f"Wizard failed: {result.stderr[:500]}"
         assert script_path.exists(), "Emitted script not created"
-        content = script_path.read_text()
+        content = script_path.read_text(encoding="utf-8")
         # Script must contain actual jmo scan/ci command, not just a mention
         assert any(
             cmd in content for cmd in ["jmo scan", "jmo ci", "scripts.cli.jmo"]
@@ -64,8 +72,16 @@ class TestWizardWorkflows:
                 "scripts.cli.jmo",
                 "wizard",
                 "--yes",
-                "--repos-dir",
+                # `--repos-dir` is a `jmo scan` flag, not a wizard flag -- the
+                # wizard takes `--target` / `--target-type`. Passing it made
+                # argparse exit 2 before `--emit-script` was ever read, so this
+                # test asserted nothing about emitted scripts. Confusingly, the
+                # script the wizard *emits* does contain `--repos-dir`, because
+                # that is the scan command it generates.
+                "--target",
                 str(E2E_FIXTURES),
+                "--target-type",
+                "repo",
                 "--profile",
                 "fast",
                 "--emit-script",
@@ -77,7 +93,7 @@ class TestWizardWorkflows:
         )
         assert result.returncode == 0, f"Wizard failed: {result.stderr[:500]}"
         assert script_path.exists(), "Emitted script not created"
-        content = script_path.read_text()
+        content = script_path.read_text(encoding="utf-8")
         # Script must contain actual jmo scan/ci command, not just a mention
         assert any(
             cmd in content for cmd in ["jmo scan", "jmo ci", "scripts.cli.jmo"]

--- a/tests/security/test_input_validation.py
+++ b/tests/security/test_input_validation.py
@@ -139,7 +139,21 @@ args: ['echo pwned > /tmp/yaml-pwned.txt']
         test_env = os.environ.copy()
         test_env["CI"] = "true"
 
-        # Test with absurdly large timeout value
+        # Test with absurdly large timeout value.
+        #
+        # `--tools`/`--allow-missing-tools` bound the work to one scanner. This
+        # test asserts the CLI does not crash on a huge integer; it does not
+        # need a full profile to prove that, and running one made its runtime a
+        # function of how many scanners the developer happens to have installed
+        # (#748). CI installs none, so the scan found nothing to run and
+        # returned in seconds -- it passed there for releases while failing on
+        # any machine with real tools.
+        #
+        # Measured on a box with 8 scanners in ~/.jmo/bin: the unbounded form
+        # exceeded 45s (the 30s cap below could never be met), redirecting HOME
+        # so no tools resolve still took 26s against that 30s cap, and this
+        # bounded form takes 12s. Only the last one is independent of the
+        # machine it runs on.
         result = subprocess.run(
             [
                 sys.executable,
@@ -147,12 +161,15 @@ args: ['echo pwned > /tmp/yaml-pwned.txt']
                 "scan",
                 "--repo",
                 str(tmp_path),
+                "--tools",
+                "trufflehog",
+                "--allow-missing-tools",
                 "--timeout",
                 "999999999999999",  # Absurdly large
             ],
             capture_output=True,
             text=True,
-            timeout=30,  # Increased from 5s for slower systems
+            timeout=60,
             env=test_env,
         )
 


### PR DESCRIPTION
Refs #769, #768, #748.

## The gate could not fail

Run `31241312938` dispatched all six e2e jobs. **Every one reported success.** The macOS log contained:

```
E2E Release Readiness: FAIL (89.5% pass rate, threshold: 95%)
===== 2 failed, 17 passed, 15 skipped, 60 deselected =====
```

`continue-on-error: true` on the pytest steps — there so results and logs still upload on failure — meant nothing downstream saw the exit code. #752 exists to *run* this gate, and the gate was structurally incapable of failing.

**The fix lands in `e2e-summary`**, which already downloads every `pytest-report.json` and parses the failure counts, then discarded them. It now fails the run when any suite reports a failure — **and when zero reports are found**, because "the suites never ran" must not be indistinguishable from "the suites passed". That is the same mistake in a different costume. `continue-on-error` stays, so artifacts still upload.

## Then the two failures it was hiding

### 1. A test that had never tested anything

`test_wizard_emit_script_macos` passed `--repos-dir`. **`jmo wizard` has no such flag** — it takes `--target`/`--target-type`; `--repos-dir` belongs to `jmo scan`. It exited at argparse with rc=2 *before* `--emit-script` was read, so every assertion below it had never run.

The Windows sibling had the identical defect and is worse off: the class is `requires_tools`, which **no Windows job runs**, so it failed nowhere at all. Both fixed. The Windows one now **passes locally, having never executed before**.

### 2. checkov's zero findings — an unpinned, failure-swallowing install

Reproduced locally through the same JMo path — **8 failed_checks**, including `CKV2_AWS_6` which satisfies the test's own `found_s3_public` condition. **IaC routing is fine**; that was the serious possibility and it is ruled out.

| | |
|---|---|
| `versions.yaml` pin | checkov **3.3.8** |
| Runner ran | **3.3.0** |
| Install line | `brew install semgrep trivy syft checkov hadolint \|\| echo "Some tools failed"` |

Unpinned **and** failure-swallowing. checkov is now installed at the `versions.yaml` pin read **at runtime** — a hardcoded copy is precisely #747 (`ci.yml` said trufflehog 3.94.3 while `versions.yaml` said 3.95.9) — and a tool that fails to install now fails the step instead of leaving a scanner silently absent.

## Also in scope, because the same run surfaced them

### SC1017 → INFO (#768)

A CRLF encoding lint that fires **once per line**. On a Windows checkout of Juice Shop: **83 findings from 2 files, 35% of an entire `fast` scan, every one HIGH.**

| | before | after |
|---|---|---|
| Total findings | 234 | **234** |
| HIGH | 99 | **16** |

Total unchanged — **nothing is hidden**. The level mapping is correct and untouched; `error -> HIGH` still holds for every other rule, guarded by `test_other_error_level_rules_stay_high`. Mutation-verified: removing the override fails exactly the new test, restoring gives 20 passed.

**Deliberately not deduplication.** Collapsing by `(tool, ruleId, file)` was measured on the real scan: it merges the **4 distinct `CKV_SECRET_6` secrets in `users.yml` into 1**, and destroys 12 `syft` SBOM package entries. Adding title+message still merges the secrets. The lossless version is #770.

### #748 — a test whose runtime depended on the developer's tool installation

`test_integer_overflow_in_scan_parameters` asserts only `returncode in [0,1,2]` — that a huge `--timeout` does not crash the CLI — but ran a **full profile** to prove it. CI installs no scanners, so it returned in seconds and passed there for releases, while failing on any machine with real tools.

| Variant | Elapsed |
|---|---|
| As written, 8 scanners installed | **>45 s** (30 s cap unmeetable) |
| `HOME` redirected so no tools resolve | 26 s — against a 30 s cap |
| **Bounded to one tool (this PR)** | **12 s** |

## Verification

| Check | Result |
|---|---|
| Changed tests | **22 passed, 1 skipped** (the macOS-only wizard test) |
| SC1017 mutation | override removed → exactly the new test fails; restored → 20 passed |
| Real-scan effect | 234 → 234 findings, HIGH 99 → 16 |
| Full shard filter, `-n auto` | 6 failures — **all six diagnosed as local oversubscription**, see below |
| Controlled A/B, same 6 IDs, serial, **with these changes** | **5 passed, 1 failed** — the 1 being #748, now fixed here |
| pre-commit at commit | 22 hooks, 0 failures |
| EOL flip check | clean |

**On the 6 shard-filter failures:** four `subprocess.TimeoutExpired`, two crashed xdist workers, and grype flagged `contradictory` (killed after writing output — the exact signature `release.rules.md` documents). All of them spawn a real `jmo scan`. CI pins `JMO_THREADS: "2"` and shards across 4 machines; a local `-n auto` on 20 cores lets 20 workers each launch a scan with ~20 threads. Same root cause as #767. Running them serially, **with these changes applied**, 5 of 6 pass — so none is caused by this PR, and the sixth is #748, fixed here.


---

## The gate CI structurally cannot run

`scheduled.yml` triggers on `schedule` and `workflow_dispatch` only — no
`push`, no `pull_request`. So **every CI run on this PR validates the three
collateral changes and none of the gate itself.** The gate was instead
exercised directly, on this branch's head, before merge:

```
gh workflow run scheduled.yml --ref fix/769-e2e-truthful-gate -f task=e2e
```

Run [31280793604](https://github.com/jimmy058910/jmo-security-repo/actions/runs/31280793604),
confirmed running `fc1c8b0` (not `dev`'s copy of the workflow).

### Result — and the number that needed explaining

```
reports found: 2 | tests failed: 0
All 2 e2e suite(s) reported zero failures.
```

| Suite | Total | Passed | Failed | Skipped |
|---|---|---|---|---|
| macos | 33 | 19 | **0** | 14 |
| ubuntu | 25 | 15 | **0** | 10 |

macOS log: `E2E Release Readiness: PASS (100.0% pass rate, threshold: 95%)`.
Run 31241312938 — the run that motivated this PR — had `2 failed` and
`FAIL (89.5%)` at the same place. **The wizard fix in this PR is what closed
those two**, so the suite this gate guards is now genuinely clean rather than
quietly dirty.

"Two reports, five jobs" is correct by design; the comment that said otherwise
is fixed in `76be78a`:

| Job | `continue-on-error` | uploads report | matched by `e2e-*-results-*` |
|---|---|---|---|
| `e2e-ubuntu` | yes (:843) | yes, `if: always()` | yes |
| `e2e-macos` | yes (:965) | yes, `if: always()` | yes |
| `e2e-tool-integration` | no | no | name yes, no report |
| `tool-contract-tests` | no | no | no |
| `e2e-visual` | no | no | no |

Only the two silenced jobs are the two the gate reads. The other three fail
the run natively.

### The failure path, proven red-green

The live run exercised the **pass** branch, which is not proof the gate can
fail. The step's script was extracted verbatim from `fc1c8b0` and driven
through every path:

| `E2E_REPORTS` / `E2E_TOTAL_FAILED` | exit | branch |
|---|---|---|
| `2` / `0` | `0` | matches the live run's output byte-for-byte |
| `2` / `3` | **`1`** | **failure path — the thing being added** |
| `0` / `0` | `1` | absent evidence |
| both unset | `1` | guard's own failure mode fails *safe* |

`GITHUB_ENV` propagation is proven by the live run (both variables arrived
populated); the branch logic is proven above.

### Known remaining gap — #772

The `reports == 0` guard catches total absence, not partial: one report where
two are expected still passes. Filed as #772 rather than patched here, because
the fix needs a count that survives adding a sixth e2e job and that is a design
call, not a one-liner. Current behaviour is strictly better than `dev`.
