### PR TITLE
fix(scan): two target types that never worked, and a scan that scanned nothing exiting 0

### DIFF
--- a/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign-tracker.md
+++ b/docs/superpowers/plans/2026-08-08-v1.1.0-audit-campaign-tracker.md
@@ -6,14 +6,14 @@
 
 ## Progress
 
-**3 / 22 chunks complete.**
+**4 / 22 chunks complete.**
 
 | # | Chunk | Prereqs met? | Findings | Resolved | Status |
 |---|---|---|---:|---:|---|
 | 0 | Environment prerequisites | — | — | — | **done** — table below |
 | 1 | Config + CLI shell | yes | 8 | 8 | **done** — 5 FIXED, 3 DISMISSED |
 | 2 | Tool registry + profiles | yes | 7 | 7 | **done** — 5 FIXED, 1 DELETED, 1 resolved; #795/#796 split out |
-| 3 | scan: target-type matrix | | | | not started |
+| 3 | scan: target-type matrix | yes | 7 | 7 | **done** — 5 FIXED, 2 split out |
 | 4 | scan: runtime | | | | not started |
 | 5 | adapters A | | | | not started |
 | 6 | adapters B + `jmo adapters` + loader | | | | not started |
@@ -340,6 +340,93 @@ permission-denied.
 
 **Acceptance:** each target type produces findings or a clear reason; no
 degenerate input crashes or silently scans nothing (the #715 class).
+
+### Result: 7 findings — 5 FIXED here, 2 split out
+
+Nothing crashed. What the sweep found instead was two target types that had
+never produced a finding, and a discovery layer that could not tell a typo from
+an empty request.
+
+**Per-target-type matrix, measured end to end:**
+
+| Target type | Positive case | Verdict |
+|---|---|---|
+| repository | planted secret in a **non-git** dir → 1 finding, `zero-secrets` correctly failed | healthy |
+| image | `debian:11` → 99 findings (6 CRITICAL) | healthy |
+| iac | `bad.tf` → **0 findings where trivy alone finds 12** | **broken** → #804 |
+| k8s | died at trivy argument parsing on every path | **broken** → #803 |
+| url | `zap` present; `nuclei` not installed | flags verified, live scan not run |
+| gitlab | needs a token; the degenerate path diagnoses correctly | BLOCKED-UNVERIFIABLE (no token) |
+
+- [x] **#803 — the `k8s` target type has never worked. FIXED.** Four stacked
+      breakages: `--context` (trivy has no such flag — context is the trailing
+      **positional**), `-n` (`unknown shorthand flag`), `--all-namespaces` (no
+      such flag; all namespaces is the default), and a trailing literal `"all"`
+      that trivy read as the context name. The fourth fires on **every** path,
+      so no invocation could ever have worked. A fifth layer:
+      `--k8s-all-namespaces` never reached the scanner, because discovery
+      writes `namespace: "*"` while the scanner read an `all_namespaces` key
+      only the dead `jmo.py:_iter_k8s_resources` ever set.
+      **Discriminator used:** a *parse* error fires before cluster contact, so
+      the gate is trivy reaching `failed getting k8s cluster: context ... does
+      not exist` instead of `unknown flag`. Verified. Whether a real cluster
+      then yields findings is **BLOCKED-UNVERIFIABLE** — no cluster here.
+- [x] **#804 — `trivy config` rejects `--no-progress`, so every IaC scan was
+      inert. FIXED.** All four profiles set it (`jmo.yml:38,68,103,145`), and
+      `config` is the only one of the four subcommands JMo drives that does not
+      accept it. Measured on one file: **0 findings before, 12 after**, matching
+      `trivy config` standalone. Root shape: `per_tool.<tool>.flags` is applied
+      per **tool**, but trivy's flag surface is per **subcommand**.
+- [x] **#805 — six path flags dropped a non-existent target silently. FIXED.**
+      `--repo`, `--repos-dir`, `--targets` (file *and* each listed line),
+      `--terraform-state`, `--cloudformation`, `--k8s-manifest` all used a bare
+      `if p.exists()` with no `else`, while `--image` and `--url` already
+      warned. Every refusal now names the target and the reason.
+- [x] **#806 — a scan that scanned nothing exited 0. FIXED.** Eight degenerate
+      inputs produced eight identical `rc=0` runs saying "No scan targets
+      provided" — including cases where a target *was* provided. Now `rc=1`,
+      and the two mistakes read differently: every-target-rejected names them;
+      no-flag-at-all keeps the original wording. **User-visible behaviour
+      change**, same call as #788.
+- [x] **#807 — `--api-spec` was advertised in `--help` and did nothing. FIXED.**
+      Only `jmo.py:_iter_urls` ever handled it, and nothing calls that. Wired
+      into `_discover_urls`: remote specs become URL targets, local files become
+      `file://` targets, a missing file is rejected rather than ignored.
+- [x] **#808 — six dead `_iter_*` discovery helpers, 129 tests on dead code.
+      SPLIT OUT.** All six have zero production callers; the live path is
+      `ScanOrchestrator._discover_*`. The two implementations have diverged in
+      **both** directions, and #803 and #807 exist precisely because a fix lived
+      only in the copy that stopped being called. `scan_jobs/base_scanner.py`
+      has the same shape: `BaseScanner`/`ScanResult` have zero production
+      subclasses and appear in no doc, rule or skill. Deleting six functions and
+      rehoming 129 tests is not small and must not ride along with behaviour
+      fixes.
+- [x] **#809 — a target whose scan could not run renders as a success. SPLIT
+      OUT to chunk 4.** GitLab-without-token and the failing k8s run both print
+      `[1/1] ✓`. The accounting layer is *correct* — `scan-timings.json` records
+      `status: "no_output"`, the returncode and the stderr — so this is
+      propagation, not detection, which is chunk 4's stated acceptance.
+
+**Dismissed by measurement, do not re-file:**
+
+- *"trufflehog is inert on a non-git directory"* — it is not. The 0-byte output
+  that suggested it came from **my fixture**: an AWS secret key with no `AKIA…`
+  access-key ID is not detectable. With a proper pair, `trufflehog filesystem`
+  reports `unverified_secrets: 1` on a plain directory and `2` on a git repo,
+  and JMo surfaces it and fails `zero-secrets`.
+- *"`--repo` plus `--repos-dir` silently ignores the second"* — argparse makes
+  the three repo flags a **mutually exclusive group**, so it is rejected before
+  any discovery code runs.
+- *"`alpine:3.14` scanning 0 vulnerabilities is a defect"* — trivy genuinely
+  reports 0 for that EOL image; `debian:11` returns 192 on the same setup.
+
+**Verification.** Every guard mutation-tested (mutate → red → restore, file
+backups). Local suite, `PYTHONUTF8` unset: half A **5258 passed / 65 skipped**
+(baseline 5234/65 — **+24 = exactly the new tests**, skips unchanged); half B
+**2886 passed / 2 failed / 40 skipped** (2886+2 = the 2888 baseline). Both half-B
+failures are **worker crashes reproduced on clean `origin/dev`**, where the same
+two files fail *worse* (10 vs 2) — `test_stress.py::test_100k_findings_memory_usage`
+is #792 and takes neighbouring workers with it.
 
 ---
 

--- a/scripts/cli/jmo.py
+++ b/scripts/cli/jmo.py
@@ -2956,14 +2956,27 @@ def cmd_scan(args) -> int:
     orchestrator = ScanOrchestrator(scan_config)
     targets = orchestrator.discover_targets(args)
 
-    # Validate at least one target
+    # Validate at least one target. A scan that scanned nothing is not a
+    # success: `jmo scan --repo "$REPO" || exit 1` used to pass when $REPO was
+    # a typo, because this returned 0. Same call as #788 made for
+    # `jmo tools check`. The two cases are reported differently because they
+    # are different mistakes.
     if targets.is_empty():
-        _log(
-            args,
-            "WARN",
-            "No scan targets provided (repos, images, IaC files, URLs, GitLab, or K8s resources).",
-        )
-        return 0
+        if targets.rejected:
+            _log(
+                args,
+                "ERROR",
+                "Every target was rejected, so nothing was scanned: "
+                + "; ".join(targets.rejected),
+            )
+        else:
+            _log(
+                args,
+                "ERROR",
+                "No scan targets provided (repos, images, IaC files, URLs, "
+                "GitLab, or K8s resources).",
+            )
+        return 1
 
     # Log scan targets summary
     _log(args, "INFO", f"Scan targets: {targets.summary()}")

--- a/scripts/cli/scan_jobs/iac_scanner.py
+++ b/scripts/cli/scan_jobs/iac_scanner.py
@@ -18,7 +18,12 @@ from ...core.config import RetryConfig
 from ...core.scan_timings import write_scan_timings
 from ...core.tool_runner import ToolDefinition, ToolRunner
 from ..path_sanitizers import _sanitize_path_component, _validate_output_path
-from ..scan_utils import find_tool, report_tool_failure, write_stub
+from ..scan_utils import (
+    filter_trivy_flags,
+    find_tool,
+    report_tool_failure,
+    write_stub,
+)
 
 
 def scan_iac_file(
@@ -117,7 +122,7 @@ def scan_iac_file(
         trivy_out = out_dir / "trivy.json"
         trivy_path = _find_tool("trivy")
         if trivy_path:
-            trivy_flags = get_tool_flags("trivy")
+            trivy_flags = filter_trivy_flags("config", get_tool_flags("trivy"))
             trivy_cmd = [
                 trivy_path,
                 "config",

--- a/scripts/cli/scan_jobs/k8s_scanner.py
+++ b/scripts/cli/scan_jobs/k8s_scanner.py
@@ -57,7 +57,13 @@ def scan_k8s_resource(
 
     context = k8s_info["context"]
     namespace = k8s_info["namespace"]
-    all_namespaces = k8s_info.get("all_namespaces", "False") == "True"
+    # Two producers build this dict and they disagree: the live discovery path
+    # (scan_orchestrator._discover_k8s_resources) signals "every namespace" by
+    # writing namespace="*" and sets no all_namespaces key at all, so reading
+    # only the key made --k8s-all-namespaces unreachable. Accept both shapes.
+    all_namespaces = (
+        str(k8s_info.get("all_namespaces", "False")) == "True" or namespace == "*"
+    )
 
     safe_name = f"{context}_{namespace}".replace("/", "_").replace("*", "all")
     out_dir = results_dir / safe_name
@@ -97,18 +103,24 @@ def scan_k8s_resource(
                 *trivy_flags,
             ]
 
-            # Add context if not current
-            if context != "current":
-                trivy_cmd.extend(["--context", context])
+            # Namespace selection. trivy scans every namespace unless told
+            # otherwise, so "all namespaces" is the absence of a filter rather
+            # than a flag - there is no --all-namespaces. "default" is the
+            # sentinel _discover_k8s_resources writes when the user named no
+            # namespace, so it means "unspecified" here, not the namespace
+            # literally called default.
+            if not all_namespaces and namespace not in ("", "*", "default"):
+                trivy_cmd.extend(["--include-namespaces", namespace])
 
-            # Add namespace selection
-            if all_namespaces:
-                trivy_cmd.append("--all-namespaces")
-            elif namespace != "default":
-                trivy_cmd.extend(["-n", namespace])
+            trivy_cmd.extend(["-o", str(trivy_out)])
 
-            # Output file and target (scan all K8s resources)
-            trivy_cmd.extend(["-o", str(trivy_out), "all"])
+            # Context is a POSITIONAL argument - `trivy kubernetes [flags]
+            # [CONTEXT]` - so it goes last and takes no flag. This previously
+            # passed --context, which trivy rejects outright, and then appended
+            # a literal "all" that trivy read as the context name. Both killed
+            # the run at argument parsing, before any cluster contact.
+            if context and context != "current":
+                trivy_cmd.append(context)
 
             tool_defs.append(
                 ToolDefinition(

--- a/scripts/cli/scan_orchestrator.py
+++ b/scripts/cli/scan_orchestrator.py
@@ -116,6 +116,10 @@ class ScanTargets:
     urls: list[str] = field(default_factory=list)
     gitlab_repos: list[dict[str, str]] = field(default_factory=list)
     k8s_resources: list[dict[str, str]] = field(default_factory=list)
+    # Targets the caller asked for that discovery refused, with the reason.
+    # Without this, a mistyped path was indistinguishable from asking for
+    # nothing: both produced an empty ScanTargets and the same message.
+    rejected: list[str] = field(default_factory=list)
 
     def total_count(self) -> int:
         """Return total number of scan targets across all types."""
@@ -219,6 +223,10 @@ class ScanOrchestrator:
             config: Scan configuration
         """
         self.config = config
+        # Initialized here, not in discover_targets, because the _discover_*
+        # methods are also called directly (7 tests do exactly that) and must
+        # not depend on state their usual caller happens to set first.
+        self._rejected: list[str] = []
 
     def discover_targets(self, args) -> ScanTargets:
         """
@@ -231,6 +239,9 @@ class ScanOrchestrator:
             ScanTargets with all discovered targets
         """
         targets = ScanTargets()
+        # Reset per call - discover_targets may run more than once per process
+        # (the wizard and `jmo ci` both build orchestrators).
+        self._rejected = []
 
         # Discover repositories
         targets.repos = self._discover_repos(args)
@@ -253,7 +264,19 @@ class ScanOrchestrator:
         # Apply repository filters (include/exclude patterns)
         targets.repos = self._filter_repos(targets.repos)
 
+        targets.rejected = list(self._rejected)
         return targets
+
+    def _reject(self, flag: str, value: object, reason: str) -> None:
+        """Record and log a target that was asked for but will not be scanned.
+
+        `--image` and `--url` already warned on bad input; the six path-based
+        flags dropped silently, so a typo read exactly like passing no target
+        at all. Everything that refuses a target now goes through here.
+        """
+        message = f"{flag} {value!s}: {reason}"
+        self._rejected.append(message)
+        logger.warning("Not scanning %s", message)
 
     def _discover_repos(self, args) -> list[Path]:
         """
@@ -276,11 +299,14 @@ class ScanOrchestrator:
             # Check for MSYS path mangling (Git Bash on Windows + Docker)
             if _detect_msys_path_mangling(repo_path):
                 _warn_msys_path_mangling(repo_path)
+                self._reject("--repo", repo_path, "path looks MSYS-mangled")
                 return repos  # Return empty - path is invalid
 
             p = Path(repo_path)
             if p.exists():
                 repos.append(p)
+            else:
+                self._reject("--repo", repo_path, "path does not exist")
 
         # Directory of repositories
         elif getattr(args, "repos_dir", None):
@@ -289,24 +315,41 @@ class ScanOrchestrator:
             # Check for MSYS path mangling
             if _detect_msys_path_mangling(repos_dir_path):
                 _warn_msys_path_mangling(repos_dir_path)
+                self._reject("--repos-dir", repos_dir_path, "path looks MSYS-mangled")
                 return repos
 
             base = Path(repos_dir_path)
-            if base.exists() and base.is_dir():
+            if not base.exists():
+                self._reject("--repos-dir", repos_dir_path, "directory does not exist")
+            elif not base.is_dir():
+                self._reject("--repos-dir", repos_dir_path, "is not a directory")
+            else:
                 # Find all subdirectories (assumed to be repos)
                 repos.extend([p for p in base.iterdir() if p.is_dir()])
+                if not repos:
+                    self._reject(
+                        "--repos-dir", repos_dir_path, "contains no subdirectories"
+                    )
 
         # Targets file (list of repository paths)
         elif getattr(args, "targets", None):
             targets_file = Path(args.targets)
-            if targets_file.exists():
+            if not targets_file.exists():
+                self._reject("--targets", args.targets, "file does not exist")
+            else:
+                listed = 0
                 for line in targets_file.read_text(encoding="utf-8").splitlines():
                     line = line.strip()
                     if not line or line.startswith("#"):
                         continue
+                    listed += 1
                     p = Path(line)
                     if p.exists():
                         repos.append(p)
+                    else:
+                        self._reject("--targets", line, "listed path does not exist")
+                if listed == 0:
+                    self._reject("--targets", args.targets, "file lists no paths")
 
         return repos
 
@@ -328,12 +371,14 @@ class ScanOrchestrator:
             if validate_container_image(image):
                 images.append(image)
             else:
-                logger.warning(f"Skipping invalid container image: '{image}'")
+                self._reject("--image", image, "not a valid container image reference")
 
         # Images file
         if getattr(args, "images_file", None):
             images_file = Path(args.images_file)
-            if images_file.exists():
+            if not images_file.exists():
+                self._reject("--images-file", args.images_file, "file does not exist")
+            else:
                 for line in images_file.read_text(encoding="utf-8").splitlines():
                     line = line.strip()
                     if not line or line.startswith("#"):
@@ -341,7 +386,11 @@ class ScanOrchestrator:
                     if validate_container_image(line):
                         images.append(line)
                     else:
-                        logger.warning(f"Skipping invalid container image: '{line}'")
+                        self._reject(
+                            "--images-file",
+                            line,
+                            "not a valid container image reference",
+                        )
 
         return images
 
@@ -356,23 +405,19 @@ class ScanOrchestrator:
         """
         iac_files: list[tuple[str, Path]] = []
 
-        # Terraform state files
-        if getattr(args, "terraform_state", None):
-            p = Path(args.terraform_state)
+        for flag, attr, iac_type in (
+            ("--terraform-state", "terraform_state", "terraform"),
+            ("--cloudformation", "cloudformation", "cloudformation"),
+            ("--k8s-manifest", "k8s_manifest", "k8s"),
+        ):
+            value = getattr(args, attr, None)
+            if not value:
+                continue
+            p = Path(value)
             if p.exists():
-                iac_files.append(("terraform", p))
-
-        # CloudFormation templates
-        if getattr(args, "cloudformation", None):
-            p = Path(args.cloudformation)
-            if p.exists():
-                iac_files.append(("cloudformation", p))
-
-        # Kubernetes manifests
-        if getattr(args, "k8s_manifest", None):
-            p = Path(args.k8s_manifest)
-            if p.exists():
-                iac_files.append(("k8s", p))
+                iac_files.append((iac_type, p))
+            else:
+                self._reject(flag, value, "file does not exist")
 
         return iac_files
 
@@ -395,12 +440,14 @@ class ScanOrchestrator:
             if validate_url(url):
                 urls.append(url)
             else:
-                logger.warning(f"Skipping invalid URL: '{url}'")
+                self._reject("--url", url, "only http/https URLs are scanned")
 
         # URLs file
         if getattr(args, "urls_file", None):
             urls_file = Path(args.urls_file)
-            if urls_file.exists():
+            if not urls_file.exists():
+                self._reject("--urls-file", args.urls_file, "file does not exist")
+            else:
                 for line in urls_file.read_text(encoding="utf-8").splitlines():
                     line = line.strip()
                     if not line or line.startswith("#"):
@@ -408,7 +455,23 @@ class ScanOrchestrator:
                     if validate_url(line):
                         urls.append(line)
                     else:
-                        logger.warning(f"Skipping invalid URL: '{line}'")
+                        self._reject(
+                            "--urls-file", line, "only http/https URLs are scanned"
+                        )
+
+        # OpenAPI/Swagger spec. This is advertised in `jmo scan --help` but was
+        # handled only by jmo.py's _iter_urls, which nothing has called since
+        # discovery moved here - so the flag was silently accepted and dropped.
+        if getattr(args, "api_spec", None):
+            spec = args.api_spec
+            if spec.startswith(("http://", "https://")):
+                urls.append(spec)
+            else:
+                p = Path(spec)
+                if p.exists():
+                    urls.append(f"file://{p.absolute()}")
+                else:
+                    self._reject("--api-spec", spec, "spec file does not exist")
 
         return urls
 

--- a/scripts/cli/scan_utils.py
+++ b/scripts/cli/scan_utils.py
@@ -256,6 +256,47 @@ def report_tool_failure(result: ToolResult, reason: str) -> None:
     )
 
 
+# jmo.yml configures flags per *tool*, but trivy's flag surface is per
+# *subcommand*, and JMo drives trivy with four of them (fs, image, config, k8s).
+# Measured against trivy 0.70.0: `trivy config` is the only one that rejects
+# --no-progress, and it rejects it fatally at argument parsing - so every IaC
+# scan died before it started and contributed nothing. All four shipped profiles
+# set that flag, so no profile escaped it.
+#
+# Only value-less flags belong here: dropping one must never orphan a value
+# argument. --scanners is accepted by all four subcommands and is not listed.
+TRIVY_UNSUPPORTED_FLAGS: dict[str, frozenset[str]] = {
+    "config": frozenset({"--no-progress"}),
+}
+
+
+def filter_trivy_flags(subcommand: str, flags: list[str]) -> list[str]:
+    """Drop configured trivy flags that ``subcommand`` does not accept.
+
+    Args:
+        subcommand: The trivy subcommand being invoked ("config", "fs", ...).
+        flags: Flags from per-tool configuration.
+
+    Returns:
+        The flags the subcommand actually accepts.
+    """
+    unsupported = TRIVY_UNSUPPORTED_FLAGS.get(subcommand)
+    if not unsupported:
+        return list(flags)
+
+    kept = [f for f in flags if f not in unsupported]
+    dropped = [f for f in flags if f in unsupported]
+    if dropped:
+        logging.getLogger(__name__).warning(
+            "trivy %s does not accept %s; dropping so the scan can run. "
+            "Configure it under a profile that does not reach this subcommand "
+            "if you need it.",
+            subcommand,
+            ", ".join(dropped),
+        )
+    return kept
+
+
 def write_stub(tool: str, out_path: Path) -> None:
     """Write empty JSON stub for missing tool."""
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/cli/test_jmo.py
+++ b/tests/cli/test_jmo.py
@@ -978,3 +978,76 @@ class TestScanPathLoggingIsReachable:
             "caplog cannot see an INFO record from a scripts.* logger after a "
             "jmo command configured logging - the scan's level leaked past it"
         )
+
+
+# ========== Scan: nothing scanned is not a success (#806) ==========
+
+
+class TestScanExitsNonZeroWhenNothingWasScanned:
+    """`jmo scan --repo "$REPO" || exit 1` used to pass when $REPO was a typo.
+
+    cmd_scan returned 0 whenever discovery came up empty, so a CI gate reported
+    success for a scan that never ran. Same call as #788 made for
+    `jmo tools check`.
+    """
+
+    @staticmethod
+    def _run(argv):
+        from scripts.cli.jmo import cmd_scan, parse_args
+
+        with patch("sys.argv", argv):
+            return cmd_scan(parse_args())
+
+    def test_missing_repo_path_fails(self, tmp_path):
+        rc = self._run(
+            [
+                "jmo",
+                "scan",
+                "--repo",
+                str(tmp_path / "definitely-not-here"),
+                "--results-dir",
+                str(tmp_path / "out"),
+                "--tools",
+                "trufflehog",
+                "--no-store-history",
+            ]
+        )
+        assert rc != 0, "a scan that scanned nothing reported success"
+
+    def test_no_target_flag_at_all_fails(self, tmp_path):
+        rc = self._run(
+            [
+                "jmo",
+                "scan",
+                "--results-dir",
+                str(tmp_path / "out"),
+                "--tools",
+                "trufflehog",
+                "--no-store-history",
+            ]
+        )
+        assert rc != 0
+
+    def test_the_rejected_target_is_named_in_the_log(self, tmp_path, caplog):
+        import logging
+
+        missing = tmp_path / "typo-here"
+        with caplog.at_level(logging.WARNING):
+            self._run(
+                [
+                    "jmo",
+                    "scan",
+                    "--repo",
+                    str(missing),
+                    "--results-dir",
+                    str(tmp_path / "out"),
+                    "--tools",
+                    "trufflehog",
+                    "--no-store-history",
+                ]
+            )
+
+        assert "typo-here" in caplog.text, (
+            "the rejected path must appear on some stream; the old message named "
+            f"no target at all:\n{caplog.text}"
+        )

--- a/tests/cli/test_jmo.py
+++ b/tests/cli/test_jmo.py
@@ -993,12 +993,27 @@ class TestScanExitsNonZeroWhenNothingWasScanned:
 
     @staticmethod
     def _run(argv):
+        """Run cmd_scan with tool pre-flight neutralised.
+
+        cmd_scan bails at `jmo.py:2929` when no requested tool is installed,
+        before discovery ever runs, and returns 1 (silently - #811). On a
+        runner without trufflehog that made the two exit-code tests below pass
+        for entirely the wrong reason: the missing-tool bail also returns
+        non-zero, so they were green while never reaching the code under test.
+        Pinning the pre-flight keeps these tests about target discovery.
+        """
         from scripts.cli.jmo import cmd_scan, parse_args
 
         with patch("sys.argv", argv):
-            return cmd_scan(parse_args())
+            args = parse_args()
 
-    def test_missing_repo_path_fails(self, tmp_path):
+        with patch(
+            "scripts.cli.jmo._check_scan_tools",
+            side_effect=lambda _a, requested: (list(requested), []),
+        ):
+            return cmd_scan(args)
+
+    def test_missing_repo_path_fails(self, tmp_path, capsys):
         rc = self._run(
             [
                 "jmo",
@@ -1013,8 +1028,11 @@ class TestScanExitsNonZeroWhenNothingWasScanned:
             ]
         )
         assert rc != 0, "a scan that scanned nothing reported success"
+        # Asserting the exit code alone is not enough: several earlier bail-outs
+        # also return non-zero, so this must confirm it failed *here* (#811).
+        assert "Every target was rejected" in capsys.readouterr().err
 
-    def test_no_target_flag_at_all_fails(self, tmp_path):
+    def test_no_target_flag_at_all_fails(self, tmp_path, capsys):
         rc = self._run(
             [
                 "jmo",
@@ -1027,6 +1045,9 @@ class TestScanExitsNonZeroWhenNothingWasScanned:
             ]
         )
         assert rc != 0
+        # Asking for nothing stays a distinct message from asking for something
+        # that does not exist.
+        assert "No scan targets provided" in capsys.readouterr().err
 
     def test_the_rejected_target_is_named_in_the_log(self, tmp_path, caplog):
         import logging

--- a/tests/cli/test_k8s_scanner.py
+++ b/tests/cli/test_k8s_scanner.py
@@ -82,13 +82,19 @@ class TestK8sScanner:
                 find_tool_func=mock_find_tool,
             )
 
-            # Verify --all-namespaces flag is used
+            # trivy has no --all-namespaces flag; it scans every namespace
+            # unless --include-namespaces narrows it. This asserted
+            # "--all-namespaces" in the command until #803 - which trivy 0.70.0
+            # answers with `FATAL unknown flag: --all-namespaces`, killing the
+            # run at argument parsing. The test passed because it only ever
+            # inspected the command JMo built, never what trivy accepts.
             MockRunner.assert_called_once()
             args, kwargs = MockRunner.call_args
             tool_defs = kwargs.get("tools") or (args[0] if args else [])
             trivy_def = next((t for t in tool_defs if t.name == "trivy"), None)
             assert trivy_def is not None, "trivy tool definition not found"
-            assert "--all-namespaces" in trivy_def.command
+            assert "--all-namespaces" not in trivy_def.command
+            assert "--include-namespaces" not in trivy_def.command
 
     def test_scan_k8s_custom_context(self, tmp_path):
         """Test K8s scanning with custom context"""
@@ -123,14 +129,22 @@ class TestK8sScanner:
                 find_tool_func=mock_find_tool,
             )
 
-            # Verify --context flag is used
+            # trivy's usage is `trivy kubernetes [flags] [CONTEXT]` - context is
+            # POSITIONAL and must be last. There is no --context flag; passing
+            # one is `FATAL unknown flag: --context` (#803).
             MockRunner.assert_called_once()
             args, kwargs = MockRunner.call_args
             tool_defs = kwargs.get("tools") or (args[0] if args else [])
             trivy_def = next((t for t in tool_defs if t.name == "trivy"), None)
             assert trivy_def is not None, "trivy tool definition not found"
-            assert "--context" in trivy_def.command
-            assert "production" in trivy_def.command
+            assert "--context" not in trivy_def.command
+            assert trivy_def.command[-1] == "production", (
+                "context must be the trailing positional argument, got: "
+                f"{trivy_def.command}"
+            )
+            # The old command also appended a literal "all" after -o, which
+            # trivy read as the context name.
+            assert "all" not in trivy_def.command
 
     def test_scan_k8s_sanitizes_name(self, tmp_path):
         """Test that context/namespace are sanitized for directory names"""
@@ -401,7 +415,11 @@ class TestK8sScanner:
             assert "--context" not in trivy_def.command
 
     def test_scan_k8s_specific_namespace(self, tmp_path):
-        """Test K8s scanning with specific (non-default) namespace includes -n flag"""
+        """A named namespace narrows the scan with --include-namespaces.
+
+        Not -n: trivy answers that with `FATAL unknown shorthand flag: 'n'`
+        (#803).
+        """
 
         def mock_find_tool(tool_name):
             return f"/usr/bin/{tool_name}" if tool_name == "trivy" else None
@@ -438,8 +456,10 @@ class TestK8sScanner:
             tool_defs = kwargs.get("tools") or (args[0] if args else [])
             trivy_def = next((t for t in tool_defs if t.name == "trivy"), None)
             assert trivy_def is not None
-            assert "-n" in trivy_def.command
-            assert "monitoring" in trivy_def.command
+            assert "-n" not in trivy_def.command
+            assert "--include-namespaces" in trivy_def.command
+            ns_index = trivy_def.command.index("--include-namespaces")
+            assert trivy_def.command[ns_index + 1] == "monitoring"
 
     def test_scan_k8s_default_namespace_no_n_flag(self, tmp_path):
         """Test K8s scanning with default namespace does NOT add -n flag"""
@@ -480,6 +500,94 @@ class TestK8sScanner:
             trivy_def = next((t for t in tool_defs if t.name == "trivy"), None)
             assert trivy_def is not None
             assert "-n" not in trivy_def.command
+            assert "--include-namespaces" not in trivy_def.command
+
+    def test_trivy_k8s_command_is_accepted_by_trivys_own_grammar(self, tmp_path):
+        """Pin the whole command shape, not one flag at a time.
+
+        Every flag in the pre-#803 command was rejected by trivy, and four
+        separate tests passed anyway because each asserted only on the argv JMo
+        built. This asserts the grammar trivy documents -
+        `trivy kubernetes [flags] [CONTEXT]` - so a regression in any single
+        position fails here.
+        """
+
+        def mock_find_tool(tool_name):
+            return f"/usr/bin/{tool_name}" if tool_name == "trivy" else None
+
+        with patch("scripts.cli.scan_jobs.k8s_scanner.ToolRunner") as MockRunner:
+            MockRunner.return_value = MagicMock()
+
+            from scripts.core.tool_runner import ToolResult
+
+            MockRunner.return_value.run_all_parallel.return_value = [
+                ToolResult(tool="trivy", status="success", attempts=1),
+            ]
+
+            scan_k8s_resource(
+                k8s_info={"context": "prod", "namespace": "monitoring"},
+                results_dir=tmp_path,
+                tools=["trivy"],
+                timeout=600,
+                retries=0,
+                per_tool_config={},
+                allow_missing_tools=False,
+                find_tool_func=mock_find_tool,
+            )
+
+            args, kwargs = MockRunner.call_args
+            tool_defs = kwargs.get("tools") or (args[0] if args else [])
+            cmd = next(t for t in tool_defs if t.name == "trivy").command
+
+            assert cmd[1] == "k8s"
+            # Flags trivy 0.70.0 does not have on `k8s`, each measured as a
+            # FATAL parse error before any cluster contact.
+            for rejected in ("--context", "-n", "--all-namespaces"):
+                assert rejected not in cmd, f"trivy k8s rejects {rejected}"
+            # Context is the trailing positional, and nothing follows it.
+            assert cmd[-1] == "prod"
+            # -o must still carry the output path.
+            assert cmd[cmd.index("-o") + 1].endswith("trivy.json")
+
+    def test_all_namespaces_is_reachable_via_the_star_namespace(self, tmp_path):
+        """The live discovery path signals all-namespaces with namespace="*".
+
+        scan_orchestrator._discover_k8s_resources writes namespace="*" and no
+        all_namespaces key at all, so reading only the key made
+        --k8s-all-namespaces unreachable in production (#803).
+        """
+
+        def mock_find_tool(tool_name):
+            return f"/usr/bin/{tool_name}" if tool_name == "trivy" else None
+
+        with patch("scripts.cli.scan_jobs.k8s_scanner.ToolRunner") as MockRunner:
+            MockRunner.return_value = MagicMock()
+
+            from scripts.core.tool_runner import ToolResult
+
+            MockRunner.return_value.run_all_parallel.return_value = [
+                ToolResult(tool="trivy", status="success", attempts=1),
+            ]
+
+            scan_k8s_resource(
+                k8s_info={"context": "prod", "namespace": "*"},
+                results_dir=tmp_path,
+                tools=["trivy"],
+                timeout=600,
+                retries=0,
+                per_tool_config={},
+                allow_missing_tools=False,
+                find_tool_func=mock_find_tool,
+            )
+
+            args, kwargs = MockRunner.call_args
+            tool_defs = kwargs.get("tools") or (args[0] if args else [])
+            cmd = next(t for t in tool_defs if t.name == "trivy").command
+
+            # No namespace filter at all == every namespace, which is trivy's
+            # default. A literal "*" must never be passed through.
+            assert "--include-namespaces" not in cmd
+            assert "*" not in cmd
 
     def test_scan_k8s_sanitized_directory_special_chars(self, tmp_path):
         """Test directory name sanitization for context/namespace with special chars"""

--- a/tests/cli/test_scan_orchestrator.py
+++ b/tests/cli/test_scan_orchestrator.py
@@ -335,6 +335,7 @@ class TestScanOrchestrator:
         args = MagicMock()
         args.url = "https://example.com"
         args.urls_file = None
+        args.api_spec = None
 
         urls = orchestrator._discover_urls(args)
 
@@ -549,6 +550,7 @@ class TestScanOrchestrator:
         args.k8s_manifest = None
         args.url = "https://example.com"
         args.urls_file = None
+        args.api_spec = None
         args.gitlab_repo = None
         args.gitlab_group = None
         args.k8s_context = None
@@ -646,6 +648,7 @@ class TestDiscoverUrlsFromFile:
         args = MagicMock()
         args.url = None
         args.urls_file = str(urls_file_path)
+        args.api_spec = None
 
         urls = orchestrator._discover_urls(args)
         assert len(urls) == 2
@@ -665,6 +668,7 @@ class TestDiscoverUrlsFromFile:
         args = MagicMock()
         args.url = None
         args.urls_file = str(urls_file_path)
+        args.api_spec = None
 
         urls = orchestrator._discover_urls(args)
         assert len(urls) == 1
@@ -681,6 +685,7 @@ class TestDiscoverUrlsFromFile:
         args = MagicMock()
         args.url = None
         args.urls_file = str(urls_file_path)
+        args.api_spec = None
 
         urls = orchestrator._discover_urls(args)
         assert len(urls) == 1
@@ -698,6 +703,7 @@ class TestDiscoverUrlsFromFile:
         args = MagicMock()
         args.url = None
         args.urls_file = str(urls_file_path)
+        args.api_spec = None
 
         with caplog.at_level(logging.WARNING):
             urls = orchestrator._discover_urls(args)
@@ -913,6 +919,7 @@ class TestInvalidUrlWarning:
         class Args:
             url = "not-a-valid-url"  # Single invalid URL
             urls_file = None
+            api_spec = None
 
         with caplog.at_level(logging.WARNING):
             urls = orchestrator._discover_urls(Args())
@@ -932,6 +939,7 @@ class TestInvalidUrlWarning:
         class Args:
             url = "https://example.com"  # Valid URL
             urls_file = None
+            api_spec = None
 
         with caplog.at_level(logging.WARNING):
             urls = orchestrator._discover_urls(Args())
@@ -1013,3 +1021,159 @@ class TestUnroutedToolsAreReported:
             orch.scan_all(targets, per_tool_config={})
 
         assert "no target type in this scan" not in caplog.text
+
+
+class TestRejectedTargetsAreNamed:
+    """Discovery must say which target it refused, and why.
+
+    Eight degenerate inputs used to produce one identical message - "No scan
+    targets provided" - at exit code 0, so a typo'd path, a missing targets
+    file and an empty directory were indistinguishable from asking for nothing
+    (#805, #806). `--image` and `--url` already warned; the six path-based
+    flags dropped silently.
+    """
+
+    @staticmethod
+    def _args(**kw):
+        from types import SimpleNamespace
+
+        base = {
+            "repo": None,
+            "repos_dir": None,
+            "targets": None,
+            "image": None,
+            "images_file": None,
+            "terraform_state": None,
+            "cloudformation": None,
+            "k8s_manifest": None,
+            "url": None,
+            "urls_file": None,
+            "api_spec": None,
+            "gitlab_url": None,
+            "gitlab_repo": None,
+            "gitlab_group": None,
+            "k8s_context": None,
+            "k8s_namespace": None,
+            "k8s_all_namespaces": False,
+        }
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    @staticmethod
+    def _orchestrator(tmp_path):
+        return ScanOrchestrator(
+            ScanConfig(tools=["trufflehog"], results_dir=tmp_path / "results")
+        )
+
+    @pytest.mark.parametrize(
+        "flag,value_factory,fragment",
+        [
+            ("repo", lambda t: str(t / "nope"), "--repo"),
+            ("repos_dir", lambda t: str(t / "nope_dir"), "--repos-dir"),
+            ("targets", lambda t: str(t / "nope.txt"), "--targets"),
+            ("terraform_state", lambda t: str(t / "nope.tfstate"), "--terraform-state"),
+            ("cloudformation", lambda t: str(t / "nope.yaml"), "--cloudformation"),
+            ("k8s_manifest", lambda t: str(t / "nope.yaml"), "--k8s-manifest"),
+        ],
+    )
+    def test_missing_path_is_named_not_dropped(
+        self, tmp_path, flag, value_factory, fragment
+    ):
+        orch = self._orchestrator(tmp_path)
+        targets = orch.discover_targets(self._args(**{flag: value_factory(tmp_path)}))
+
+        assert targets.is_empty()
+        assert targets.rejected, f"{fragment} was dropped without a reason"
+        assert any(fragment in r for r in targets.rejected)
+
+    def test_empty_repos_dir_is_distinguished_from_a_missing_one(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        orch = self._orchestrator(tmp_path)
+        targets = orch.discover_targets(self._args(repos_dir=str(empty)))
+
+        assert targets.is_empty()
+        assert any("no subdirectories" in r for r in targets.rejected)
+
+    def test_targets_file_names_each_missing_line(self, tmp_path):
+        listing = tmp_path / "targets.txt"
+        listing.write_text("# a comment\n/definitely/not/here\n\n", encoding="utf-8")
+
+        orch = self._orchestrator(tmp_path)
+        targets = orch.discover_targets(self._args(targets=str(listing)))
+
+        assert targets.is_empty()
+        assert any("/definitely/not/here" in r for r in targets.rejected)
+
+    def test_invalid_image_and_url_also_count_as_rejections(self, tmp_path):
+        """These already logged a warning but nothing acted on it."""
+        orch = self._orchestrator(tmp_path)
+
+        image_targets = orch.discover_targets(self._args(image="not a valid image!!"))
+        assert image_targets.rejected
+
+        url_targets = orch.discover_targets(self._args(url="ftp://evil.example"))
+        assert url_targets.rejected
+
+    def test_no_target_flag_at_all_records_no_rejection(self, tmp_path):
+        """Asking for nothing is a different mistake from asking for something
+        that does not exist, and must stay distinguishable."""
+        orch = self._orchestrator(tmp_path)
+        targets = orch.discover_targets(self._args())
+
+        assert targets.is_empty()
+        assert targets.rejected == []
+
+    def test_rejections_do_not_leak_between_calls(self, tmp_path):
+        orch = self._orchestrator(tmp_path)
+        orch.discover_targets(self._args(repo=str(tmp_path / "nope")))
+        second = orch.discover_targets(self._args())
+
+        assert second.rejected == []
+
+
+class TestApiSpecIsDiscovered:
+    """`--api-spec` is advertised in `jmo scan --help` and was a no-op (#807).
+
+    The only code that handled it was jmo.py's _iter_urls, which nothing has
+    called since discovery moved to ScanOrchestrator.
+    """
+
+    @staticmethod
+    def _args(**kw):
+        return TestRejectedTargetsAreNamed._args(**kw)
+
+    @staticmethod
+    def _orchestrator(tmp_path):
+        return ScanOrchestrator(
+            ScanConfig(tools=["zap"], results_dir=tmp_path / "results")
+        )
+
+    def test_remote_spec_becomes_a_url_target(self, tmp_path):
+        orch = self._orchestrator(tmp_path)
+        targets = orch.discover_targets(
+            self._args(api_spec="https://example.com/openapi.json")
+        )
+
+        assert targets.urls == ["https://example.com/openapi.json"]
+        assert not targets.is_empty()
+
+    def test_local_spec_becomes_a_file_url(self, tmp_path):
+        spec = tmp_path / "openapi.json"
+        spec.write_text('{"openapi": "3.0.0"}', encoding="utf-8")
+
+        orch = self._orchestrator(tmp_path)
+        targets = orch.discover_targets(self._args(api_spec=str(spec)))
+
+        assert len(targets.urls) == 1
+        assert targets.urls[0].startswith("file://")
+
+    def test_missing_local_spec_is_rejected_rather_than_ignored(self, tmp_path):
+        orch = self._orchestrator(tmp_path)
+        targets = orch.discover_targets(
+            self._args(api_spec=str(tmp_path / "gone.json"))
+        )
+
+        assert targets.is_empty()
+        assert any("--api-spec" in r for r in targets.rejected)

--- a/tests/unit/test_scan_utils.py
+++ b/tests/unit/test_scan_utils.py
@@ -241,3 +241,52 @@ def test_tool_install_hints_complete():
         assert tool in TOOL_INSTALL_HINTS
         hint = TOOL_INSTALL_HINTS[tool]
         assert "Install" in hint or "see" in hint
+
+
+class TestFilterTrivyFlags:
+    """jmo.yml configures flags per tool; trivy's flag surface is per subcommand.
+
+    All four shipped profiles set --no-progress, which `trivy config` rejects
+    fatally at argument parsing - so every IaC scan produced 0 findings where
+    the same file and tool yield 12 (#804).
+    """
+
+    def test_no_progress_is_dropped_for_trivy_config(self):
+        from scripts.cli.scan_utils import filter_trivy_flags
+
+        assert filter_trivy_flags("config", ["--no-progress"]) == []
+
+    def test_other_subcommands_keep_it(self):
+        from scripts.cli.scan_utils import filter_trivy_flags
+
+        for subcommand in ("fs", "image", "k8s"):
+            assert filter_trivy_flags(subcommand, ["--no-progress"]) == [
+                "--no-progress"
+            ]
+
+    def test_supported_flags_survive_and_keep_their_values(self):
+        """--scanners is accepted by every subcommand, including config, and
+        takes a value - dropping a flag must never orphan its argument."""
+        from scripts.cli.scan_utils import filter_trivy_flags
+
+        flags = ["--no-progress", "--scanners", "vuln,secret,misconfig"]
+
+        assert filter_trivy_flags("config", flags) == [
+            "--scanners",
+            "vuln,secret,misconfig",
+        ]
+
+    def test_the_drop_is_announced(self, caplog):
+        import logging
+
+        from scripts.cli.scan_utils import filter_trivy_flags
+
+        with caplog.at_level(logging.WARNING):
+            filter_trivy_flags("config", ["--no-progress"])
+
+        assert "--no-progress" in caplog.text
+
+    def test_unknown_subcommand_is_left_alone(self):
+        from scripts.cli.scan_utils import filter_trivy_flags
+
+        assert filter_trivy_flags("rootfs", ["--no-progress"]) == ["--no-progress"]


### PR DESCRIPTION
v1.1.0 audit campaign, **chunk 3 — scan: target-type matrix**. Tracking #785.

Nothing crashed on degenerate input. What the sweep found instead was **two
target types that had never produced a finding**, and a discovery layer that
could not tell a typo from an empty request.

## Per-target-type matrix, measured end to end

| Target type | Positive case | Verdict |
|---|---|---|
| repository | planted secret in a **non-git** dir → 1 finding, `zero-secrets` correctly failed | healthy |
| image | `debian:11` → 99 findings (6 CRITICAL) | healthy |
| iac | `bad.tf` → **0 findings where trivy alone finds 12** | **broken** → #804 |
| k8s | died at trivy argument parsing on every path | **broken** → #803 |
| url | `zap` present, `nuclei` not installed | flags verified, live scan not run |
| gitlab | needs a token; the degenerate path diagnoses correctly | BLOCKED-UNVERIFIABLE |

## Fixed here

- **#803 — the `k8s` target type has never worked.** Four stacked breakages
  against trivy 0.70.0: `--context` (no such flag — context is the trailing
  **positional**), `-n` (`unknown shorthand flag`), `--all-namespaces` (no such
  flag; all namespaces is the default), and a trailing literal `"all"` trivy
  read as the context name. The fourth fires on **every** path. A fifth layer:
  `--k8s-all-namespaces` never reached the scanner — discovery writes
  `namespace: "*"`, the scanner read an `all_namespaces` key only the uncalled
  `jmo.py:_iter_k8s_resources` ever set.
- **#804 — `trivy config` rejects `--no-progress`, so every IaC scan was inert.**
  All four profiles set it; `config` is the only one of the four subcommands JMo
  drives that does not accept it. **0 findings before, 12 after** on the same
  file. Flags are now filtered against the subcommand.
- **#805 — six path flags dropped a non-existent target silently**, while
  `--image`/`--url` already warned. Every refusal now names target and reason.
- **#806 — a scan that scanned nothing exited 0.** Eight degenerate inputs gave
  eight identical `rc=0` runs. Now `rc=1`.
- **#807 — `--api-spec` was advertised in `--help` and did nothing.**

## Split out, not absorbed

- **#808** — six dead `_iter_*` discovery helpers with **129 tests** on them.
  #803 and #807 both exist *because* a fix lived only in the copy that stopped
  being called. Deleting six functions and rehoming 129 tests must not ride
  along with behaviour fixes.
- **#809** — a target whose scan could not run still renders `✓`. The accounting
  layer is correct (`scan-timings.json` has `status`, returncode and stderr); it
  is propagation that is missing, which is chunk 4's stated acceptance.

## Dismissed by measurement — do not re-file

- *trufflehog inert on non-git dirs* — it is not. The 0-byte output came from
  **my fixture**: an AWS secret key without an `AKIA…` ID is not detectable.
  With a proper pair, `trufflehog filesystem` reports 1 unverified secret on a
  plain directory and 2 on a git repo, and JMo surfaces it.
- *`--repo` + `--repos-dir` silently ignoring the second* — argparse makes the
  three an explicit **mutually exclusive group**.
- *`alpine:3.14` finding 0 vulnerabilities* — trivy genuinely reports 0 for that
  EOL image; `debian:11` returns 192 on the same setup.

## Verification, and what it cost

The verification CI structurally cannot provide is **running the CLI against
real degenerate inputs with `PYTHONUTF8` unset**. Every finding above came from
that, not from reading code.

- **Every guard mutation-tested** — mutate → watch red → restore, file backups
  only. All five went red; none is blind.
- **Half A: 5258 passed / 65 skipped** (baseline 5234/65). **+24 = exactly the
  new tests**, skips unchanged, nothing silently dropped.
- **Half B: 2886 passed / 2 failed / 40 skipped** (2886+2 = the 2888 baseline).
  Both failures are **worker crashes reproduced on clean `origin/dev`**, where
  the same two files fail *worse* — **10 failed vs 2**.
  `test_stress.py::test_100k_findings_memory_usage` is **#792** and takes
  neighbouring xdist workers with it. Not a regression from this PR.
- **k8s is verified only up to cluster contact** — there is no Kubernetes
  cluster here. The gate is trivy accepting the arguments: it now answers
  `failed getting k8s cluster: context "nosuchctx" does not exist` where it
  previously answered `unknown flag: --context`. Whether a real cluster yields
  findings stays **BLOCKED-UNVERIFIABLE**.

### Three tests asserted the bug as the spec

`test_scan_k8s_custom_context` asserted `"--context" in command`;
`test_scan_k8s_all_namespaces` asserted `--all-namespaces`;
`test_scan_k8s_specific_namespace` asserted `-n`. All three passed because they
only inspected the argv JMo *built* — they never invoked trivy, so nothing could
tell them trivy rejects all three. Corrected, and a new test pins the whole
command grammar rather than one flag at a time.

## Release note (v1.1.0, behaviour change)

`jmo scan` now **exits non-zero when it scanned nothing**. Anyone whose pipeline
currently passes over an empty or mistyped target will see a new failure — that
is the point, and it is the same call #788 made for `jmo tools check`.

Closes #803, #804, #805, #806, #807


---

## Merge gate — the verification CI structurally cannot provide

**The gate:** run the real CLI against real degenerate inputs, with the scanners
actually installed and `PYTHONUTF8` unset.

**Why CI cannot be it.** The PR shards install no scanners — that is precisely
what broke this PR's first CI run, where `trufflehog` was absent and `cmd_scan`
bailed before discovery. A runner with no trivy cannot detect that
`trivy config` rejects `--no-progress`, or that `trivy k8s` rejects `--context`.
Every finding here came from running the tool, not from reading it.

**Ran it. Numbers:**

| Check | Result |
|---|---|
| IaC, same file and profile | **0 findings → 12**, matching `trivy config` standalone |
| k8s argument parsing | `unknown flag: --context` → `failed getting k8s cluster: context "nosuchctx" does not exist` |
| 8 degenerate discovery inputs | `rc=0` + one misleading message → **`rc=1` + the target named, each with its own reason** |
| `--api-spec`, 3 branches | no-op → remote URL / `file://` / rejected-when-missing |
| repository, non-git dir | 1 finding surfaced, `zero-secrets` correctly **failed** |
| image, `debian:11` | 99 findings (6 CRITICAL) |
| CI-condition simulation | uninstalled tool → `rc=1`, target named, reason stated |

**Mutation-tested**, file backups only: all five guards go red when reverted.

**CI, both events green on `f567bc6`** (push `31335517146`, pull_request
`31335518801`), 27/27 checks.

**`windows-2022` shard read from its job log, not its tick** (it is
`continue-on-error: true`) — identical on both events:

| | baseline | now |
|---|---:|---:|
| passed | 8102 | **8126** (+24 = exactly the new tests) |
| skipped | 105 | **105** |
| deselected | 230 | **230** |

Local suite, `PYTHONUTF8` unset: half A **5258 / 65** (baseline 5234/65); half B
**2886 passed / 2 failed / 40 skipped**, both failures reproduced on clean
`origin/dev` where the same two files fail worse (**10 vs 2**) — #792 crashing
xdist workers, not a regression from this PR.
