### PR TITLE
fix(e2e): fail the gate when a suite reports nothing, not only when all do

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1250,12 +1250,14 @@ jobs:
 
           reports=0
           total_failed=0
+          seen=""
 
           for report_file in test-results/*/pytest-report.json; do
             if [[ -f "$report_file" ]]; then
               reports=$((reports + 1))
               job=$(dirname "$report_file" | xargs basename \
                 | sed 's/-results-.*//' | sed 's/e2e-//')
+              seen="${seen} ${job}"
 
               total=$(get_field "$report_file" total)
               passed=$(get_field "$report_file" passed)
@@ -1279,6 +1281,7 @@ jobs:
 
           echo "E2E_REPORTS=$reports" >> "$GITHUB_ENV"
           echo "E2E_TOTAL_FAILED=$total_failed" >> "$GITHUB_ENV"
+          echo "E2E_SEEN_SUITES=${seen}" >> "$GITHUB_ENV"
 
       - name: Upload summary
         uses: actions/upload-artifact@v7
@@ -1312,12 +1315,42 @@ jobs:
       # two are expected still passes. Tightening that needs a count that
       # survives adding a sixth e2e job; see the issue for the options.
       - name: Fail the run if any e2e test failed
+        env:
+          # The suites that upload a pytest-report.json -- which is exactly the
+          # set whose pytest step runs under `continue-on-error: true`, so
+          # their failures cannot fail their own job and need this gate. The
+          # other three e2e jobs (tool-integration, contract, visual) have no
+          # continue-on-error and fail the run natively.
+          #
+          # Add a job to that set and you must add it here, or its failures go
+          # unwatched exactly as #769's did.
+          EXPECTED_E2E_SUITES: "ubuntu macos"
         run: |
           echo "reports found: ${E2E_REPORTS} | tests failed: ${E2E_TOTAL_FAILED}"
+          echo "suites reporting:${E2E_SEEN_SUITES:- <none>}"
 
           if [[ "${E2E_REPORTS}" -eq 0 ]]; then
             echo "::error::No pytest-report.json was produced by any e2e job." \
               "The suites did not run, so this is a failure, not a pass."
+            exit 1
+          fi
+
+          # Partial absence is absent evidence too (#772). Until this check,
+          # one report where two were expected printed "All 1 e2e suite(s)
+          # reported zero failures" and exited 0 -- #769's mistake in a smaller
+          # costume, inferring health from the absence of bad news. The guard
+          # above only caught the all-or-nothing case.
+          read -ra expected_suites <<< "${EXPECTED_E2E_SUITES}"
+          missing=""
+          for suite in "${expected_suites[@]}"; do
+            case " ${E2E_SEEN_SUITES} " in
+              *" ${suite} "*) ;;
+              *) missing="${missing} ${suite}" ;;
+            esac
+          done
+          if [[ -n "${missing// /}" ]]; then
+            echo "::error::No pytest-report.json from:${missing}." \
+              "Those suites produced no evidence, which is a failure, not a pass."
             exit 1
           fi
 
@@ -1327,7 +1360,8 @@ jobs:
             exit 1
           fi
 
-          echo "All ${E2E_REPORTS} e2e suite(s) reported zero failures."
+          echo "All ${E2E_REPORTS} e2e suite(s) reported zero failures:" \
+            "${E2E_SEEN_SUITES# }."
 
 # ==============================================================================
 # PERFORMANCE TESTS - Benchmark comparison


### PR DESCRIPTION
The gate #771 added fails on **zero** `pytest-report.json` files but not on
**some**. One report where two were expected printed `All 1 e2e suite(s)
reported zero failures` and exited 0 — #769's mistake in a smaller costume:
inferring health from the absence of bad news rather than the presence of
evidence.

## Why the expected set is definitional, not arbitrary

This was filed as needing a design decision. Checking the wiring settled it:

| Job | `continue-on-error` | uploads a report |
|---|---|---|
| `e2e-ubuntu` | **yes** (`:843`) | **yes**, `if: always()` |
| `e2e-macos` | **yes** (`:965`) | **yes**, `if: always()` |
| `e2e-tool-integration` | no | no |
| `tool-contract-tests` | no | no |
| `e2e-visual` | no | no |

The jobs that upload a report are *exactly* the jobs whose pytest step cannot
fail their own job. That is not a coincidence — it is the reason this gate
exists. So `EXPECTED_E2E_SUITES: "ubuntu macos"` names a set with a rule
behind it, and the comment beside it states the rule: add a
`continue-on-error` job and you must add it here.

## Names, not a count

The aggregate step already derives a suite name per report for the summary
table. It now exports them too, so the gate compares names.

A count (`-eq 2`) was the obvious alternative and is worse twice over: it
breaks confusingly the day a sixth e2e job appears, and when it does fire it
cannot say *which* suite went silent. The error here names it.

## Verification

CI cannot run this — `scheduled.yml` triggers only on `schedule` and
`workflow_dispatch`. Driven against the step's script extracted verbatim from
this commit:

| suites present | reports | failed | exit | behaviour |
|---|---|---|---|---|
| ubuntu + macos | 2 | 0 | **0** | passes — matches today's real run byte-for-byte |
| **ubuntu only** | 1 | 0 | **1** | **names `macos` missing** |
| **macos only** | 1 | 0 | **1** | **names `ubuntu` missing** |
| none | 0 | 0 | **1** | pre-existing guard still fires |
| ubuntu + macos | 2 | 3 | **1** | failure path intact |

A `workflow_dispatch` run on this branch is also queued, so the gate is
exercised in situ before merge rather than after.

`yamllint` and `actionlint` both pass.

Closes #772
