### PR TITLE
fix(validate): make --tier full assert contracts this project still holds

### DIFF
--- a/scripts/core/validators/cli_validator.py
+++ b/scripts/core/validators/cli_validator.py
@@ -525,15 +525,25 @@ def _check_scan_help_mentions_repo() -> CheckResult | None:
 # ---------------------------------------------------------------------------
 
 
+# `jmo tools check` probes all 29 registry entries. Measured standalone on a
+# Windows box with the tools actually installed: 49s cold, 33s warm. The bound
+# here was 60s -- 1.22x the cold run -- and this validator is itself the load,
+# spawning subprocess checks throughout, so the check ERRORed and `--tier full`
+# reported NO-GO (#773). Same shape as #748, where a bound with 1.03-1.36x
+# headroom passed on a machine with no tools installed and failed on one that
+# had them. Sized at ~3.7x the cold measurement instead.
+_TOOLS_CHECK_TIMEOUT = 180
+
+
 def _full_tools_check() -> CheckResult | None:
     """Run 'jmo tools check' and verify it completes."""
     try:
-        result = _run_jmo("tools", "check", timeout=60)
+        result = _run_jmo("tools", "check", timeout=_TOOLS_CHECK_TIMEOUT)
     except subprocess.TimeoutExpired:
         return CheckResult(
             name="full: tools check",
             status=CheckStatus.ERROR,
-            message="Timed out (60s)",
+            message=f"Timed out ({_TOOLS_CHECK_TIMEOUT}s)",
         )
     # tools check may return non-zero if tools are missing, but
     # it should at least produce output and not crash

--- a/scripts/core/validators/release_validator.py
+++ b/scripts/core/validators/release_validator.py
@@ -1117,23 +1117,34 @@ def _check_test_count() -> CheckResult:
         )
 
 
+# The floor CI actually enforces, at .github/workflows/ci.yml:734
+# (`if coverage_pct < 80: sys.exit(1)`). This check demanded 85 until #773 -- a
+# number nothing in the repo has ever enforced (#756), so it could only ever
+# WARN, no matter how healthy coverage was. #766 raised the real floor from 70
+# to 80 and updated its citations; this site was missed because only
+# `--tier full` reaches it and that tier had never been run.
+_ENFORCED_COVERAGE_FLOOR = 80
+
+
 def _check_coverage_threshold() -> CheckResult:
-    """Coverage configuration requires >=85%."""
+    """Coverage configuration meets the floor CI enforces."""
     # Check pyproject.toml or .coveragerc for threshold
     try:
         _get_pyproject_data()  # validate pyproject.toml is loadable
-        # Check if CI config implies 85%
         # Also check Makefile for --cov-fail-under
         if _path_exists("Makefile"):
             makefile = _read_text("Makefile")
             m = re.search(r"--cov-fail-under[=\s]+(\d+)", makefile)
             if m:
                 threshold = int(m.group(1))
-                if threshold < 85:
+                if threshold < _ENFORCED_COVERAGE_FLOOR:
                     return CheckResult(
                         name="coverage-threshold",
                         status=CheckStatus.FAIL,
-                        message=f"Coverage threshold is {threshold}% (need >=85%)",
+                        message=(
+                            f"Coverage threshold is {threshold}% "
+                            f"(need >={_ENFORCED_COVERAGE_FLOOR}%)"
+                        ),
                     )
                 return CheckResult(
                     name="coverage-threshold",
@@ -1149,17 +1160,19 @@ def _check_coverage_threshold() -> CheckResult:
         m = re.search(r"--cov-fail-under[=\s]+(\d+)", ci)
         if m:
             threshold = int(m.group(1))
-            if threshold >= 85:
+            if threshold >= _ENFORCED_COVERAGE_FLOOR:
                 return CheckResult(
                     name="coverage-threshold",
                     status=CheckStatus.PASS,
                     message=f"CI enforces {threshold}% coverage",
                 )
-        # Also check inline Python threshold (e.g. "if coverage_pct < 85:")
+        # Also check inline Python threshold (e.g. "if coverage_pct < 80:").
+        # This is the branch that actually fires: nothing in this repo sets
+        # --cov-fail-under (#756), so ci.yml's inline check is the only gate.
         m = re.search(r"coverage_pct\s*<\s*(\d+)", ci)
         if m:
             threshold = int(m.group(1))
-            if threshold >= 85:
+            if threshold >= _ENFORCED_COVERAGE_FLOOR:
                 return CheckResult(
                     name="coverage-threshold",
                     status=CheckStatus.PASS,
@@ -1168,7 +1181,7 @@ def _check_coverage_threshold() -> CheckResult:
     return CheckResult(
         name="coverage-threshold",
         status=CheckStatus.WARN,
-        message="Cannot verify coverage threshold >=85%",
+        message=f"Cannot verify coverage threshold >={_ENFORCED_COVERAGE_FLOOR}%",
     )
 
 
@@ -1500,31 +1513,47 @@ def _check_dockerfile_build(dockerfile: str) -> CheckResult:
     return None  # type: ignore[return-value]
 
 
-def _check_pip_install() -> CheckResult:
-    """pip install -e '.[dev]' succeeds."""
+def _check_dev_install() -> CheckResult:
+    """The documented dev install resolves against the lockfile.
+
+    This probed `pip install -e '.[dev]' --dry-run` until #773, which was wrong
+    twice over. The `[project.optional-dependencies] dev` extra was removed by
+    the uv migration (#683) in favour of a PEP 735 `[dependency-groups]` group
+    -- pyproject.toml records why -- so that extra failing is the intended
+    state, not a defect. And uv-created venvs ship no pip, so `python -m pip`
+    exits 1 with "No module named pip" rather than raising FileNotFoundError:
+    the SKIP guard below could never fire on the project's own primary dev
+    path, and the check reported FAIL on a correctly configured machine.
+
+    The guard was right in shape and attached to the wrong probe. A missing
+    `uv` executable does raise FileNotFoundError, so it now means what it says.
+
+    Only `--tier full` reaches this check, which is why it went unnoticed until
+    that tier was run for the first time.
+    """
     try:
         result = _run_cmd(
-            [sys.executable, "-m", "pip", "install", "-e", ".[dev]", "--dry-run"],
+            ["uv", "sync", "--locked", "--group", "dev", "--dry-run"],
             timeout=120,
         )
         if result.returncode != 0:
             return CheckResult(
-                name="pip-install-dev",
+                name="dev-install",
                 status=CheckStatus.FAIL,
-                message="pip install -e '.[dev]' would fail",
+                message="uv sync --locked --group dev would fail",
                 details=(result.stderr or "")[:500],
             )
     except FileNotFoundError:
         return CheckResult(
-            name="pip-install-dev",
+            name="dev-install",
             status=CheckStatus.SKIP,
-            message="pip not available",
+            message="uv not available",
         )
     except subprocess.TimeoutExpired:
         return CheckResult(
-            name="pip-install-dev",
+            name="dev-install",
             status=CheckStatus.SKIP,
-            message="pip install timed out",
+            message="uv sync timed out",
         )
     return None  # type: ignore[return-value]
 
@@ -1646,7 +1675,7 @@ def validate_release(tier: str) -> CategoryResult:
                     _make_docker_check(dockerfile),
                 )
             )
-        checks.append(timed_check("pip-install-dev", _check_pip_install))
+        checks.append(timed_check("dev-install", _check_dev_install))
         checks.append(timed_check("jmo-entry-point", _check_jmo_version_entry_point))
 
     return CategoryResult(name="Release Artifacts", checks=checks)

--- a/tests/core/test_cli_validator.py
+++ b/tests/core/test_cli_validator.py
@@ -1064,6 +1064,31 @@ class TestFullTierEdgeCases:
             result = _full_tools_check()
             assert result.status == CheckStatus.FAIL
 
+    def test_full_tools_check_bound_clears_the_measured_runtime(self):
+        """The bound must survive the validator's own load (#773).
+
+        `jmo tools check` probes all 29 registry entries -- measured 49s cold
+        and 33s warm, standalone, on a box with the tools installed. The old
+        60s literal was 1.22x the cold run while this validator spawns
+        subprocess checks alongside it, so the check ERRORed and `--tier full`
+        reported NO-GO. Same shape as #748, where a bound sized against an
+        unloaded machine failed on one that had the tools.
+
+        The other two cases here mock `_run_jmo` wholesale, so nothing else in
+        this file would notice the bound being tightened again.
+        """
+        from scripts.core.validators.cli_validator import (
+            _TOOLS_CHECK_TIMEOUT,
+            _full_tools_check,
+        )
+
+        assert _TOOLS_CHECK_TIMEOUT >= 150, "must clear the 49s cold measurement"
+
+        with patch("scripts.core.validators.cli_validator._run_jmo") as mock_run:
+            mock_run.return_value = _mock_completed(returncode=0, stdout="ok")
+            _full_tools_check()
+            assert mock_run.call_args.kwargs["timeout"] == _TOOLS_CHECK_TIMEOUT
+
     def test_full_diff_auto_accepts_rc_two(self):
         """diff --auto with rc=2 (no git context) is acceptable."""
         from scripts.core.validators.cli_validator import _full_diff_auto

--- a/tests/core/test_release_validator.py
+++ b/tests/core/test_release_validator.py
@@ -19,6 +19,7 @@ from scripts.core.validators.release_validator import (
     _check_contributing_exists,
     _check_coverage_threshold,
     _check_deep_profile_versions,
+    _check_dev_install,
     _check_dockerfile_build,
     _check_docs_key_files,
     _check_git_clean,
@@ -39,7 +40,6 @@ from scripts.core.validators.release_validator import (
     _check_no_skip_without_reason,
     _check_no_sleep_in_tests,
     _check_outdated_tools,
-    _check_pip_install,
     _check_precommit_order,
     _check_precommit_yml,
     _check_pypi_badge_version,
@@ -936,6 +936,27 @@ class TestTestHealthChecks:
         result = _check_coverage_threshold()
         assert result.status == CheckStatus.PASS
 
+    @patch("scripts.core.validators.release_validator._path_exists")
+    @patch("scripts.core.validators.release_validator._read_text")
+    @patch("scripts.core.validators.release_validator._get_pyproject_data")
+    def test_coverage_threshold_accepts_the_floor_ci_enforces(
+        self, mock_data, mock_read, mock_exists
+    ):
+        """`coverage_pct < 80` is ci.yml's real gate, so it must PASS.
+
+        The check demanded >=85 until #773 -- a figure nothing in the repo has
+        ever enforced (#756) -- so it WARNed against this project's own CI
+        config no matter how healthy coverage was. The other cases here use 85
+        and 50, which straddle both the old and new floors and so cannot tell
+        the two apart; this one can.
+        """
+        mock_data.return_value = {"tool": {}}
+        mock_exists.side_effect = lambda p: p == ".github/workflows/ci.yml"
+        mock_read.return_value = "if coverage_pct < 80:\n    sys.exit(1)\n"
+        result = _check_coverage_threshold()
+        assert result.status == CheckStatus.PASS
+        assert "80" in result.message
+
     @patch("scripts.core.validators.release_validator._path_exists", return_value=True)
     @patch("scripts.core.validators.release_validator._read_text")
     def test_conftest_exists_pass(self, mock_read, mock_exists):
@@ -1122,18 +1143,45 @@ class TestFullTierChecks:
         assert "Docker not available" in result.message
 
     @patch("scripts.core.validators.release_validator._run_cmd")
-    def test_pip_install_pass(self, mock_cmd):
+    def test_dev_install_pass(self, mock_cmd):
         mock_cmd.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        result = _check_pip_install()
+        result = _check_dev_install()
         assert result is None
 
     @patch("scripts.core.validators.release_validator._run_cmd")
-    def test_pip_install_fail(self, mock_cmd):
+    def test_dev_install_fail(self, mock_cmd):
         mock_cmd.return_value = MagicMock(
             returncode=1, stdout="", stderr="Could not find package"
         )
-        result = _check_pip_install()
+        result = _check_dev_install()
         assert result.status == CheckStatus.FAIL
+
+    @patch("scripts.core.validators.release_validator._run_cmd")
+    def test_dev_install_probes_uv_not_the_deleted_dev_extra(self, mock_cmd):
+        """The probe must not reference `[dev]`, which #683 removed.
+
+        Dev dependencies moved to a PEP 735 `[dependency-groups]` group, so
+        `pip install -e '.[dev]'` failing is the intended state. Asserting on
+        it made the check FAIL on a correct machine (#773).
+        """
+        mock_cmd.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        _check_dev_install()
+        cmd = mock_cmd.call_args[0][0]
+        assert cmd[0] == "uv"
+        assert not any(".[dev]" in str(part) for part in cmd)
+
+    @patch("scripts.core.validators.release_validator._run_cmd")
+    def test_dev_install_skips_when_the_tool_is_absent(self, mock_cmd):
+        """Missing tooling must SKIP, not FAIL.
+
+        The pre-#773 probe was `python -m pip`, where a missing pip *module*
+        exits 1 rather than raising -- so this guard could never fire on a uv
+        venv, which is every dev machine this project documents.
+        """
+        mock_cmd.side_effect = FileNotFoundError("uv")
+        result = _check_dev_install()
+        assert result.status == CheckStatus.SKIP
+        assert "uv not available" in result.message
 
     @patch("scripts.core.validators.release_validator._run_cmd")
     def test_jmo_entry_point_pass(self, mock_cmd):


### PR DESCRIPTION
Fixes the three things that made `jmo validate --tier full` return **NO-GO** on
a correctly configured machine.

`--tier full` had never been run. `release.yml:378` is `--tier quick`, nothing
else invokes it, and the checks below are registered only under
`if tier == "full"`. That is the whole reason these survived: no execution path
reached them. #752 asked for this gate to be run before v1.0.9 — running it is
what found the gate itself was broken.

## Verdict

| | before | after |
|---|---|---|
| PASS | 268/283 | **270/283** |
| WARN | 5 | 5 |
| FAIL | **1** | **0** |
| ERROR | **1** | **0** |
| verdict | **NO-GO** | **GO** |

`verdict = "NO-GO" if total_fail > 0 or total_error > 0` (`validate_commands.py:93`),
so both the FAIL and the ERROR had to go.

## 1. `pip-install-dev` — FAIL → PASS

Probed `pip install -e '.[dev]' --dry-run`. Two independent defects:

- **`.[dev]` no longer exists.** The uv migration (#683) removed the
  `[project.optional-dependencies] dev` extra for a PEP 735
  `[dependency-groups]` group. `pyproject.toml:57-64` documents the removal and
  its reason. The extra failing is the *intended* state; the check asserted the
  opposite.
- **The SKIP guard could not fire.** `except FileNotFoundError` catches a
  missing *executable*. uv venvs ship no pip module, so `python -m pip` runs
  Python fine and exits 1:

  ```console
  $ .venv/Scripts/python.exe -m pip install -e ".[dev]" --dry-run
  ...: No module named pip
  exit=1
  ```

  So "pip not available" was unreachable in exactly the environment it was
  written for, and the check reported FAIL instead of SKIP.

The guard was right in shape and attached to the wrong probe. It now runs
`uv sync --locked --group dev --dry-run` — the install this project documents —
where a missing `uv` genuinely raises `FileNotFoundError`. Verified 1s, exit 0.
`--dry-run` is documented as "without writing the lockfile or modifying the
project environment", so the validator stays read-only.

## 2. `coverage-threshold` — WARN → PASS

Demanded `>=85%`, a figure nothing in this repo has ever enforced (#756). CI's
only floor is **80%** (`ci.yml:734`, raised from 70 by #766). The check located
that real gate via its `coverage_pct\s*<\s*(\d+)` branch, read 80, and rejected
it for not being 85 — so it could only ever WARN, however healthy coverage was.

Now a named `_ENFORCED_COVERAGE_FLOOR = 80` with the provenance in a comment.
The three existing tests use 85 and 50, which straddle both the old and new
floors and so cannot distinguish them; the new test uses the repo's actual
value.

## 3. `full: tools check` — ERROR → PASS

Bounded `jmo tools check` at 60s. Measured standalone, Windows, tools actually
installed:

| run | elapsed |
|---|---|
| cold | **48,972 ms** |
| warm | **33,402 ms** |

60s is **1.22× the cold run**, and this validator is itself the load — it
spawns subprocess checks throughout. Same shape as **#748**, which #771 just
fixed: a bound sized against an unloaded machine, failing on one that has the
tools. Now 180s (~3.7×), as a named constant.

This is a bound correction, not a silenced signal: 33–49s is what probing 29
registry entries costs, and the check still ERRORs if it genuinely hangs.

## Verification

| Check | Result |
|---|---|
| `tests/core/test_release_validator.py` + `test_cli_validator.py` | **214 passed** |
| `jmo validate --tier full` on this tree | **GO**, exit 0 |
| Red-green | probe→pip and floor→85 turn 2 new tests red; restored byte-identical from a file backup |
| EOL flip check | raw == ignore-CR on every changed file |
| black / ruff / mypy / 22 pre-commit hooks | clean |

Honest note on the red-green: `test_dev_install_skips_when_the_tool_is_absent`
still passes under that mutation, because its mock raises regardless of which
command is probed. It guards the SKIP semantics rather than the probe choice.
Two of the three new tests discriminate the mutation.

## Deliberately not included

#773 also suggested the verdict line should say when Docker builds were
skipped — all four `docker-build-*` checks SKIP when no daemon is present, so
a GO does not imply Docker was validated. That is a display decision about what
the verdict should claim, not a broken assertion, so it stays on the issue.
