### PR TITLE
fix(validate): count skipped checks and say what a GO does not cover

### DIFF
--- a/scripts/cli/validate_commands.py
+++ b/scripts/cli/validate_commands.py
@@ -140,6 +140,7 @@ def _render_terminal(results: list[CategoryResult], verbose: bool) -> int:
     total_warn = sum(r.warned for r in results)
     total = sum(r.total for r in results)
     total_error = sum(r.errored for r in results)
+    total_skip = sum(r.skipped for r in results)
 
     has_failures = total_fail > 0 or total_error > 0
 
@@ -178,6 +179,12 @@ def _render_terminal(results: list[CategoryResult], verbose: bool) -> int:
         parts.append(f"{total_fail} FAIL")
     if total_error > 0:
         parts.append(f"{total_error} ERROR")
+    # SKIP was absent from this line until #773, so the checks between
+    # total_pass and total were simply unaccounted for -- `270/283 PASS |
+    # 5 WARN` with no hint where the other 8 went. The JSON renderer has always
+    # reported `skipped`; only the terminal scorecard dropped it.
+    if total_skip > 0:
+        parts.append(f"{total_skip} SKIP")
 
     _print_line(f"Result: {' | '.join(parts)}")
 
@@ -187,6 +194,14 @@ def _render_terminal(results: list[CategoryResult], verbose: bool) -> int:
         verdict_display = _colorize("GO", "green", use_color)
 
     _print_line(f"Verdict: {verdict_display}")
+
+    # A GO says nothing about checks that never ran, and `--tier full` degrades
+    # quietly when a prerequisite is missing: with no Docker daemon all four
+    # docker-build-* checks SKIP, so a green verdict can coexist with zero
+    # images built. Say that where the verdict is read rather than leaving it
+    # to be inferred from the rows above.
+    if not has_failures and total_skip > 0:
+        _print_line(f"  ({total_skip} check(s) skipped - GO covers only what ran)")
 
     return 1 if has_failures else 0
 

--- a/tests/cli/test_validate_commands.py
+++ b/tests/cli/test_validate_commands.py
@@ -28,6 +28,56 @@ class TestRenderScorecard:
         assert "GO" in captured.out
         assert exit_code == 0
 
+    def test_skips_are_counted_and_qualify_the_go(self, capsys):
+        """A GO must disclose what never ran (#773).
+
+        `--tier full` degrades quietly: with no Docker daemon all four
+        docker-build-* checks SKIP, so a green verdict can coexist with zero
+        images built. Worse, SKIP was missing from the Result line entirely,
+        so `270/283 PASS | 5 WARN` left 8 checks unaccounted for -- the reader
+        had to subtract to notice they existed at all.
+        """
+        results = [
+            CategoryResult(
+                name="Release Artifacts",
+                checks=[
+                    CheckResult(name="version", status=CheckStatus.PASS),
+                    CheckResult(
+                        name="docker-build-dockerfile.deep",
+                        status=CheckStatus.SKIP,
+                        message="Docker not available",
+                    ),
+                    CheckResult(
+                        name="docker-build-dockerfile.fast",
+                        status=CheckStatus.SKIP,
+                        message="Docker not available",
+                    ),
+                ],
+            ),
+        ]
+        exit_code = render_scorecard(results, verbose=False)
+        captured = capsys.readouterr()
+
+        assert "2 SKIP" in captured.out
+        assert "GO" in captured.out
+        assert "covers only what ran" in captured.out
+        # Skips are not failures: the verdict and exit code stay green.
+        assert "NO-GO" not in captured.out
+        assert exit_code == 0
+
+    def test_no_skip_note_when_nothing_was_skipped(self, capsys):
+        """The qualifier must not appear on a fully-executed run."""
+        results = [
+            CategoryResult(
+                name="CLI Completeness",
+                checks=[CheckResult(name="help works", status=CheckStatus.PASS)],
+            ),
+        ]
+        render_scorecard(results, verbose=False)
+        captured = capsys.readouterr()
+        assert "SKIP" not in captured.out
+        assert "covers only what ran" not in captured.out
+
     def test_with_failures(self, capsys):
         results = [
             CategoryResult(


### PR DESCRIPTION
Closes the last item on #773 — the one #774 deliberately left, because it was
a display decision rather than a broken assertion.

Investigating it found something sharper than the issue described. The
terminal scorecard computed PASS, FAIL, WARN and ERROR but **not SKIP**, so
skipped checks never appeared on the Result line at all:

```
Result: 270/283 PASS | 5 WARN        <- where did the other 8 go?
```

The reader had to subtract to learn those checks existed. The JSON renderer
(`_render_json`) has always emitted `skipped`; only the terminal path lost it.

## Why it matters where it is least visible

`--tier full` degrades quietly when a prerequisite is missing. With no Docker
daemon, all four `docker-build-*` checks SKIP — so a **GO could coexist with
zero images built**, and nothing in the verdict said so.

That is the defect this cycle keeps turning up, one layer further out: #769
was a green tick over a failing suite, #772 a green gate over a suite that
never reported, and this is a green verdict over checks that never ran. Each
one infers success from the absence of bad news.

## Measured

| | Result line |
|---|---|
| before | `270/283 PASS \| 5 WARN` |
| after | `270/283 PASS \| 5 WARN \| 8 SKIP` |

plus, under the verdict:

```
Verdict: GO
  (8 check(s) skipped - GO covers only what ran)
```

`270 + 5 + 8 = 283` — the line now accounts for every check.

Confirmed against `--tier quick` as the negative case: it has no skips
(`247/252 PASS | 5 WARN`, and 247 + 5 = 252), and neither the SKIP entry nor
the qualifier appears.

Skips stay non-fatal — `has_failures` is untouched, so verdict and exit code
are unchanged. A test asserts that explicitly, so this cannot drift into
treating a skip as a failure.

`tests/cli/test_validate_commands.py`: **24 passed**. black / ruff / mypy /
bandit clean.

Closes #773
