### PR TITLE
docs(plan): v1.1.0 audit campaign strategy and tracker

### DIFF
--- a/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign-tracker.md
+++ b/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign-tracker.md
@@ -1,0 +1,398 @@
+# v1.1.0 audit campaign — tracker
+
+**Strategy and per-chunk protocol:** [2026-08-08-v1.1.0-audit-campaign.md](2026-08-08-v1.1.0-audit-campaign.md)
+**Branch:** work each chunk off `dev`; PR into `dev`. Never `main`.
+
+## Progress
+
+**0 / 22 chunks complete.**
+
+| # | Chunk | Prereqs met? | Findings | Resolved | Status |
+|---|---|---|---:|---:|---|
+| 0 | Environment prerequisites | — | — | — | not started |
+| 1 | Config + CLI shell | | | | not started |
+| 2 | Tool registry + profiles | | | | not started |
+| 3 | scan: target-type matrix | | | | not started |
+| 4 | scan: runtime | | | | not started |
+| 5 | adapters A | | | | not started |
+| 6 | adapters B + `jmo adapters` + loader | | | | not started |
+| 7 | dedup + compliance + EPSS/KEV | | | | not started |
+| 8 | suppression | | | | not started |
+| 9 | dashboard build | | | | not started |
+| 10 | report + exports | | | | not started |
+| 11 | `jmo ci` | | | | not started |
+| 12 | diff + `history diff` | | | | not started |
+| 13 | history read-path | | | | not started |
+| 14 | history write-path + migrations | | | | not started |
+| 15 | trends | | | | not started |
+| 16 | policy | | | | not started |
+| 17 | schedule + cron + email | | | | not started |
+| 18 | validate + build | | | | not started |
+| 19 | attest + verify | | | | not started |
+| 20 | mcp-server | | | | not started |
+| 21 | Docker × 4 variants | | | | not started |
+
+## How to mark a finding off
+
+Every finding ends in one of four states. **All four count as resolved.**
+
+- `[x] FIXED` — changed the behaviour; say what changed
+- `[x] DELETED` — removed the dead thing rather than repairing it
+- `[x] DISMISSED` — verified against the code and the claim is wrong; **say why**
+- `[x] BLOCKED-UNVERIFIABLE` — cannot be checked here; **state the missing
+  prerequisite and what would unblock it**
+
+Tick the box, append the verdict inline, and update the Progress table **in the
+same commit**. A finding without a stated verdict is not resolved.
+
+**DISMISSED requires evidence, not judgement.** Today's session produced two
+claims that looked like findings and were not: a "29 vs 27 adapter mismatch"
+(the directory holds 27 adapters plus `__init__.py`, `base_adapter.py` and
+`common.py`) and "osv-scanner is fully wired" (it is in exactly one registry
+table). Both were caught by measuring. Dismiss the same way.
+
+## Carried-in findings
+
+Filed 2026-08-08 before the campaign was structured. Each belongs to a chunk:
+
+| Issue | Chunk | Summary |
+|---|---|---|
+| #779 | 15 | `trends developers` crashes `KeyError: 'scan_count'` on its default invocation |
+| #780 | 14 | branch detected from the results dir, not the scanned repo — 1633/1833 rows NULL |
+| #781 | 15 | every `trends` subcommand returns "No scans found" against 1833 scans |
+| #782 | 2 | `osv-scanner` in `TOOL_SCAN_TYPES` + Dockerfile only; no adapter, no profile |
+| #783 | 18 | CLI validator covers 13 of 20 subcommands; `attest`/`verify` unchecked |
+| #784 | 4, 12 | encoding artifacts in `diff` markdown and `trends` headers; `scan-timings` warning |
+
+Pre-existing backlog that lands in a chunk when it is reached: #538 (8), #702
+(2), #715 (3/4), #721 (14), #742, #745, #747, #750, #755 (11), #758, #765, #767.
+
+---
+
+## Chunk 0 — Environment prerequisites
+
+No PR. Establishes once what can and cannot be obtained, so later chunks are not
+each surprised by it.
+
+**Do**
+
+- [ ] Docker daemon — required by chunks 9 (build), 18 (`jmo build`), 21
+- [ ] `npm` + dashboard build — `scripts/dashboard/dist/` is gitignored; chunk 9
+- [ ] `opa` binary — chunk 16 `policy test`
+- [ ] `sigstore` + an OIDC identity — chunk 19; note `signer.py:153-170` runs an
+      **interactive** OAuth flow
+- [ ] The 27 scanner tools — chunks 5/6. Four (`afl++`, `akto`, `mobsf`,
+      `falco`) are `MANUAL_INSTALL_TOOLS` and are expected to fail
+- [ ] **Snapshot `.jmo/history.db`** (1833 scans, 659 MB) before any chunk that
+      can mutate it — 13, 14, and any `prune`/`optimize`/`repair`/`migrate`
+
+**Acceptance:** a table in this file recording, per prerequisite, present or
+absent and why. Absent ones become the BLOCKED-UNVERIFIABLE justification for
+every finding that depends on them.
+
+---
+
+## Chunk 1 — Config + CLI shell
+
+**Surface:** `scripts/core/config.py`, `load_config_with_env_overrides`,
+`JMO_PROFILE` / `JMO_THREADS` / `JMO_DEDUP_THRESHOLD`, `--config`, per-profile
+`per_tool` precedence, `jmo --help` / `--version`, exit-code conventions.
+
+**Known going in**
+
+- [ ] `jmo.yml`'s top-level `tools:` lists 8 tools, disjoint from
+      `PROFILE_TOOLS`; `report_orchestrator.py:399` passes `cfg.tools` as the
+      tool list written to history — so **history may record the jmo.yml 8
+      rather than what actually ran**. Verify, then file.
+- [ ] `jmo.py:2295 _collect_email_opt_in` calls `input()` on first run — an
+      interactive prompt in a CLI that CI invokes.
+- [ ] `jmo.py:2408` prints `jmo config --email ...`; **there is no `jmo config`
+      subcommand.** Phantom command in user-facing output.
+
+**Acceptance:** config precedence (defaults → `jmo.yml` → env → flags) proven by
+a test per layer; no interactive prompt reachable on a non-TTY.
+
+---
+
+## Chunk 2 — Tool registry + profiles
+
+**Surface:** `PROFILE_TOOLS`, `TOOL_BINARY_NAMES`, `TOOL_EXECUTION_COMMANDS`,
+`TOOL_SCAN_TYPES`, `TOOL_VARIANTS`, `CONTENT_TRIGGERED_TOOLS`,
+`MANUAL_INSTALL_TOOLS`, `versions.yaml` reconciliation.
+
+**Known going in**
+
+- [ ] #782 — decide: delete `osv-scanner`, or complete it as a new adapter.
+      Deleting cascades into `test_docker_workflows.py::DOCKER_VARIANTS`,
+      `DEEP_EXPECTED_TOOLS` and the `scheduled.yml` matrix.
+- [ ] #702 — `update_versions.py --sync` silently skips hyphenated names.
+- [ ] `versions.yaml` holds 6 entries in no profile (`alpine`, `ubuntu`, `ruff`,
+      `shfmt`, `falcoctl`, `osv-scanner`); confirm which are legitimately
+      non-scanner and which are orphans.
+
+**Acceptance:** every registry table agrees with every other, proven by a test
+that derives rather than restates.
+
+---
+
+## Chunk 3 — scan: target-type matrix
+
+**Surface:** the 6 scanners in `scripts/cli/scan_jobs/` — repository, image,
+iac, k8s, url, gitlab. `--repo`, `--repos-dir`, `--targets`, `--image`.
+Degenerate inputs: empty dir, non-git dir, missing path, path traversal,
+permission-denied.
+
+**Acceptance:** each target type produces findings or a clear reason; no
+degenerate input crashes or silently scans nothing (the #715 class).
+
+---
+
+## Chunk 4 — scan: runtime
+
+**Surface:** `scan_orchestrator.py`, `scan_session.py`, `tool_runner.py`,
+`scan_timings.py`. Retries (`RetryConfig.attempts_for_failure`), per-tool
+timeouts and floors, `threads: auto`, partial-failure accounting,
+`--allow-missing-tools`.
+
+**Known going in**
+
+- [ ] #784 — `report` warns "No adapter plugin found for: scan-timings" on every
+      run, training the reader to ignore adapter warnings.
+
+**Acceptance:** a tool that fails, times out, or is missing is reported
+distinctly from one that found nothing — the distinction #769 and the
+`zero-secrets` incident both turned on.
+
+---
+
+## Chunks 5-6 — adapters A / B
+
+**Surface:** 27 adapters × real tool output; CommonFinding v1.2.0 conformance
+against `docs/schemas/common_finding.v1.json`; `jmo adapters list/validate`;
+the plugin loader.
+
+**Split:** A = the 13 whose tools install cleanly; B = the remainder plus the
+`adapters` command and loader. Four tools will not install (chunk 0) — their
+adapters are BLOCKED-UNVERIFIABLE unless a recorded fixture exists.
+
+**Stop condition:** if conformance failures are systemic rather than
+per-adapter, **stop and split**. A shared `adapters/common.py` defect touches 27
+adapters, every fixture, the schema and much of the suite — that is a release,
+not a chunk.
+
+**Acceptance:** every adapter's output validates against the schema, proven on
+real tool output rather than fixtures where possible. `results/summaries/findings.json`
+is the conformance corpus; `raw_finding` in the history DB is **not** — it holds
+each tool's native JSON.
+
+---
+
+## Chunk 7 — dedup + compliance + EPSS/KEV/priority
+
+**Surface:** `fingerprint()`, cross-tool clustering
+(`deduplication.similarity_threshold`, default 0.65), the 10 compliance mapping
+tables, `epss_integration.py`, `kev_integration.py`, `priority_calculator.py`,
+`_enrich_with_priority` (`normalize_and_report.py:248`).
+
+**Known going in**
+
+- [ ] `_enrich_with_priority` swallows every exception into `logger.debug`
+      (`:254-257`) — network-dependent enrichment can fail totally and silently.
+- [ ] #770 — per-line rule inflation; the lossless `occurrences` model. Naive
+      dedupe by `(tool, rule, file)` was **measured** to merge 4 distinct
+      `CKV_SECRET_6` secrets into 1 and destroy 12 syft SBOM entries. Do not
+      implement the naive version.
+
+**Acceptance:** clustering neither merges distinct findings nor splits
+identical ones, on the measured Juice Shop corpus.
+
+---
+
+## Chunk 8 — suppression
+
+**Surface:** `jmo.suppress.yml`, the suppression engine, `SUPPRESSIONS.md`.
+
+**Known going in**
+
+- [ ] #538 — the engine is **id-only**; `path`/`ruleId`/`severity`/`line`
+      entries are silently ignored.
+
+**Acceptance:** every documented suppression key either works or is removed from
+the docs; a no-op key never fails silently.
+
+---
+
+## Chunk 9 — dashboard build
+
+**Must precede chunk 10.**
+
+**Surface:** `scripts/dashboard/`, `npm run build`, `dist/` (gitignored),
+`html_reporter.py:36-50`.
+
+**Known going in**
+
+- [ ] `html_reporter.py` falls back to
+      `tests/fixtures/dashboard/test-inline-dashboard.html`, then to hardcoded
+      HTML, warning only at `logging.warning`. **Auditing `dashboard.html`
+      without building first audits a test fixture.**
+
+**Acceptance:** a built dashboard is distinguishable from the fallback at
+runtime, loudly.
+
+---
+
+## Chunk 10 — report + exports
+
+**Surface:** `jmo report`, and the **14** artifacts (the 13 observed plus
+`SUPPRESSIONS.md`, `report_orchestrator.py:209`, which only appears when
+suppressions exist).
+
+**Known going in**
+
+- [ ] Artifact writes are config-gated (`if "x" in cfg.outputs`) and failures are
+      swallowed at DEBUG — `write_yaml` (`:186-188`), all three compliance
+      reports (`:214-222`). **Assert presence against config**, not against
+      whatever happens to appear.
+
+**Acceptance:** SARIF validates against its schema, CSV parses, YAML
+round-trips, JSON validates against `common_finding.v1.json`, and every artifact
+the config requests is present or fails loudly.
+
+---
+
+## Chunk 11 — `jmo ci`
+
+**Surface:** `scripts/cli/ci_orchestrator.py`, `--fail-on`, exit codes.
+
+**Known going in**
+
+- [ ] `ci_orchestrator.py:66+` re-marshals scan args through a hand-written
+      `class ScanArgs` built entirely from `getattr(a, "x", None)`. **Any flag
+      added or renamed in chunks 3-4 silently fails to reach the scanner via
+      `jmo ci`, with no type error** — the getattr-masks-mypy class this repo has
+      already been bitten by.
+- [ ] #755 — `jmo ci --profile <name>` exits 2; `--profile` is a boolean.
+
+**Acceptance:** a test that fails when a scan flag exists but `ScanArgs` does not
+forward it.
+
+---
+
+## Chunk 12 — diff + `history diff`
+
+**Surface:** `jmo diff` + its 4 format subcommands (`json`, `md`, `html`,
+`sarif`), `jmo history diff`, `diff_engine`.
+
+**Known going in**
+
+- [ ] #784 — `# [?] Security Diff Report`: the artifact, not just the console,
+      carries the replacement character.
+
+**Acceptance:** a diff between two known scans reports exactly the known delta.
+
+---
+
+## Chunk 13 — history read-path
+
+**Surface:** `list`, `show`, `query`, `stats`, `export`, `trends`.
+**Snapshot the DB first.**
+
+---
+
+## Chunk 14 — history write-path + migrations + integrity
+
+**Surface:** `store`, `prune`, `optimize`, `migrate`, `verify`, `repair`;
+`history_migrations.py`, `history_integrity.py`, `scripts/migrations/v1_2_0.py`.
+**Destructive — snapshot first. The 659 MB DB is the only migration fixture
+that exists.**
+
+**Known going in**
+
+- [ ] #780 — branch from results dir. **Decide the data disposition before
+      starting**: backfill (cannot recover branch for moved/deleted repos),
+      re-scan, or accept NULL and change the trends defaults. This is the
+      campaign's most likely stall point.
+- [ ] #721 — `slim` scans are silently dropped from the history database.
+
+---
+
+## Chunk 15 — trends
+
+**Surface:** 8 subcommands. Run **after** chunk 14, so the DB semantics are
+settled.
+
+**Known going in**
+
+- [ ] #779 — `developers` crashes `KeyError: 'scan_count'` on the no-data path,
+      which is the default invocation. Every other subcommand checks
+      `status == "no_data"` first.
+- [ ] #781 — `--branch` defaults to `main` (0 of 1833 scans) and, without
+      `--days`/`--last`, a 30-day window. **Reproduces even after #780 is
+      fixed** — it is a separate defect.
+
+---
+
+## Chunk 16 — policy
+
+**Surface:** `list`, `validate`, `test`, `show`, `install`; `policy_engine`.
+Needs an `opa` binary (chunk 0).
+
+---
+
+## Chunk 17 — schedule + cron + email/newsletter
+
+**Surface:** 9 `schedule` subcommands, `schedule_manager`, `cron_installer`,
+`email_service.py` (524 LOC), `newsletter_broadcast.py` (608), `newsletter/`,
+`jmo.yml` `email:`. Needs platform scheduler access.
+
+---
+
+## Chunk 18 — validate + build
+
+**Surface:** `jmo validate quick|full` (note: subcommands **and** a `--tier`
+flag exist — reconcile), `jmo build fast|slim|balanced|deep`.
+
+**Known going in**
+
+- [ ] #783 — `MAIN_SUBCOMMANDS` covers 13 of 20; the 7 unchecked are `fast`,
+      `balanced`, `full`, `setup`, `adapters`, `attest`, `verify`.
+      `_MAIN_HELP_COUNT  # 13` is a hardcoded comment that will drift again —
+      **derive the list from the parser**, or this chunk re-creates the bug it
+      just fixed.
+
+---
+
+## Chunk 19 — attest + verify
+
+**Surface:** `scripts/core/attestation/`.
+
+**Known going in**
+
+- [ ] `signer.py:215` and `verifier.py:258` hardcode
+      `["python3", "-m", "sigstore", ...]` — not on a default Windows PATH, and
+      never the uv venv interpreter.
+- [ ] `signer.py:153-170` runs an interactive OAuth flow; likely
+      BLOCKED-UNVERIFIABLE without an OIDC identity.
+
+---
+
+## Chunk 20 — mcp-server
+
+**Surface:** `get_security_findings`, `apply_fix` (test `dry_run=True` first),
+`mark_resolved`.
+
+**Acceptance is the collection count, not "it starts."** The mcp 2.0
+`FastMCP`→`MCPServer` rename once turned 235 tests into silent non-collection
+behind green CI.
+
+---
+
+## Chunk 21 — Docker × 4 variants
+
+**Surface:** 4 Dockerfiles, tags, image contents, `tests/e2e/test_docker_workflows.py`.
+Needs a daemon (chunk 0). **Budget 2 sessions.**
+
+**Remember:** `:latest` **is** the deep variant; there are no `:latest-deep` /
+`:latest-slim` tags. A correctly-built `deep` container reports 24 installed and
+**rc=1**, because 4 of its 28 are `MANUAL_INSTALL_TOOLS` — that is not a build
+failure.

--- a/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign-tracker.md
+++ b/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign-tracker.md
@@ -1,6 +1,7 @@
 # v1.1.0 audit campaign — tracker
 
 **Strategy and per-chunk protocol:** [2026-08-08-v1.1.0-audit-campaign.md](2026-08-08-v1.1.0-audit-campaign.md)
+**Tracking issue:** [#785](https://github.com/jimmy058910/jmo-security-repo/issues/785)
 **Branch:** work each chunk off `dev`; PR into `dev`. Never `main`.
 
 ## Progress

--- a/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign.md
+++ b/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign.md
@@ -1,6 +1,7 @@
 # v1.1.0 audit campaign — strategy and protocol
 
 **Tracker (live state):** [2026-08-08-v1.1.0-audit-campaign-tracker.md](2026-08-08-v1.1.0-audit-campaign-tracker.md)
+**Tracking issue:** [#785](https://github.com/jimmy058910/jmo-security-repo/issues/785)
 **Branch discipline:** work each chunk off `dev`; PR into `dev`. Never `main`.
 
 v1.0.9 is abandoned. The work below ships as **v1.1.0** — a catch-up release

--- a/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign.md
+++ b/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign.md
@@ -1,0 +1,174 @@
+# v1.1.0 audit campaign — strategy and protocol
+
+**Tracker (live state):** [2026-08-08-v1.1.0-audit-campaign-tracker.md](2026-08-08-v1.1.0-audit-campaign-tracker.md)
+**Branch discipline:** work each chunk off `dev`; PR into `dev`. Never `main`.
+
+v1.0.9 is abandoned. The work below ships as **v1.1.0** — a catch-up release
+that exercises the whole tool, not the parts a release happens to touch.
+
+## Why this exists
+
+A half-day of actually *running* the CLI against real data produced six defects
+(#779-#784), including a headline v1.0 feature — trend analysis — returning
+nothing on a 1833-scan database, and a scanner shipped in the deep image that no
+profile can invoke. None was findable by reading code or by the 8,000-test
+suite. They needed the tool run against real inputs.
+
+The campaign generalises that: exercise every command path, every adapter, every
+artifact, with real data, and fix what it finds.
+
+## Scope (locked)
+
+Full audit. Three layers:
+
+| Layer | Surface |
+|---|---|
+| **CLI** | 67 invocable command paths (20 top-level + 47 sub) |
+| **Integration** | 4 Docker variants, MCP server, HTML dashboard, 14 output artifacts, export-format validity, `--image` and multi-target scanning |
+| **Core** | 27 adapters × real tool output, CommonFinding v1.2.0 conformance, dedup/clustering, compliance enrichment (10 mapping tables), suppression engine |
+
+## Cadence (locked)
+
+**A chunk is one area, end to end**, and lands as one PR:
+
+1. Sweep the area with real data *and* degenerate inputs
+2. File every finding as a GitHub issue
+3. Fix the small and clear ones **in this chunk**
+4. Split anything too large into its own chunk rather than stalling
+5. PR + tracker update **in the same commit**
+
+## Release bar (locked)
+
+**Campaign complete = release.** Every finding ends in a terminal state. There
+are four, and the fourth exists because three would force dishonesty:
+
+- `[x] FIXED` — changed the behaviour; say what changed
+- `[x] DELETED` — removed the dead thing rather than repairing it
+- `[x] DISMISSED` — verified against the code and the claim is wrong; **say why**
+- `[x] BLOCKED-UNVERIFIABLE` — **cannot be checked in this environment.** State
+  the missing prerequisite and what would unblock it.
+
+> **Why the fourth state.** Parts of this scope cannot be verified on the
+> maintainer's machine: Docker findings need a daemon, four
+> `MANUAL_INSTALL_TOOLS` (`afl++`, `akto`, `mobsf`, `falco`) deliberately do not
+> install, `attest`/`verify` need sigstore plus an interactive OIDC identity, and
+> `policy test` needs an `opa` binary. With only three states, the sole way to
+> close those findings is to DISMISS things nobody checked — and "campaign
+> complete" would then mean the opposite of what it says. A finding parked as
+> BLOCKED-UNVERIFIABLE is honest and searchable; a wrongly-DISMISSED one is
+> neither.
+>
+> **BLOCKED-UNVERIFIABLE does not block the release.** It blocks the *claim of
+> coverage*, which is the thing worth protecting.
+
+## Ordering follows the data pipeline, not the command list
+
+The first draft of this plan ordered chunks by CLI surface and put
+`report + exports` second. That is wrong. Measured in
+`normalize_and_report.py:gather_results`:
+
+```text
+adapters -> fingerprint dedup -> trivy/syft enrich -> compliance enrich
+        -> EPSS/KEV priority -> cross-tool clustering -> suppression -> reporters
+```
+
+`report` sits at the **end** of that chain. Auditing it early means every
+artifact-content finding is invalidated by four later chunks — a guaranteed
+re-run under a no-deferrals bar. Chunks are therefore ordered upstream-first.
+
+The same reasoning moves four other things:
+
+| Chunk | Must follow | Because |
+|---|---|---|
+| `report + exports` | adapters, dedup, enrichment, suppression | it renders their output |
+| `dashboard build` | — but must **precede** `report` | `scripts/dashboard/dist/` is gitignored and `html_reporter.py:36-50` silently falls back to a **test fixture**, so auditing `dashboard.html` first audits a fixture |
+| `diff` | dedup/clustering | `diff` keys on `common_finding.fingerprint()`; any fingerprint change invalidates every baseline |
+| `trends` | history write-path | trends only *filters* on branch; #780 is a write-path bug in `history_db.py:908-931` |
+| `jmo ci` | scan **and** report | it wraps both |
+
+## Per-chunk protocol
+
+**Before sweeping**
+
+- Re-read the chunk's acceptance criteria in the tracker.
+- Note which prerequisites are present. A missing one is a BLOCKED-UNVERIFIABLE
+  finding, not a reason to skip the chunk.
+
+**While sweeping**
+
+- Run with `PYTHONUTF8` **unset**. CI pins it to `1`, which is an environment no
+  real Windows user has, and it hides the console-encoding class entirely.
+- Bound local suite runs — unbounded `-n auto` manufactures failures (#767):
+  ```bash
+  JMO_THREADS=2 .venv/Scripts/python.exe -m pytest tests/ -n 8 -q \
+    -m "not smoke and not requires_tools and not docker"
+  ```
+- Record the command and its **actual output**. A finding without a reproduction
+  is a hypothesis.
+
+**Before the PR**
+
+- Prove any new guard can fail: mutate, watch it go red, restore — with a **file
+  backup**, never `git checkout --`.
+- Read the `windows-2022` shard's **job log**, not its check tick; it is
+  `continue-on-error: true` and reports green over exit-code-1. A shifted *skip*
+  count is as much a signal as a failure.
+- Check **both** CI events — every push runs `ci.yml` twice (`push` and
+  `pull_request`) and they see different worlds.
+
+## Standing risks
+
+**The history database is a single irreplaceable fixture.** 1833 scans, 138k
+findings, 659 MB, and `history prune/optimize/repair/migrate` are destructive.
+**Snapshot it before the history chunks.** Note also that ~67% of its findings
+are test/dogfood noise, so any trend or regression assertion built on it is
+measuring noise unless filtered.
+
+**#780 has an unrecoverable-data decision inside it.** Fixing `store_scan` fixes
+future rows; the 1633 existing NULL-branch rows stay NULL, and branch cannot be
+recovered for scans whose repo has moved or gone. Decide the disposition —
+backfill, re-scan, or accept NULL and change the trends defaults — **before**
+starting that chunk, or it stalls mid-session.
+
+**Adapter conformance may not be chunk-sized.** If CommonFinding v1.2.0
+violations turn out to be systemic (a shared `adapters/common.py` defect rather
+than per-adapter), the fix touches 27 adapters, every fixture, the schema and
+much of the suite. That is a release, not a chunk. If the sweep shows that
+shape, stop and split rather than absorbing it.
+
+**Prerequisites are unevenly available.** Chunk 0 exists to establish exactly
+what can and cannot be obtained, once, so later chunks are not each surprised by
+it.
+
+## Chunk list
+
+Full detail, acceptance criteria and per-finding verdicts live in the tracker.
+
+| # | Chunk | Notes |
+|---|---|---|
+| 0 | Environment prerequisites | no PR; records what cannot be obtained |
+| 1 | Config + CLI shell | `config.py` precedence, `JMO_*` env, `cfg.tools` drift, first-run `input()` |
+| 2 | Tool registry + profiles | `PROFILE_TOOLS`, scan-type maps, #782 disposition |
+| 3 | scan: target-type matrix | 6 scanners in `scan_jobs/` |
+| 4 | scan: runtime | retries, timeouts, threads, partial failure |
+| 5 | adapters A | |
+| 6 | adapters B + `jmo adapters` + plugin loader | |
+| 7 | dedup + compliance + EPSS/KEV/priority | |
+| 8 | suppression | #538 |
+| 9 | dashboard build | **must precede report** |
+| 10 | report + exports (14 artifacts) | |
+| 11 | `jmo ci` | wraps scan + report |
+| 12 | diff + `history diff` | |
+| 13 | history read-path | |
+| 14 | history write-path + migrations + integrity | #780 |
+| 15 | trends | #779, #781 |
+| 16 | policy | needs `opa` |
+| 17 | schedule + cron + email/newsletter | |
+| 18 | validate + build | derive subcommand list from the parser |
+| 19 | attest + verify | needs sigstore + OIDC |
+| 20 | mcp-server | acceptance = **collection count** |
+| 21 | Docker × 4 variants | budget 2 sessions |
+
+22 slots. The first draft had 17; the honest consequence of full scope with no
+deferrals is a campaign ~30% larger than it first appeared. Better priced now
+than discovered at chunk 14.


### PR DESCRIPTION
Strategy and live tracker for the **v1.1.0 audit campaign**. v1.0.9 is
abandoned; this work ships as v1.1.0. Tracking issue: #785.

## Why

Half a day of actually running the CLI against real data produced six defects
(#779-#784) — trend analysis returning nothing on a 1833-scan database, a
scanner shipped in the deep image that no profile can invoke, a crash on a
default invocation. None was findable by reading code, and the 8,000-test suite
caught none of them. They needed the tool run against real inputs.

## Two structural decisions worth reviewing

**Ordering follows the data pipeline, not the CLI surface.** The first draft put
`report + exports` second. Measured in `normalize_and_report.gather_results`,
that stage is *last*:

```text
adapters -> dedup -> enrich -> EPSS/KEV -> clustering -> suppression -> reporters
```

Auditing it early means four later chunks invalidate its findings — a guaranteed
re-run under a no-deferrals bar. The same reasoning:

| Move | Why |
|---|---|
| dashboard **before** report | `scripts/dashboard/dist/` is gitignored and `html_reporter.py:36-50` silently falls back to a **test fixture** — auditing `dashboard.html` first audits a fixture |
| diff **after** dedup | `diff` keys on `common_finding.fingerprint()` |
| trends **after** history write-path | #780 is a write-path bug in `history_db.py`, not a trends bug |
| **added** `jmo ci` | the only top-level command the first draft left with no owner |

**Four terminal states, not three.** Parts of this scope cannot be verified on
the maintainer's machine — Docker needs a daemon, four `MANUAL_INSTALL_TOOLS`
deliberately do not install, `attest`/`verify` need an interactive OIDC identity,
`policy test` needs `opa`. With only FIXED/DELETED/DISMISSED, the only way to
close those findings is to dismiss things nobody checked, and "campaign
complete" would mean the opposite of what it says. `BLOCKED-UNVERIFIABLE`
records the missing prerequisite instead. It does not block the release; it
blocks the *claim of coverage*.

## Scale

22 chunks, not the 17 first drafted — the honest consequence of full scope with
no deferrals. Better priced now than discovered at chunk 14.

## Two corrections this plan already absorbed

Both were mine, both caught by measuring before writing:

- A claimed "29 adapters vs 27 plugins" mismatch is **not a defect**. The
  directory holds 27 adapters plus `__init__.py`, `base_adapter.py` and
  `common.py`. `jmo adapters list` is correct. Recorded in the tracker so nobody
  burns a session on it.
- #782's "fully wired" was wrong, and the truth is worse — `osv-scanner` is in
  exactly one registry table, with no adapter, no binary-name mapping and no
  execution command. Issue updated.

Docs-only. `markdownlint` and `doc-links` pass.

Refs #785, #752
