### PR TITLE
docs(testing): correct three profile tool counts the #731 sweep did not reach

### DIFF
--- a/docs/internal/MANUAL_TESTING_CHECKLIST.md
+++ b/docs/internal/MANUAL_TESTING_CHECKLIST.md
@@ -456,9 +456,21 @@ have folded 64 SBOM inventory rows into a vulnerability expectation.
 | Profile | Tool Count | Notes |
 |---------|-----------|-------|
 | fast | 9 | Includes OPA for policy checks |
-| slim | 14 | fast + cloud/IaC tools |
-| balanced | 18 | slim + DAST/SCA tools |
-| deep | 29 | All tools including fuzzing, mobile, host security |
+| slim | 13 | fast + cloud/IaC tools |
+| balanced | 17 | slim + DAST/SCA tools |
+| deep | 28 | All tools including fuzzing, mobile, host security. 4 of these are `MANUAL_INSTALL_TOOLS` (`afl++`, `akto`, `falco`, `mobsf`) and are deliberately absent from every Docker image |
+
+> **29 is the catalogue total, not a profile count.** The unique tool catalogue
+> has 29 entries; no profile has 29. `README.md`'s "29 tools across 12
+> categories" is correct because it says catalogue — see #731, which flags that
+> exact number as one not to "fix". `deep` is 28.
+>
+> Derive these rather than trusting the table:
+>
+> ```bash
+> python -c "from scripts.core.tool_registry import PROFILE_TOOLS; \
+>   print({p: len(t) for p, t in PROFILE_TOOLS.items()})"
+> ```
 
 ---
 


### PR DESCRIPTION
`MANUAL_TESTING_CHECKLIST.md` claimed `slim 14`, `balanced 18`, `deep 29`.

```console
$ python -c "from scripts.core.tool_registry import PROFILE_TOOLS; \
    print({p: len(t) for p, t in PROFILE_TOOLS.items()})"
{'fast': 9, 'slim': 13, 'balanced': 17, 'deep': 28}
```

| Profile | claimed | actual |
|---|---|---|
| fast | 9 | 9 |
| slim | **14** | **13** |
| balanced | **18** | **17** |
| deep | **29** | **28** |

## Why this needed doing now

`Closes #731` is already on `dev`, so the issue closes on the next
`dev` → `main`. But #731's scope was explicit — `docs/PROFILES_AND_TOOLS.md:687`
and `release.yml:789-791, 879` — and never included this file. The issue would
have closed correctly while the same defect survived in a checklist a release
is signed off against.

## The deep row is the interesting one

29 is the **catalogue** total. #731 lists that number under *"Not stale, do not
fix"*, because `README.md`'s "29 tools across 12 categories" is correct
precisely when it says catalogue — and warns that a contributor acting on a
naive flag "would have made it wrong."

This table did the thing the issue warned about: it used the catalogue total as
a profile count. So this is not a line the sweep missed by accident; it is the
same confusion reproduced elsewhere. The fix records the distinction explicitly
and includes the one-liner that derives the numbers, so the next reader checks
rather than trusts a table.

## Also recorded

4 of `deep`'s 28 are `MANUAL_INSTALL_TOOLS` (`afl++`, `akto`, `falco`, `mobsf`)
and ship in no Docker image — which is why a correctly built `deep` container
reports 24 installed and exits 1, a result that has previously been read as a
build failure.

Docs-only; `markdownlint` and `doc-links` pass.

Refs #731
