### PR TITLE
fix(cli): record what a scan ran in history, and four CLI-shell contracts

### DIFF
--- a/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign-tracker.md
+++ b/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign-tracker.md
@@ -6,12 +6,12 @@
 
 ## Progress
 
-**0 / 22 chunks complete.**
+**2 / 22 chunks complete.**
 
 | # | Chunk | Prereqs met? | Findings | Resolved | Status |
 |---|---|---|---:|---:|---|
-| 0 | Environment prerequisites | — | — | — | not started |
-| 1 | Config + CLI shell | | | | not started |
+| 0 | Environment prerequisites | — | — | — | **done** — table below |
+| 1 | Config + CLI shell | yes | 8 | 8 | **done** — 5 FIXED, 3 DISMISSED |
 | 2 | Tool registry + profiles | | | | not started |
 | 3 | scan: target-type matrix | | | | not started |
 | 4 | scan: runtime | | | | not started |
@@ -75,21 +75,32 @@ Pre-existing backlog that lands in a chunk when it is reached: #538 (8), #702
 No PR. Establishes once what can and cannot be obtained, so later chunks are not
 each surprised by it.
 
-**Do**
+**Done 2026-08-08.** Measured, not assumed — three of the six came back
+different from what the plan predicted.
 
-- [ ] Docker daemon — required by chunks 9 (build), 18 (`jmo build`), 21
-- [ ] `npm` + dashboard build — `scripts/dashboard/dist/` is gitignored; chunk 9
-- [ ] `opa` binary — chunk 16 `policy test`
-- [ ] `sigstore` + an OIDC identity — chunk 19; note `signer.py:153-170` runs an
-      **interactive** OAuth flow
-- [ ] The 27 scanner tools — chunks 5/6. Four (`afl++`, `akto`, `mobsf`,
-      `falco`) are `MANUAL_INSTALL_TOOLS` and are expected to fail
-- [ ] **Snapshot `.jmo/history.db`** (1833 scans, 659 MB) before any chunk that
-      can mutate it — 13, 14, and any `prune`/`optimize`/`repair`/`migrate`
+| Prerequisite | State | Evidence, and what would unblock it |
+|---|---|---|
+| **Docker daemon** | **PRESENT — via WSL only** | Absent on the Windows side: not on PATH, no `C:\Program Files\Docker`, no `C:\ProgramData\DockerDesktop`, no docker processes — genuinely not installed, not merely stopped. Present inside WSL `Ubuntu-24.04`: **docker 29.3.1**, daemon responsive (`Ubuntu 24.04.4 LTS`, 4 images), and the repo is visible at `/mnt/c/Projects/jmo-security-repo`. **Chunks 18 and 21 are NOT blocked** — they run from WSL, not the Windows shell. Expect the bind-mount UID trap (`testing.cross-platform.rules.md`) since the tree lives on `/mnt/c`. |
+| **`npm` + dashboard build** | **PRESENT — but `dist/` is STALE** | node `v22.22.2`, npm `10.9.7`, `node_modules/` present. `scripts/dashboard/dist/index.html` exists (977 KB, built **May 7**) while **5 `src/` files are newer** (May 28). So chunk 9 will *not* hit the `html_reporter.py:36-50` test-fixture fallback — it will silently inline a 3-week-old bundle, which is worse, because it looks legitimate. **Chunk 9 must `npm run build` first, and must treat "stale `dist/`" as a second failure mode alongside "fell back to the fixture".** |
+| **`opa` binary** | **PRESENT** | `~/.jmo/bin/opa.exe`, version **1.18.2**, reported `OK` by `jmo tools check`. **Not on the shell PATH** — `command -v opa` finds nothing; JMo resolves it through its own bin dir. **Chunk 16 is NOT blocked**, but anything shelling out to a bare `opa` without JMo's resolution will fail. |
+| **`sigstore` + OIDC** | **PARTIAL** | `sigstore 4.5.0` imports fine from `.venv/Scripts/python.exe`. But `signer.py:215` / `verifier.py:258` hardcode `["python3", "-m", "sigstore", ...]`, and here `python3` resolves to an unrelated venv — `...\hermes-agent\venv\Scripts\python3.exe`, Python 3.11.15 — which answers **`No module named sigstore`, rc=1**. The wired-in invocation is broken for a sharper reason than "not on a default Windows PATH": it binds to whatever `python3` happens to be first. OIDC identity still untested (`signer.py:153-170` is an interactive OAuth flow). Chunk 19 can verify the subprocess-wiring defect; the signing round-trip stays BLOCKED-UNVERIFIABLE. |
+| **The 27 scanner tools** | **`deep` 21/28 installed, 18 execution-ready** | Real missing **3**: `noseyparker`, `nuclei`, `scancode`. MANUAL missing **4**, exactly as expected: `afl++`, `akto`, `falco`, `mobsf`. Critical-outdated **2**: `prowler` 5.35.0 < 5.36.0, `semgrep` 1.161.0 < 1.172.0 (and `semgrep-secrets` with it). Per profile: `fast` 8/9, `slim` 12/13, `balanced` 15/17. Adapters for the 3 real-missing and 4 manual tools are BLOCKED-UNVERIFIABLE in chunks 5/6 unless a recorded fixture exists. |
+| **`.jmo/history.db` snapshot** | **DONE** | `.jmo/history.db.snapshot-20260808`, **691,752,960 bytes**, size-identical to the source; gitignored via `.gitignore:179` (`.jmo/`). Taken before anything in this session could touch it. |
 
-**Acceptance:** a table in this file recording, per prerequisite, present or
-absent and why. Absent ones become the BLOCKED-UNVERIFIABLE justification for
-every finding that depends on them.
+**Two corrections to this plan's own assumptions**
+
+- This section previously listed Docker as required by **chunk 9**. It is not —
+  `html_reporter.py` contains no Docker reference; chunk 9 needs `npm`. Docker is
+  needed by chunks 18 and 21 only.
+- Docker and `opa` were both expected to be absent and are both obtainable. The
+  only genuinely blocked thing found is the sigstore **OIDC identity**.
+
+**Routed to chunk 2 (found here, not chased here):** `jmo tools check --json`
+(all profiles) emits `warnings` claiming `semgrep-secrets`, `trivy-rbac` and
+`checkov-cicd` are `Missing`, while `jmo tools check --profile deep` reports the
+same three as `OUTDATED`, `OK` and `OK`. Two output modes of one command
+disagree about the same tool, and "missing" means two different things
+(`missing` vs `not_ready`) between them.
 
 ---
 
@@ -101,17 +112,136 @@ every finding that depends on them.
 
 **Known going in**
 
-- [ ] `jmo.yml`'s top-level `tools:` lists 8 tools, disjoint from
-      `PROFILE_TOOLS`; `report_orchestrator.py:399` passes `cfg.tools` as the
-      tool list written to history — so **history may record the jmo.yml 8
-      rather than what actually ran**. Verify, then file.
-- [ ] `jmo.py:2295 _collect_email_opt_in` calls `input()` on first run — an
-      interactive prompt in a CLI that CI invokes.
-- [ ] `jmo.py:2408` prints `jmo config --email ...`; **there is no `jmo config`
-      subcommand.** Phantom command in user-facing output.
+- [x] **FIXED** — `jmo.yml`'s top-level `tools:` lists 8 tools;
+      `report_orchestrator.py:399` passed `cfg.tools` to `store_scan`, so
+      **history recorded the config's list, not what ran.** Filed **#787**.
+      Confirmed on real data, same scan 10 s apart:
+      `.scan_metadata.json` said `{"profile":"deep"→"balanced","tools":["trufflehog"]}`
+      while the history row recorded 8 tools. At scale: **1790 of 1833 rows
+      (97.7%) carry the identical 8-tool list across `fast` (9 tools),
+      `balanced` (17) and `deep` (28)** — and `nuclei` is in all 1790 while
+      `jmo tools check` reports it MISSING, so it cannot have run in any.
+      The same function already resolved the truth into `tools_used` (`:150`,
+      annotated "Bug #5 fix") and `profile` (`:137-147`) and passed
+      `sorted(tools_used)` to `findings.json`'s metadata at `:176` — the
+      history hook just ignored both. Now stores `sorted(tools_used)`, so the
+      history row and `findings.json` agree about the same scan by
+      construction. Note the tools list no longer falls back to `cfg.tools` at
+      all: if neither scan metadata nor findings name a tool, it records `[]`.
+      An honest "unknown" beats a fabricated 8. `profile` keeps its config
+      fallback, because `cfg.default_profile` is a real answer to "which
+      profile" in a way that `cfg.tools` never was to "what ran".
+- [x] **DISMISSED** — `_collect_email_opt_in` is **already guarded**.
+      `jmo.py:2298` returns early on `not sys.stdin.isatty()`, and `:2302-2307`
+      also short-circuit on `JMO_NON_INTERACTIVE`, `CI` and `DOCKER_CONTAINER`.
+      The premise "an interactive prompt in a CLI that CI invokes" does not hold.
+      Swept every `input()` site outside `wizard_flows/` to check the acceptance
+      criterion properly: `jmo.py:2125`, `:3476`, `history_commands.py:400`
+      (`prune`) and `tool_commands.py:945` (`uninstall`) all catch `EOFError`;
+      `tool_commands.py:513`/`:618` gate on `isatty()` with a comment on why
+      that alone is unreliable under Git Bash; `jmo.py:3003` (resume) gates on
+      both stdin and stdout; `scan_utils.py:182` is behind `if interactive:`
+      (`:137`) and its only caller is `wizard.py:961`, which passes
+      `interactive=True`. **Exactly one** was unguarded — see #789 below.
+- [x] **FIXED** — `jmo.py:2408` printed `jmo config --email ...`; there is no
+      `jmo config`. Filed **#790**, and the sweep found a **second** one:
+      `:2360` printed ``Run `jmo subscribe` later to finish signup`` and there
+      is no `jmo subscribe` either. The retry path it promises was never built —
+      `pending_subscription` is written at `:2342` and **never read**, as is
+      `email_opt_in`. Both messages now point at
+      `https://jmotools.com/subscribe.html`, which exists (README.md:15). Also
+      corrected the same fiction in `email_service.py:57`.
 
-**Acceptance:** config precedence (defaults → `jmo.yml` → env → flags) proven by
-a test per layer; no interactive prompt reachable on a non-TTY.
+**Found during the sweep**
+
+- [x] **FIXED** — `jmo tools check` **exits 0 when tools are missing**, against
+      its own docstring at `tool_commands.py:120-122`. Filed **#788**. The
+      `--profile` path returns 1; the default path returned 0 unconditionally at
+      `:140` and `:154` while the JSON it printed said `"ready": false` for all
+      four profiles. Measured with the format held constant, so the variable is
+      `--profile`, not the output mode:
+      `tools check --profile deep --json` → **1**; `tools check --json` → **0**;
+      bare `tools check` → **0**, with 3 real-missing tools in `deep`. A CI gate
+      written `jmo tools check || exit 1` passed with scanners missing — the same
+      silent-success class as #769 and the `zero-secrets` incident. Both default
+      branches now return the same condition the `--profile` path uses.
+- [x] **FIXED** — `jmo schedule delete` was the **only** prompt in the CLI that
+      raised on a non-TTY. Filed **#789**. `schedule_commands.py:377` called
+      `input()` with no `try/except` while every peer catches `EOFError`, and it
+      guards a destructive action. Not reproducible end to end here (`schedule
+      list` reports no schedules, so the command returns early at `:370`, and
+      creating one would register a real OS scheduled task) — proven instead by
+      a regression test with a stub manager and stdin at EOF, which fails
+      before the fix.
+- [x] **FIXED** — per-profile `per_tool` **replaced** a tool's whole entry
+      instead of merging, silently dropping sibling keys. Filed **#791**.
+      `USER_GUIDE.md:1652` promises *"profile values win and are merged"* and
+      `:1225` *"merged with per-profile overrides"*, but `jmo.py:106` used
+      `_merge_dict`, i.e. `dict.update()`, which is one level too shallow.
+      Measured: with root `semgrep: {timeout: 111, flags: [--from-root]}` and
+      `profiles.fast.per_tool.semgrep: {timeout: 222}`, the effective config
+      came back `{'semgrep': {'timeout': 222}, 'trivy': {'timeout': 999}}` —
+      profile wins (correct), untouched `trivy` survives (correct),
+      **`flags` gone** (wrong). Does not affect the shipped `jmo.yml`, which has
+      no root-level `per_tool` — which is why it went unnoticed. Now merges per
+      tool then per key, and copies rather than aliasing so a merge cannot leak
+      back into the loaded config.
+- [x] **DISMISSED** — "`--config <path that does not exist>` silently uses
+      defaults." It does, and it is the **documented contract**:
+      `config.py:202-203` (*"Raises: None: Returns default Config() if path is
+      None, file missing, or YAML error"*) and `:213-215`. It is also what makes
+      `jmo` runnable in a repo with no `jmo.yml`, and the suite depends on it.
+      Not a defect. The narrower risk — a *typo'd explicit* `--config` reading as
+      "no config" — is real but cannot be distinguished today, because
+      `--config` argparse-defaults to `"jmo.yml"` at three sites
+      (`jmo.py:185`, `:307`, `:425`), so nothing knows whether the user typed it.
+      Recorded here rather than filed; fixing it means defaulting to `None` and
+      resolving later, which is a UX change, not a bug fix.
+- [x] **DISMISSED** — "the scan path ignores `threads:` in `jmo.yml`."
+      `scan_orchestrator.get_effective_max_workers` (`:591-614`) does document a
+      precedence that skips `cfg.threads` and hardcodes `4`, but it is
+      unreachable in production: `jmo.py:2921` populates
+      `ScanConfig.max_workers` with `_get_max_workers(args, eff, cfg)` — the full
+      5-layer resolver — which never returns `None`, so the `is not None` branch
+      always wins first. The dead ladder is exercised only by tests. Its
+      docstring is inaccurate, which is a doc nit, not a behaviour bug.
+
+**Acceptance — met**
+
+- Config precedence proven by a test per layer, **observing the resolved value**:
+  `tests/unit/test_config_precedence.py` (24 tests) covers threads
+  (defaults → `jmo.yml` → `JMO_THREADS` → `--threads`, plus `auto` and junk-env
+  fallthrough), `deduplication.similarity_threshold` through the real
+  `load_config_with_env_overrides` (default → file → env → rejected-env keeps the
+  file value), and `per_tool` (profile wins · root siblings survive · unmentioned
+  tools untouched · merge does not mutate the loaded config). The pre-existing
+  `tests/integration/test_cli_profile_threads.py` does **not** count: it asserts
+  `rc in (0, 1)` under the comment *"We cannot easily read threads back from
+  aggregator here"*, so it cannot fail when the ordering changes.
+- No interactive prompt reachable on a non-TTY: swept above; the one exception
+  is fixed.
+- All seven guards proven able to fail by reverting each fix against a **file
+  backup** and watching the specific test go red, then restoring. **7/7 red.**
+
+**Surfaced here, not a chunk 1 finding:** **#792** —
+`test_stress.py::test_100k_findings_memory_usage` gates on an absolute 500 MB
+RSS *delta*. Three measurements on this machine in one afternoon on the same
+branch: **passed**, **506.0 MB**, **535.8 MB**. Proven unrelated to this
+chunk — it calls `gather_results` in `normalize_and_report.py`, which this
+branch does not touch (`git diff origin/dev` on that file is empty), and the
+`import-direction` hook forbids `scripts/core/` importing `scripts/cli/`. It is
+marked `slow`, which the Ubuntu and macOS PR shards **include**.
+
+**Correction to this chunk's premise:** the surface listed `JMO_PROFILE`
+alongside `JMO_THREADS`/`JMO_DEDUP_THRESHOLD` as a config env override. It is
+not one. `JMO_PROFILE` is a **timing-profiler toggle** compared strictly against
+`"1"` (`normalize_and_report.py:152`), unrelated to scan profiles — so the
+shipped `docs/examples/.gitlab-ci.yml:7` idiom `JMO_PROFILE: "balanced"` is
+harmless (it is interpolated into `--profile-name`, never read by JMo), but the
+name collision is real and will mislead. Only `JMO_DEDUP_THRESHOLD` of the three
+is handled by `load_config_with_env_overrides`; note also that its docstring
+(`config.py:361-368`) advertises a general 4-level precedence while the function
+handles only the 7 policy and dedup vars, of 23 `JMO_*` vars in `scripts/`.
 
 ---
 
@@ -314,6 +444,12 @@ that exists.**
       re-scan, or accept NULL and change the trends defaults. This is the
       campaign's most likely stall point.
 - [ ] #721 — `slim` scans are silently dropped from the history database.
+- [ ] Noted in chunk 1, not chased there: the auto-storage hook swallows
+      **every** exception into a `WARN` plus a printed traceback
+      (`report_orchestrator.py:423-429`) and does not affect the exit code, so a
+      scan can complete "successfully" having stored nothing. Check this against
+      #721 — a silent drop and a swallowed store failure look identical from
+      outside, and #721 may be a symptom of this rather than its own bug.
 
 ---
 
@@ -359,7 +495,16 @@ flag exist — reconcile), `jmo build fast|slim|balanced|deep`.
       `balanced`, `full`, `setup`, `adapters`, `attest`, `verify`.
       `_MAIN_HELP_COUNT  # 13` is a hardcoded comment that will drift again —
       **derive the list from the parser**, or this chunk re-creates the bug it
-      just fixed.
+      just fixed. `tests/unit/test_config_precedence.py::_parser_subcommands`
+      (added in chunk 1) already does this by capturing the subparsers action
+      out of `parse_args()`; promote it rather than writing a third list.
+- [ ] Noted in chunk 1: **there is no central exit-code contract to validate
+      against.** `CLI_REFERENCE.md` documents exit codes only per command (e.g.
+      `verify` at `:306-310`); nothing states the global convention. Measured
+      and consistent so far: `--version`/`--help` → 0, unknown subcommand → 2,
+      no subcommand → 2 (which `cli_validator.py:458` asserts is intended),
+      threshold breach → 1. This chunk's acceptance needs that table to exist
+      before "the validator covers 20 subcommands" means anything.
 
 ---
 

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -51,6 +51,27 @@ def _merge_dict(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _merge_per_tool(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
+    """Merge per-tool overrides one level deeper than ``dict.update()``.
+
+    USER_GUIDE.md:1652 promises root and per-profile ``per_tool`` blocks are
+    "merged", with profile values winning. A flat update replaces a tool's whole
+    entry, so a profile that set only ``semgrep.timeout`` silently discarded a
+    root-level ``semgrep.flags`` (#791). Merge per tool, then per key.
+    """
+    out: dict[str, Any] = {
+        tool: dict(opts) if isinstance(opts, dict) else opts
+        for tool, opts in (a or {}).items()
+    }
+    for tool, opts in (b or {}).items():
+        existing = out.get(tool)
+        if isinstance(existing, dict) and isinstance(opts, dict):
+            existing.update(opts)
+        else:
+            out[tool] = dict(opts) if isinstance(opts, dict) else opts
+    return out
+
+
 def _effective_scan_settings(args) -> dict[str, Any]:
     """Compute effective scan settings from CLI, config, and optional profile.
 
@@ -82,7 +103,7 @@ def _effective_scan_settings(args) -> dict[str, Any]:
     retries = cfg.retries  # May be int or RetryConfig
     if isinstance(profile.get("retries"), (int, dict)):
         retries = profile["retries"]
-    per_tool = _merge_dict(cfg.per_tool, profile.get("per_tool", {}))
+    per_tool = _merge_per_tool(cfg.per_tool, profile.get("per_tool", {}))
 
     # Handle --skip-tools flag to exclude specific tools
     skip_tools = getattr(args, "skip_tools", None) or []
@@ -2355,9 +2376,14 @@ def _collect_email_opt_in(args) -> None:
                     )
                 else:
                     # Audience add failed — saved locally, retry path available.
+                    # No `jmo subscribe` command exists, and the
+                    # `pending_subscription` flag written below is never read
+                    # back, so there is no CLI retry path to advertise (#790).
+                    # Point at the page that does exist.
                     _safe_print(
-                        "\n✅ Thanks! Saved your address. Run "
-                        "`jmo subscribe` later to finish signup.\n"
+                        "\n✅ Thanks! Saved your address locally, but signup"
+                        " did not complete.\n   Finish it at"
+                        " https://jmotools.com/subscribe.html\n"
                     )
                     _log(
                         args,
@@ -2404,8 +2430,10 @@ def _collect_email_opt_in(args) -> None:
                 yaml.dump(config, f)
             _log(args, "DEBUG", f"Email collection error (non-blocking): {e}")
     else:
-        _safe_print("\n👍 No problem! You can always add your email later with:")
-        print("   jmo config --email your@email.com\n")
+        # `jmo config` is not a subcommand -- the parser has 20 and that is not
+        # one of them (#790). Name the page that actually works.
+        _safe_print("\n👍 No problem! You can always subscribe later at:")
+        print("   https://jmotools.com/subscribe.html\n")
 
         # Mark onboarding complete even if skipped
         import yaml

--- a/scripts/cli/report_orchestrator.py
+++ b/scripts/cli/report_orchestrator.py
@@ -390,13 +390,16 @@ def cmd_report(args, _log_fn) -> int:
             else:
                 history_db_path = Path(".jmo/history.db")
 
-            # Get profile name from config
-            profile_name = (
-                getattr(args, "profile_name", None) or cfg.default_profile or "balanced"
-            )
-
-            # Get tools from config
-            tools = getattr(cfg, "tools", [])
+            # Record what the scan actually did, not what the config asks for.
+            # `profile` and `tools_used` were resolved above from
+            # .scan_metadata.json (written by the scan) with a findings-derived
+            # fallback, and `tools_used` is what findings.json's metadata
+            # already reports. Reading cfg.tools here instead made every stored
+            # row claim jmo.yml's top-level `tools:` list regardless of profile
+            # -- 1790 of 1833 rows named the same 8 tools, including one that
+            # was not installed and so cannot have run (#787).
+            profile_name = getattr(args, "profile_name", None) or profile or "balanced"
+            tools = sorted(tools_used)
 
             # Get security flags (Phase 6 Step 6.1, 6.2, 6.3)
             no_store_raw = getattr(args, "no_store_raw_findings", False)

--- a/scripts/cli/schedule_commands.py
+++ b/scripts/cli/schedule_commands.py
@@ -374,7 +374,15 @@ def _cmd_schedule_delete(args, manager: ScheduleManager) -> int:
     # Confirmation prompt (unless --force)
     if not args.force:
         _warn(f"Delete schedule '{args.name}'? This cannot be undone.")
-        response = input("Type 'yes' to confirm: ")
+        try:
+            response = input("Type 'yes' to confirm: ")
+        except (EOFError, KeyboardInterrupt):
+            # Nobody is there to confirm a destructive action, so decline it.
+            # Every peer prompt already does this -- `history prune`,
+            # `tools uninstall`, the first-run and resume prompts -- and this
+            # was the one that raised instead (#789).
+            _info("Cancelled")
+            return 0
         if response.lower() != "yes":
             _info("Cancelled")
             return 0

--- a/scripts/cli/tool_commands.py
+++ b/scripts/cli/tool_commands.py
@@ -133,11 +133,23 @@ def cmd_tools_check(args: argparse.Namespace) -> int:
         statuses = manager.check_profile(profile)
         title = f"Tool Status for '{profile}' profile ({len(statuses)} tools)"
     else:
-        # Default: show profile summary
+        # Default: show profile summary across every profile.
+        #
+        # The exit code follows the same contract as the --profile path: a
+        # missing tool is a missing tool, and manual-install tools count exactly
+        # as they do there. Readiness used to be computed and then discarded --
+        # this branch returned 0 unconditionally while the JSON it printed said
+        # "ready": false for all four profiles -- so `jmo tools check` used as a
+        # CI gate passed with scanners missing (#788).
+        #
+        # ToolManager memoises per-tool status, so asking for the summaries here
+        # and again inside print_profile_summary costs cache hits, not probes.
+        summaries = {p: manager.get_profile_summary(p) for p in PROFILE_TOOLS}
+        missing_rc = 1 if any(s.get("missing", 0) for s in summaries.values()) else 0
+
         if output_json:
-            summaries = {p: manager.get_profile_summary(p) for p in PROFILE_TOOLS}
             print(json.dumps(summaries, indent=2))
-            return 0
+            return missing_rc
 
         print_profile_summary(manager, colorize)
 
@@ -151,7 +163,7 @@ def cmd_tools_check(args: argparse.Namespace) -> int:
                 print(f"  - {s.name}: {s.installed_version} -> {s.expected_version}")
             print("\nRun `jmo tools update --critical-only` to update")
 
-        return 0
+        return missing_rc
 
     # JSON output
     if output_json:

--- a/scripts/core/email_service.py
+++ b/scripts/core/email_service.py
@@ -54,9 +54,10 @@ RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
 FROM_EMAIL = os.getenv("JMO_FROM_EMAIL", "marketing@jmotools.com")
 
 # Canonical audience for the "JMo Updates" newsletter. CLI signup touchpoints
-# (first-run prompt, `jmo wizard` end-of-flow, `jmo subscribe`) push contacts
-# here so they land in the same audience that scripts/core/newsletter_broadcast.py
-# targets when sending release digests.
+# (first-run prompt, `jmo wizard` end-of-flow) push contacts here so they land
+# in the same audience that scripts/core/newsletter_broadcast.py targets when
+# sending release digests. This list used to name a third touchpoint,
+# `jmo subscribe`, which is not a subcommand and never was (#790).
 JMO_UPDATES_AUDIENCE_ID = "fb900b6d-10de-4171-97df-e4e5eebf20fd"
 RESEND_AUDIENCE_ID = os.getenv("RESEND_AUDIENCE_ID", JMO_UPDATES_AUDIENCE_ID)
 

--- a/tests/cli/test_tool_commands.py
+++ b/tests/cli/test_tool_commands.py
@@ -259,7 +259,13 @@ def test_cmd_tools_check_specific_tools():
 
 
 def test_cmd_tools_check_json_output_profile_summary():
-    """Test cmd_tools_check JSON output for profile summary."""
+    """Test cmd_tools_check JSON output for profile summary.
+
+    This asserted `result == 0` while mocking two *missing* tools, which pinned
+    the defect fixed in #788: the no-argument form returned 0 no matter what it
+    found, so `jmo tools check || exit 1` passed with scanners missing. The
+    summary is still printed; the exit code now matches the `--profile` path.
+    """
     from scripts.cli.tool_commands import cmd_tools_check
 
     mock_manager = MagicMock()
@@ -275,8 +281,8 @@ def test_cmd_tools_check_json_output_profile_summary():
         with patch("builtins.print") as mock_print:
             result = cmd_tools_check(args)
 
-    # Should print JSON
-    assert result == 0
+    # Should print JSON, and report the missing tools through the exit code
+    assert result == 1
     mock_print.assert_called()
 
 
@@ -1684,10 +1690,18 @@ class TestCmdToolsCheckComprehensive:
         assert result == 0
 
     def test_check_no_profile_shows_summary(self):
-        """Test check without profile shows summary."""
+        """Test check without profile shows summary.
+
+        The summary is what this asserts; the exit code is pinned separately by
+        tests/unit/test_config_precedence.py. `get_profile_summary` must return
+        a real dict rather than a bare Mock — since #788 the no-profile path
+        reads `missing` from it, and `Mock().get(...)` is truthy, which would
+        make the exit code an artefact of the mock rather than of the input.
+        """
         from scripts.cli.tool_commands import cmd_tools_check
 
         mock_manager = MagicMock()
+        mock_manager.get_profile_summary.return_value = {"installed": 7, "missing": 0}
         mock_manager.get_critical_outdated.return_value = []
 
         args = argparse.Namespace(
@@ -1707,7 +1721,12 @@ class TestCmdToolsCheckComprehensive:
         assert result == 0
 
     def test_check_no_profile_with_critical_outdated(self):
-        """Test check without profile with critical outdated tools."""
+        """Test check without profile with critical outdated tools.
+
+        Outdated is not missing: everything is installed here, so the exit code
+        stays 0 while the critical-update notice is still printed. See the
+        sibling test for why the summary must be a real dict.
+        """
         from scripts.cli.tool_commands import cmd_tools_check
 
         mock_outdated = MagicMock()
@@ -1716,6 +1735,7 @@ class TestCmdToolsCheckComprehensive:
         mock_outdated.expected_version = "0.50.0"
 
         mock_manager = MagicMock()
+        mock_manager.get_profile_summary.return_value = {"installed": 7, "missing": 0}
         mock_manager.get_critical_outdated.return_value = [mock_outdated]
 
         args = argparse.Namespace(

--- a/tests/unit/test_config_precedence.py
+++ b/tests/unit/test_config_precedence.py
@@ -1,0 +1,453 @@
+"""Config precedence and CLI-shell contracts (v1.1.0 audit campaign, chunk 1).
+
+Every precedence layer here is proven by **observing the resolved value**, not
+by running the code path and asserting it did not raise. The pre-existing
+coverage in ``tests/integration/test_cli_profile_threads.py`` sets
+``JMO_THREADS=5``, calls ``cmd_report`` and asserts ``rc in (0, 1)`` under the
+comment *"We cannot easily read threads back from aggregator here"* — so it
+cannot go red if the ordering is reversed. These can.
+
+Also pins the four contracts chunk 1 found broken: #787 (history recorded the
+config's tool list instead of what ran), #788 (``tools check`` exited 0 with
+tools missing), #789 (a destructive prompt raised ``EOFError`` on a non-TTY),
+#790 (user-facing output named subcommands that do not exist).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import contextlib
+import io
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.cli import jmo as jmo_mod
+from scripts.core.config import Config, load_config_with_env_overrides
+
+# `_get_max_workers` falls through to CPU auto-detection. Pin it to a value no
+# other layer uses so "which layer won" is unambiguous rather than inferred.
+SENTINEL_AUTO = 99
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Precedence tests must not inherit a JMO_* var from the developer's shell."""
+    for var in ("JMO_THREADS", "JMO_DEDUP_THRESHOLD", "JMO_PROFILE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def pinned_autodetect(monkeypatch: pytest.MonkeyPatch) -> int:
+    monkeypatch.setattr(jmo_mod, "_auto_detect_threads", lambda _args: SENTINEL_AUTO)
+    return SENTINEL_AUTO
+
+
+# --------------------------------------------------------------------------
+# threads: defaults -> jmo.yml -> env -> flags, one test per layer
+# --------------------------------------------------------------------------
+
+
+def _resolve_threads(eff_threads: object, cfg_threads: object) -> int | None:
+    return jmo_mod._get_max_workers(
+        argparse.Namespace(),
+        {"threads": eff_threads},
+        Config(threads=cfg_threads),  # type: ignore[arg-type]
+    )
+
+
+def test_threads_layer1_nothing_set_falls_through_to_autodetect(pinned_autodetect):
+    """Layer 1 (defaults): no flag, no env, no config -> auto-detect."""
+    assert _resolve_threads(None, None) == SENTINEL_AUTO
+
+
+def test_threads_layer2_config_file_beats_the_default(pinned_autodetect):
+    """Layer 2 (jmo.yml): `threads: 7` is used instead of auto-detect."""
+    assert _resolve_threads(None, 7) == 7
+
+
+def test_threads_layer3_env_beats_the_config_file(
+    pinned_autodetect, monkeypatch: pytest.MonkeyPatch
+):
+    """Layer 3 (env): JMO_THREADS outranks `threads:` in jmo.yml."""
+    monkeypatch.setenv("JMO_THREADS", "5")
+    assert _resolve_threads(None, 7) == 5
+
+
+def test_threads_layer4_flag_beats_env_and_config_file(
+    pinned_autodetect, monkeypatch: pytest.MonkeyPatch
+):
+    """Layer 4 (flags): --threads outranks both env and jmo.yml."""
+    monkeypatch.setenv("JMO_THREADS", "5")
+    assert _resolve_threads(3, 7) == 3
+
+
+def test_threads_auto_keyword_is_honoured_from_env_and_config(
+    pinned_autodetect, monkeypatch: pytest.MonkeyPatch
+):
+    """'auto' means auto-detect wherever it is set, not int('auto')."""
+    monkeypatch.setenv("JMO_THREADS", "auto")
+    assert _resolve_threads(None, 7) == SENTINEL_AUTO
+    monkeypatch.delenv("JMO_THREADS")
+    assert _resolve_threads(None, "auto") == SENTINEL_AUTO
+
+
+def test_threads_unparsable_env_falls_through_to_config_file(
+    pinned_autodetect, monkeypatch: pytest.MonkeyPatch
+):
+    """A junk env value must not shadow a valid config value."""
+    monkeypatch.setenv("JMO_THREADS", "not-a-number")
+    assert _resolve_threads(None, 7) == 7
+
+
+# --------------------------------------------------------------------------
+# deduplication.similarity_threshold: same four layers, through the real loader
+# --------------------------------------------------------------------------
+
+
+def _write_cfg(tmp_path: Path, body: str) -> str:
+    p = tmp_path / "jmo.yml"
+    p.write_bytes(body.encode("utf-8"))  # write_bytes: Path.write_text flips LF->CRLF
+    return str(p)
+
+
+def test_dedup_layer1_default_when_no_config_file(tmp_path: Path):
+    cfg = load_config_with_env_overrides(str(tmp_path / "absent.yml"))
+    assert cfg.deduplication.similarity_threshold == 0.65
+
+
+def test_dedup_layer2_config_file_beats_the_default(tmp_path: Path):
+    path = _write_cfg(tmp_path, "deduplication:\n  similarity_threshold: 0.80\n")
+    assert (
+        load_config_with_env_overrides(path).deduplication.similarity_threshold == 0.80
+    )
+
+
+def test_dedup_layer3_env_beats_the_config_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = _write_cfg(tmp_path, "deduplication:\n  similarity_threshold: 0.80\n")
+    monkeypatch.setenv("JMO_DEDUP_THRESHOLD", "0.90")
+    assert (
+        load_config_with_env_overrides(path).deduplication.similarity_threshold == 0.90
+    )
+
+
+@pytest.mark.parametrize("bad", ["abc", "2.0", "0.1"])
+def test_dedup_out_of_range_or_junk_env_keeps_the_config_file_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad: str
+):
+    """Rejected env values must leave the configured value standing, not reset it."""
+    path = _write_cfg(tmp_path, "deduplication:\n  similarity_threshold: 0.80\n")
+    monkeypatch.setenv("JMO_DEDUP_THRESHOLD", bad)
+    assert (
+        load_config_with_env_overrides(path).deduplication.similarity_threshold == 0.80
+    )
+
+
+# --------------------------------------------------------------------------
+# per_tool: root block and per-profile block, "profile values win and are merged"
+# --------------------------------------------------------------------------
+
+
+_PER_TOOL_CFG = """\
+default_profile: fast
+per_tool:
+  semgrep:
+    timeout: 111
+    flags: [--from-root]
+  trivy:
+    timeout: 999
+profiles:
+  fast:
+    per_tool:
+      semgrep:
+        timeout: 222
+"""
+
+
+def _effective_per_tool(tmp_path: Path) -> dict:
+    path = _write_cfg(tmp_path, _PER_TOOL_CFG)
+    args = argparse.Namespace(
+        config=path,
+        profile_name=None,
+        threads=None,
+        timeout=None,
+        tools=None,
+        skip_tools=None,
+        include=None,
+        exclude=None,
+        retries=None,
+    )
+    return jmo_mod._effective_scan_settings(args)["per_tool"]
+
+
+def test_per_tool_profile_value_wins_over_the_root_value(tmp_path: Path):
+    assert _effective_per_tool(tmp_path)["semgrep"]["timeout"] == 222
+
+
+def test_per_tool_root_keys_survive_a_partial_profile_override(tmp_path: Path):
+    """Regression for #791.
+
+    USER_GUIDE.md:1652 promises the two blocks "are merged". A flat
+    `dict.update()` replaced semgrep's whole entry, so overriding only its
+    timeout silently dropped the root-level flags.
+    """
+    assert _effective_per_tool(tmp_path)["semgrep"]["flags"] == ["--from-root"]
+
+
+def test_per_tool_tools_the_profile_never_mentions_are_untouched(tmp_path: Path):
+    assert _effective_per_tool(tmp_path)["trivy"] == {"timeout": 999}
+
+
+def test_per_tool_merge_does_not_mutate_the_loaded_config(tmp_path: Path):
+    """The merge must copy: mutating cfg.per_tool would leak across profiles."""
+    from scripts.core.config import load_config
+
+    path = _write_cfg(tmp_path, _PER_TOOL_CFG)
+    cfg = load_config(path)
+    merged = jmo_mod._merge_per_tool(cfg.per_tool, cfg.profiles["fast"]["per_tool"])
+    merged["semgrep"]["timeout"] = 777
+    assert cfg.per_tool["semgrep"]["timeout"] == 111
+
+
+# --------------------------------------------------------------------------
+# #787 - history must record what ran, not what jmo.yml lists
+# --------------------------------------------------------------------------
+
+
+def test_history_records_the_tools_that_ran_not_the_configured_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Regression for #787.
+
+    Before the fix this asserted the config's list: 1790 of 1833 rows in the
+    real database named jmo.yml's 8 tools regardless of profile, including
+    `nuclei`, which was not installed and so cannot have run in any of them.
+    """
+    results_dir = tmp_path / "results"
+    (results_dir / "individual-repos" / "repo1").mkdir(parents=True)
+    (results_dir / ".scan_metadata.json").write_bytes(
+        json.dumps(
+            {"profile": "deep", "tools": ["trufflehog"], "target_count": 1}
+        ).encode("utf-8")
+    )
+    # A config whose tool list is deliberately nothing like what ran.
+    cfg_path = _write_cfg(
+        tmp_path,
+        "default_profile: balanced\ntools:\n- semgrep\n- trivy\n- nuclei\noutputs:\n- json\n",
+    )
+
+    args = argparse.Namespace(
+        cmd="report",
+        results_dir=str(results_dir),
+        out=str(results_dir / "summaries"),
+        config=cfg_path,
+        fail_on=None,
+        profile=False,
+        threads=None,
+        store_history=True,
+        history_db=str(tmp_path / "history.db"),  # never the real .jmo/history.db
+        profile_name=None,
+    )
+
+    with patch("scripts.core.history_db.store_scan", return_value="scan-id") as store:
+        jmo_mod.cmd_report(args)
+
+    assert store.called, "report did not reach the history-storage hook"
+    kwargs = store.call_args.kwargs
+    assert kwargs["tools"] == ["trufflehog"], (
+        "history recorded the configured tool list instead of what ran: "
+        f"{kwargs['tools']}"
+    )
+    assert kwargs["profile"] == "deep", (
+        f"history recorded the config default instead of the scanned profile: "
+        f"{kwargs['profile']}"
+    )
+
+
+def test_history_falls_back_to_config_profile_when_no_scan_metadata(
+    tmp_path: Path,
+):
+    """Without .scan_metadata.json there is nothing better than the config."""
+    results_dir = tmp_path / "results"
+    (results_dir / "individual-repos" / "repo1").mkdir(parents=True)
+    cfg_path = _write_cfg(tmp_path, "default_profile: fast\noutputs:\n- json\n")
+
+    args = argparse.Namespace(
+        cmd="report",
+        results_dir=str(results_dir),
+        out=str(results_dir / "summaries"),
+        config=cfg_path,
+        fail_on=None,
+        profile=False,
+        threads=None,
+        store_history=True,
+        history_db=str(tmp_path / "history.db"),
+        profile_name=None,
+    )
+
+    with patch("scripts.core.history_db.store_scan", return_value="scan-id") as store:
+        jmo_mod.cmd_report(args)
+
+    assert store.call_args.kwargs["profile"] == "fast"
+
+
+# --------------------------------------------------------------------------
+# #788 - `jmo tools check` exit code is the same contract in every form
+# --------------------------------------------------------------------------
+
+
+def _summary(missing: int) -> dict:
+    return {
+        "profile": "p",
+        "total": 10,
+        "installed": 10 - missing,
+        "missing": missing,
+        "real_missing": missing,
+        "manual_install_missing": 0,
+        "ready": missing == 0,
+        "warnings": [],
+    }
+
+
+@pytest.mark.parametrize("output_json", [True, False])
+def test_bare_tools_check_exits_nonzero_when_a_profile_is_short_a_tool(output_json):
+    """Regression for #788: readiness was computed and then discarded."""
+    from scripts.cli.tool_commands import cmd_tools_check
+
+    manager = MagicMock()
+    manager.get_profile_summary.side_effect = lambda _p: _summary(missing=2)
+    manager.get_critical_outdated.return_value = []
+
+    args = argparse.Namespace(tools=None, profile=None, json=output_json)
+    with (
+        patch("scripts.cli.tool_commands.ToolManager", return_value=manager),
+        patch("scripts.cli.tool_commands.print_profile_summary"),
+        patch("builtins.print"),
+    ):
+        assert cmd_tools_check(args) == 1
+
+
+@pytest.mark.parametrize("output_json", [True, False])
+def test_bare_tools_check_exits_zero_when_every_profile_is_complete(output_json):
+    from scripts.cli.tool_commands import cmd_tools_check
+
+    manager = MagicMock()
+    manager.get_profile_summary.side_effect = lambda _p: _summary(missing=0)
+    manager.get_critical_outdated.return_value = []
+
+    args = argparse.Namespace(tools=None, profile=None, json=output_json)
+    with (
+        patch("scripts.cli.tool_commands.ToolManager", return_value=manager),
+        patch("scripts.cli.tool_commands.print_profile_summary"),
+        patch("builtins.print"),
+    ):
+        assert cmd_tools_check(args) == 0
+
+
+# --------------------------------------------------------------------------
+# #789 - no destructive prompt may raise on a non-TTY
+# --------------------------------------------------------------------------
+
+
+def test_schedule_delete_declines_instead_of_raising_on_closed_stdin():
+    """Regression for #789.
+
+    Not reproducible end to end here — `schedule list` reports no schedules, so
+    the real command returns early before the prompt. A stub manager puts the
+    prompt in reach; before the fix this raised EOFError.
+    """
+    from scripts.cli.schedule_commands import _cmd_schedule_delete
+
+    manager = MagicMock()
+    manager.get.return_value = {"name": "nightly"}
+    args = argparse.Namespace(name="nightly", force=False)
+
+    with patch("builtins.input", side_effect=EOFError):
+        rc = _cmd_schedule_delete(args, manager)
+
+    assert rc == 0
+    # A declined confirmation must not delete the schedule.
+    manager.delete.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# #790 - user-facing output may not name a subcommand that does not exist
+# --------------------------------------------------------------------------
+
+
+def _parser_subcommands() -> set[str]:
+    """Derive the subcommand set from the parser itself.
+
+    Deliberately not a restated list: `cli_validator.MAIN_SUBCOMMANDS` is one of
+    those and had drifted to 13 of 20 (#783). `parse_args()` builds and parses in
+    one call, so capture the subparser action on the way past.
+    """
+    captured: dict[str, argparse._SubParsersAction] = {}
+    original = argparse.ArgumentParser.add_subparsers
+
+    def _capture(self, *a, **kw):
+        action = original(self, *a, **kw)
+        captured.setdefault(kw.get("dest") or "positional", action)
+        return action
+
+    argv = sys.argv
+    argparse.ArgumentParser.add_subparsers = _capture  # type: ignore[method-assign]
+    try:
+        sys.argv = ["jmo", "--help"]
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+            contextlib.suppress(SystemExit),
+        ):
+            jmo_mod.parse_args()
+    finally:
+        argparse.ArgumentParser.add_subparsers = original  # type: ignore[method-assign]
+        sys.argv = argv
+
+    top = captured.get("cmd")
+    assert top is not None, "could not capture the top-level subparsers action"
+    return set(top.choices)
+
+
+# Two unambiguous ways of naming a command: backtick-quoted, or followed by a
+# flag. Plain prose ("the .jmo directory", "jmo entry point failed") matches
+# neither, which is what keeps this guard from crying wolf.
+_COMMAND_REF = re.compile(r"`jmo\s+([a-z][a-z0-9-]+)|\bjmo\s+([a-z][a-z0-9-]+)\s+--")
+
+
+def test_no_user_facing_string_names_a_nonexistent_subcommand():
+    """Regression for #790.
+
+    Before the fix, first-run output told users to run `jmo config --email ...`
+    and `jmo subscribe`, neither of which is in the parser's 20 subcommands.
+
+    Scans string literals via `ast` rather than by line, so comments cannot
+    trip it — the same approach as tests/cross_platform/test_encoding_drift_guard.py.
+    """
+    real = _parser_subcommands()
+    assert len(real) >= 20, f"parser capture looks wrong: {sorted(real)}"
+
+    offenders: list[str] = []
+    for path in sorted(Path("scripts").rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:  # pragma: no cover - would fail elsewhere first
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+                continue
+            for match in _COMMAND_REF.finditer(node.value):
+                name = match.group(1) or match.group(2)
+                if name not in real:
+                    offenders.append(f"{path.as_posix()}:{node.lineno}: jmo {name}")
+
+    assert (
+        not offenders
+    ), "user-facing text names commands that do not exist:\n" + "\n".join(offenders)


### PR DESCRIPTION
Chunk 1 of the [v1.1.0 audit campaign](../blob/dev/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign.md) — **config + CLI shell**. Tracking: #785.

Closes #787, closes #788, closes #789, closes #790, closes #791.

## Findings

Eight, all terminal. Every one was measured against the running tool before being filed or dismissed.

| | Finding | Verdict |
|---|---|---|
| #787 | History records the config's tool list and profile, not what ran | **FIXED** |
| #788 | `jmo tools check` exits 0 when tools are missing | **FIXED** |
| #789 | `schedule delete` raises `EOFError` on a non-TTY | **FIXED** |
| #790 | First-run output names two commands that do not exist | **FIXED** |
| #791 | Per-profile `per_tool` replaces instead of merging | **FIXED** |
| — | "First-run `input()` is reachable in CI" | **DISMISSED** — guarded four ways at `jmo.py:2298-2307` |
| — | "The scan path ignores `cfg.threads`" | **DISMISSED** — `jmo.py:2921` uses the 5-layer resolver |
| — | "`--config <missing>` silently defaults" | **DISMISSED** — documented contract, `config.py:202-203` |

### #787 is the one worth reading

`cmd_report` already resolves what the scan actually did — `tools_used` at `:150` (annotated *"Bug #5 fix"*) and `profile` at `:137-147` — and passes `sorted(tools_used)` into `findings.json`'s metadata at `:176`. The history hook 250 lines later re-derived both from config.

Same scan, ten seconds apart:

| Source | Value |
|---|---|
| `results/.scan_metadata.json` @ 21:52:47 | `{"profile": "balanced", "tools": ["trufflehog"]}` |
| history row @ 21:52:57 | 8 tools |

At scale, on the real 1833-scan database:

```
n= 1048  profile=balanced  ntools=8  ['trufflehog','semgrep','syft','trivy','checkov','hadolint','zap','nuclei']
n=  438  profile=fast      ntools=8  (identical)
n=  304  profile=deep      ntools=8  (identical)
```

**1790 of 1833 rows (97.7%) carry the same 8 tools across profiles that run 9, 17 and 28.** That list is byte-for-byte `jmo.yml`'s top-level `tools:`. `nuclei` appears in all 1790 and `jmo tools check` reports it MISSING — so it cannot have run in a single one of them.

Consequence: every history-derived claim about tool coverage to date is wrong, and `findings.json` and the history row disagree about the same scan.

## Evidence gate

Per CLAUDE.md, the verification CI **structurally cannot** provide, and its numbers:

**1. The 1833-scan history database does not exist in CI.** The `(tools, profile)` distribution above, and the `.scan_metadata.json` ↔ history-row divergence, are only measurable against the real 659 MB fixture. Snapshotted to `.jmo/history.db.snapshot-20260808` (691,752,960 bytes) before anything ran.

**2. CI's tool state is installed-or-not; this host has three genuinely missing scanners.** So the #788 fix can be verified end to end here and not there:

```console
# before
$ jmo tools check; echo $?
0          # with noseyparker, nuclei, scancode MISSING from deep

# after
$ jmo tools check; echo $?
1
```

Runtime unchanged — 31.8 s warm, against a 33 s baseline. The added summary pass is cache hits (`ToolManager._status_cache`), not re-probes.

**3. Run with `PYTHONUTF8` unset.** CI pins it to `1`, an environment no real Windows user has.

## Guards proven able to fail

Each fix was reverted against a **file backup** (never `git checkout --`), the specific test watched go red, then restored:

```
#787 history tools               RED (guard works)
#787 history profile             RED (guard works)
#788 tools check rc (json)       RED (guard works)
#788 tools check rc (human)      RED (guard works)
#789 schedule EOF guard          RED (guard works)
#790 phantom command             RED (guard works)   -> names the site: scripts/cli/jmo.py:2415: jmo config
#791 per_tool merge              RED (guard works)
```

**7/7.**

## Tests

`tests/unit/test_config_precedence.py` — 24 tests. Each precedence layer is proven by **observing the resolved value**, which the existing coverage could not do: `test_threads_env_and_config_precedence` asserts `rc in (0, 1)` under the comment *"We cannot easily read threads back from aggregator here"*, so reversing the ordering would not turn it red.

- **threads** — defaults → `jmo.yml` → `JMO_THREADS` → `--threads`, plus `auto` at each layer and junk-env fallthrough
- **`deduplication.similarity_threshold`** — through the real `load_config_with_env_overrides`, including that a *rejected* env value leaves the configured value standing rather than resetting it
- **`per_tool`** — profile wins · root siblings survive · unmentioned tools untouched · the merge copies rather than aliasing
- Regression guards for all five fixes

The phantom-command guard derives the subcommand set **from the parser** and scans string literals via `ast`, so comments cannot trip it and a restated list cannot drift — the failure mode behind #783.

## One note for the reviewer

**`tests/cli/test_tool_commands.py`** — three tests asserted `result == 0` for the no-profile path, one of them while mocking two *missing* tools. They pinned the #788 defect. Two now supply an explicit `{"missing": 0}` summary so their exit-code assertion reflects the input rather than `MagicMock` truthiness (a bare `Mock().get("missing", 0)` is truthy); the one that mocked missing tools now expects `1`.

The diff is otherwise confined to the five fixes — no reformatting of untouched code.

## Local suite

`JMO_THREADS=2 pytest -n 8 -m "not smoke and not requires_tools and not docker"`, `PYTHONUTF8` **unset** (CI pins it to `1`). Run in two halves whose paths provably cover all of `tests/` — the second is `tests/` with `--ignore` of the first's three paths — because a single 11-minute run kept getting killed.

| | Result |
|---|---|
| `tests/unit tests/cli tests/core` | **5191 passed, 61 skipped** — exit 0 |
| `tests/` minus those three | **2887 passed, 40 skipped, 1 failed** — exit 1 |
| Total | **8078 passed, 101 skipped, 1 failed** |

The one failure is `test_stress.py::test_100k_findings_memory_usage`, filed as **#792** and **not caused by this branch**:

- it calls `gather_results` in `scripts/core/normalize_and_report.py`, and `git diff origin/dev` on that file is empty
- this branch's only `scripts/core/` change is a **comment** in `email_service.py`
- the `import-direction` hook (passing) forbids `scripts/core/` importing `scripts/cli/`, so none of the CLI changes can reach it

It gates on an absolute 500 MB RSS *delta* and produced **passed / 506.0 MB / 535.8 MB** across three runs on this machine this afternoon on the same branch.

An earlier complete run of the whole suite in one pass, before the #791 fix, gave **8073 passed / 101 skipped / 2 failed**; both failures were tests in `test_tool_commands.py` that pinned the #788 defect, and both are addressed here.

All 12 applicable pre-commit hooks pass, including `mypy`, `bandit`, `import-direction`, `doc-links` and `markdownlint-cli2`.
